### PR TITLE
fix/35: replace setDescription with setDescriptionHtml

### DIFF
--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -57,7 +57,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		$item_data = $catalog_object->getItemData();
 
 		$item_data->setName( $product->get_name() );
-		$item_data->setDescription( $product->get_description() );
+		$item_data->setDescriptionHtml( $product->get_description() );
 
 		$square_category_id = 0;
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #35 .

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Add description in Woo product with more than 4096 characters and sync the product
2. Verify that description is visible in the response from the API explorer. Use the [list-catalog](https://developer.squareup.com/explorer/square/catalog-api/list-catalog) endpoint.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Issue with syncing products with description more than 4096 characters.
