### PR TITLE
Add a `postarchive` command to fix the release artifact

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "phpcompat": "./vendor/bin/phpcs --standard=phpcs-compat.xml.dist -p .",
     "update-deps": "npm install -g rimraf && rimraf node_modules && rimraf npm-shrinkwrap.json && npm install && npm shrinkwrap --dev",
     "archive": "composer archive --file=$npm_package_name --format=zip",
+    "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "woorelease": "npm run build",
     "test:env:start": "wp-env start",
     "test:env:stop": "wp-env stop",


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When we run the command `npm run archive`, it successfully builds a zip archive of the extension but this archive does not contain the inner base folder. This prevents this archive from being used as a release asset.

Looking at some of the other Woo extensions, they have a custom `postarchive` npm command that will unzip this artifact and re-zip it with the proper base folder structure. This PR adds that same command.

### Steps to test the changes in this Pull Request:

1. On `trunk`, run `npm run archive`
2. Run the `zipinfo` command on the archive file that this steps create. You shouldn't see `woocommerce-square/` in the file path from that command output
3. Checkout this branch and follow the same steps as above
4. You should now see `woocommerce-square/` in the file paths

### Changelog entry

> Fix - ensure our archive command works properly.
