### PR TITLE
[Cash App Pay] Added end-to-end (E2E) tests for the Cash App Pay payment method.

### DIFF
--- a/tests/e2e/specs/d1.cash-app-pay.spec.js
+++ b/tests/e2e/specs/d1.cash-app-pay.spec.js
@@ -1,0 +1,340 @@
+import { test, expect, devices, chromium } from '@playwright/test';
+import {
+	createProduct,
+	doSquareRefund,
+	doesProductExist,
+	fillAddressFields,
+	gotoOrderEditPage,
+	placeCashAppPayOrder,
+	saveCashAppPaySettings,
+	selectPaymentMethod,
+	visitCheckout,
+	waitForUnBlock,
+} from '../utils/helper';
+const iPhone = devices['iPhone 14 Pro Max'];
+
+test.describe('Cash App Pay Tests', () => {
+	test.beforeAll('Setup', async ({ baseURL }) => {
+		const browser = await chromium.launch();
+		const page = await browser.newPage();
+
+		// Create a product if it doesn't exist.
+		if (!(await doesProductExist(baseURL, 'simple-product'))) {
+			await createProduct(page, {
+				name: 'Simple Product',
+				regularPrice: '14.99',
+				sku: 'simple-product',
+			});
+
+			await expect(
+				await page.getByText('Product published')
+			).toBeVisible();
+		}
+		await browser.close();
+	});
+
+	test('Store owner can see Cash App Pay in payment methods list - @foundational', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/admin.php?page=wc-settings&tab=checkout');
+		const creditCard = await page.locator(
+			'table.wc_gateways tr[data-gateway_id="square_cash_app_pay"]'
+		);
+		await expect(creditCard).toBeVisible();
+		await expect(creditCard.locator('td.name a')).toContainText(
+			'Cash App Pay (Square)'
+		);
+	});
+
+	test('Store owner can configure Cash App Pay payment gateway - @foundational', async ({
+		page,
+	}) => {
+		await saveCashAppPaySettings(page, {
+			enabled: false,
+		});
+
+		await page.goto('/product/simple-product');
+		await page.locator('.single_add_to_cart_button').click();
+
+		// Confirm that the Cash App Pay is not visible on checkout page.
+		await visitCheckout(page, false);
+		await fillAddressFields(page, false);
+		await expect(
+			await page.locator(
+				'ul.wc_payment_methods li.payment_method_square_cash_app_pay'
+			)
+		).not.toBeVisible();
+		// Confirm that the Cash App Pay is not visible on block-checkout page.
+		await visitCheckout(page, true);
+		await expect(
+			await page.locator(
+				'label[for="radio-control-wc-payment-method-options-square_cash_app_pay"]'
+			)
+		).not.toBeVisible();
+
+		const cashAppTitle = 'Cash App Pay TEST';
+		const cashAppDescription = 'Cash App Pay TEST Description';
+		await saveCashAppPaySettings(page, {
+			enabled: true,
+			title: cashAppTitle,
+			description: cashAppDescription,
+		});
+
+		// Confirm that the Cash App Pay is visible on checkout page.
+		await visitCheckout(page, false);
+		const paymentMethod = await page.locator(
+			'ul.wc_payment_methods li.payment_method_square_cash_app_pay'
+		);
+		await expect(paymentMethod).toBeVisible();
+		await selectPaymentMethod(page, 'square_cash_app_pay', false);
+		await expect(paymentMethod.locator('label').first()).toContainText(
+			cashAppTitle
+		);
+		await expect(
+			paymentMethod
+				.locator('.payment_method_square_cash_app_pay p', {
+					hasText: cashAppDescription,
+				})
+				.first()
+		).toBeVisible();
+
+		// Confirm that the Cash App Pay is visible on block-checkout page.
+		await visitCheckout(page, true);
+		const cashAppMethod = await page.locator(
+			'label[for="radio-control-wc-payment-method-options-square_cash_app_pay"]'
+		);
+		await expect(cashAppMethod).toBeVisible();
+		await expect(cashAppMethod).toContainText(cashAppTitle);
+		await selectPaymentMethod(page, 'square_cash_app_pay', true);
+		await expect(
+			page
+				.locator(
+					'.wc-block-components-radio-control-accordion-content p',
+					{
+						hasText: cashAppDescription,
+					}
+				)
+				.first()
+		).toBeVisible();
+	});
+
+	test('Store owner can configure Cash App Pay Button Appearance - @foundational', async ({
+		page,
+	}) => {
+		await saveCashAppPaySettings(page, {
+			enabled: true,
+			buttonTheme: 'light',
+			buttonShape: 'round',
+		});
+
+		// Confirm button styles on checkout page.
+		await visitCheckout(page, false);
+		const paymentMethod = await page.locator(
+			'ul.wc_payment_methods li.payment_method_square_cash_app_pay'
+		);
+		await expect(paymentMethod).toBeVisible();
+		await selectPaymentMethod(page, 'square_cash_app_pay', false);
+		const cashAppPayButton = await page
+			.locator('#wc-square-cash-app')
+			.getByTestId('cap-btn');
+		await expect(cashAppPayButton).toBeVisible();
+		await expect(cashAppPayButton).toHaveClass(/rounded-3xl/);
+		await expect(cashAppPayButton).toHaveClass(/bg-white/);
+
+		// Confirm button styles on block-checkout page.
+		await visitCheckout(page, true);
+		const cashAppMethod = await page.locator(
+			'label[for="radio-control-wc-payment-method-options-square_cash_app_pay"]'
+		);
+		await expect(cashAppMethod).toBeVisible();
+		await selectPaymentMethod(page, 'square_cash_app_pay', true);
+		const cashAppButton = await page
+			.locator('#wc-square-cash-app-pay')
+			.getByTestId('cap-btn');
+		await expect(cashAppButton).toBeVisible();
+		await expect(cashAppButton).toHaveClass(/rounded-3xl/);
+		await expect(cashAppButton).toHaveClass(/bg-white/);
+
+		await saveCashAppPaySettings(page, {
+			enabled: true,
+			buttonTheme: 'dark',
+			buttonShape: 'semiround',
+		});
+
+		// Confirm button styles on checkout page.
+		await visitCheckout(page, false);
+		const payMethod = await page.locator(
+			'ul.wc_payment_methods li.payment_method_square_cash_app_pay'
+		);
+		await expect(payMethod).toBeVisible();
+		await selectPaymentMethod(page, 'square_cash_app_pay', false);
+		const button = await page
+			.locator('#wc-square-cash-app')
+			.getByTestId('cap-btn');
+		await expect(button).toBeVisible();
+		await expect(button).toHaveClass(/rounded-md/);
+		await expect(button).toHaveClass(/bg-black/);
+
+		// Confirm button styles on block-checkout page.
+		await visitCheckout(page, true);
+		const blockPayMethod = await page.locator(
+			'label[for="radio-control-wc-payment-method-options-square_cash_app_pay"]'
+		);
+		await expect(blockPayMethod).toBeVisible();
+		await selectPaymentMethod(page, 'square_cash_app_pay', true);
+		const buttonBlock = await page
+			.locator('#wc-square-cash-app-pay')
+			.getByTestId('cap-btn');
+		await expect(buttonBlock).toBeVisible();
+		await expect(buttonBlock).toHaveClass(/rounded-md/);
+		await expect(buttonBlock).toHaveClass(/bg-black/);
+	});
+
+	test('Cash App Pay should be only available for US based sellers - @foundational', async ({
+		page,
+	}) => {
+		await page.goto('/wp-admin/admin.php?page=wc-settings&tab=general');
+		await page
+			.locator('select[name="woocommerce_default_country"]')
+			.selectOption('IN:GJ');
+		await page.locator('.woocommerce-save-button').click();
+
+		await expect(
+			page
+				.locator('.notice.notice-error p', {
+					hasText: /Cash App Pay/,
+				})
+				.first()
+		).toContainText(
+			'Your base country is IN, but Cash App Pay can’t accept transactions from merchants outside of US.'
+		);
+
+		// Confirm that the Cash App Pay is not visible on block-checkout page.
+		await visitCheckout(page, true);
+		await expect(
+			await page.locator(
+				'label[for="radio-control-wc-payment-method-options-square_cash_app_pay"]'
+			)
+		).not.toBeVisible();
+
+		await page.goto('/wp-admin/admin.php?page=wc-settings&tab=general');
+		await page
+			.locator('select[name="woocommerce_default_country"]')
+			.selectOption('US:CA');
+		await page.locator('.woocommerce-save-button').click();
+	});
+
+	test('Cash App Pay should be only available for US based buyers - @foundational', async ({
+		page,
+	}) => {
+		// Confirm that the Cash App Pay is not visible on checkout page.
+		await visitCheckout(page, false);
+		await fillAddressFields(page, false);
+
+		// non-US buyer.
+		await page.locator('#billing_country').selectOption('IN');
+		await page.locator('#billing_country').blur();
+		await waitForUnBlock(page);
+		const payMethod = await page.locator(
+			'ul.wc_payment_methods li.payment_method_square_cash_app_pay'
+		);
+		await expect(payMethod).not.toBeVisible();
+
+		// US based buyer.
+		await fillAddressFields(page, false);
+		await expect(payMethod).toBeVisible();
+
+		// Confirm that the Cash App Pay is not visible on block-checkout page.
+		await visitCheckout(page, true);
+		await fillAddressFields(page, true);
+		await page.locator('#billing-country').locator('input').fill('India');
+		await page.waitForTimeout(1500);
+		const blockPayMethod = await page.locator(
+			'label[for="radio-control-wc-payment-method-options-square_cash_app_pay"]'
+		);
+		await expect(blockPayMethod).not.toBeVisible();
+
+		// US based buyer.
+		await fillAddressFields(page, true);
+		await expect(blockPayMethod).toBeVisible();
+	});
+
+	const isBlockCheckout = [true, false];
+
+	for (const isBlock of isBlockCheckout) {
+		const title = isBlock ? '[Block]:' : '[non-Block]:';
+
+		test(
+			title + 'Customers can pay using Cash App Pay - @foundational',
+			async ({ browser }) => {
+				const context = await browser.newContext({
+					...iPhone,
+				});
+				const page = await context.newPage();
+				await page.goto('/product/simple-product');
+				await page.locator('.single_add_to_cart_button').click();
+				await visitCheckout(page, isBlock);
+				await fillAddressFields(page, isBlock);
+				await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
+				const orderId = await placeCashAppPayOrder(page, isBlock);
+
+				await gotoOrderEditPage(page, orderId);
+				await expect(page.locator('#order_status')).toHaveValue(
+					'wc-processing'
+				);
+				await expect(
+					page.getByText(
+						'Cash App Pay (Square) Test Charge Approved for an amount of'
+					)
+				).toBeVisible();
+			}
+		);
+	}
+
+	test('Store owners can fully refund Cash App Pay orders - @foundational', async ({
+		browser,
+	}) => {
+		const isBlock = true;
+		const context = await browser.newContext({
+			...iPhone,
+		});
+		const page = await context.newPage();
+		await page.goto('/product/simple-product');
+		page.on('dialog', dialog => dialog.accept());
+		await page.locator('.single_add_to_cart_button').click();
+		await visitCheckout(page, isBlock);
+		await fillAddressFields(page, isBlock);
+		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
+		const orderId = await placeCashAppPayOrder(page, isBlock);
+		await gotoOrderEditPage(page, orderId);
+		await doSquareRefund( page, '14.99' );
+		await expect( page.locator( '#order_status' ) ).toHaveValue( 'wc-refunded' );
+		await expect( await page.getByText( 'Cash App Pay (Square) Refund in the amount of $14.99 approved' ) ).toBeVisible();
+		await expect( await page.getByText( 'Cash App Pay (Square) Order completely refunded.' ) ).toBeVisible();
+	});
+
+	test('Store owners can partially refund Cash App Pay orders - @foundational', async ({
+		browser,
+	}) => {
+		const isBlock = true;
+		const context = await browser.newContext({
+			...iPhone,
+		});
+		const page = await context.newPage();
+		await page.goto('/product/simple-product');
+		page.on('dialog', dialog => dialog.accept());
+		await page.locator('.single_add_to_cart_button').click();
+		await visitCheckout(page, isBlock);
+		await fillAddressFields(page, isBlock);
+		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
+		const orderId = await placeCashAppPayOrder(page, isBlock);
+		await gotoOrderEditPage(page, orderId);
+		await doSquareRefund( page, '1' );
+		await expect( await page.getByText( 'Cash App Pay (Square) Refund in the amount of $1.00 approved' ) ).toBeVisible();
+		await expect( page.locator( '#order_status' ) ).toHaveValue( 'wc-processing' );
+
+		await doSquareRefund( page, '13.99' );
+		await expect( page.locator( '#order_status' ) ).toHaveValue( 'wc-refunded' );
+		await expect( await page.getByText( 'Cash App Pay (Square) Order completely refunded.' ) ).toBeVisible();
+	});
+});

--- a/tests/e2e/specs/d1.cash-app-pay.spec.js
+++ b/tests/e2e/specs/d1.cash-app-pay.spec.js
@@ -1,5 +1,6 @@
 import { test, expect, devices, chromium } from '@playwright/test';
 import {
+	clearCart,
 	createProduct,
 	doSquareRefund,
 	doesProductExist,
@@ -360,6 +361,7 @@ test.describe('Cash App Pay Tests', () => {
 			...iPhone,
 		});
 		const page = await context.newPage();
+		await clearCart( page );
 		await page.goto('/product/simple-product');
 		page.on('dialog', dialog => dialog.accept());
 		await page.locator('.single_add_to_cart_button').click();

--- a/tests/e2e/specs/d2.cash-app-pay-inventory-sync.spec.js
+++ b/tests/e2e/specs/d2.cash-app-pay-inventory-sync.spec.js
@@ -1,0 +1,134 @@
+import { test, expect, devices, chromium } from '@playwright/test';
+import {
+	deleteAllProducts,
+	doSquareRefund,
+	doesProductExist,
+	fillAddressFields,
+	gotoOrderEditPage,
+	placeCashAppPayOrder,
+	selectPaymentMethod,
+	visitCheckout,
+} from '../utils/helper';
+import {
+	clearSync,
+	createCatalogObject,
+	deleteAllCatalogItems,
+	importProducts,
+	retrieveInventoryCount,
+	updateCatalogItemInventory,
+} from '../utils/square-sandbox';
+const iPhone = devices['iPhone 14 Pro Max'];
+
+/**
+ * Marked test skip because:
+ *  1. It is flaky and flakiness depends on the Square sandbox environment.
+ *  2. It takes a long time to run. (more than 1 minute)
+ * 
+ *  We can run this test locally by removing the skip during the smoke testing or support WP/WC version bumps.
+ */
+test.describe('Cash App Pay Inventory Sync Tests', () => {
+	let itemId;
+	const quantity = 100;
+	test.beforeAll('Setup', async ({ baseURL }) => {
+		const browser = await chromium.launch();
+		const page = await browser.newPage();
+
+		await deleteAllProducts(page);
+		await deleteAllCatalogItems();
+		const response = await createCatalogObject(
+			'Sample product with inventory',
+			'sample-product-with-inventory',
+			1900,
+			'This is a sample product with inventory.'
+		);
+		itemId = response.catalog_object.item_data.variations[0].id;
+
+		await updateCatalogItemInventory(itemId, `${quantity}`);
+		await clearSync(page);
+
+		await page.goto('/wp-admin/admin.php?page=wc-settings&tab=square');
+		await page
+			.locator('#wc_square_system_of_record')
+			.selectOption({ label: 'Square' });
+		await page.locator('.woocommerce-save-button').click();
+		await expect(
+			await page.getByText('Your settings have been saved.')
+		).toBeVisible();
+
+		await browser.close();
+	});
+
+	test.skip('Product inventory should be sync for order placed by Cash App Pay', async ({
+		browser,
+		page,
+		baseURL,
+	}) => {
+		// Sync product with inventory to Square first.
+		test.slow();
+
+		page.on('dialog', (dialog) => dialog.accept());
+		await importProducts(page);
+
+		const nRetries = 8;
+		let isProductExist = false;
+		for (let i = 0; i < nRetries; i++) {
+			isProductExist = await doesProductExist(
+				baseURL,
+				'sample-product-with-inventory/	'
+			);
+			if ( isProductExist ) {
+				break;
+			} else {
+				await page.waitForTimeout(4000); // wait for import inventory to be completed.
+			}
+		}
+
+		// Skip the test if the product is not imported.
+		if ( !isProductExist ) {
+			test.skip();
+		}
+
+		// Place order with Cash App Pay.
+		const isBlock = true;
+		const context = await browser.newContext({
+			...iPhone,
+		});
+		const mobilePage = await context.newPage();
+		await mobilePage.goto('/product/sample-product-with-inventory/');
+		mobilePage.on('dialog', (dialog) => dialog.accept());
+		await mobilePage.locator('.single_add_to_cart_button').click();
+		await visitCheckout(mobilePage, isBlock);
+		await fillAddressFields(mobilePage, isBlock);
+		await selectPaymentMethod(mobilePage, 'square_cash_app_pay', isBlock);
+		const orderId = await placeCashAppPayOrder(mobilePage, isBlock);
+
+		// Confirm that the inventory is deducted.
+		await mobilePage.waitForTimeout(6000);
+		const updatedInventory = await retrieveInventoryCount(itemId);
+		const updatedQty =
+			updatedInventory.counts &&
+			updatedInventory.counts[0] &&
+			updatedInventory.counts[0].quantity;
+		await expect(updatedQty).toBe(`${quantity - 1}`);
+
+		await gotoOrderEditPage(mobilePage, orderId);
+		await doSquareRefund(mobilePage, '19');
+		await expect(
+			await mobilePage.getByText(
+				'Cash App Pay (Square) Order completely refunded.'
+			)
+		).toBeVisible();
+		await expect(mobilePage.locator('#order_status')).toHaveValue(
+			'wc-refunded'
+		);
+
+		// Confirm that the inventory is restored after refund.
+		await mobilePage.waitForTimeout(6000);
+		const updatedInventory2 = await retrieveInventoryCount(itemId);
+		const updatedQty2 =
+			updatedInventory2.counts &&
+			updatedInventory2.counts[0] &&
+			updatedInventory2.counts[0].quantity;
+		await expect(updatedQty2).toBe(`${quantity}`);
+	});
+});

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -322,6 +322,9 @@ export async function doSquareRefund( page, amount = '' ) {
  */
 export async function deleteAllProducts( page, permanent = true ) {
 	await page.goto( '/wp-admin/edit.php?post_type=product' );
+	if ( ! await page.locator( '#cb-select-all-1' ).isVisible() ) {
+		return;
+	}
 	await page.locator( '#cb-select-all-1' ).check();
 	await page.locator( '#bulk-action-selector-top' ).selectOption( { value: 'trash' } );
 	await page.locator( '#doaction' ).click();

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -437,8 +437,9 @@ export async function selectPaymentMethod(
  *
  * @param {Object}  page    Playwright page object.
  * @param {Boolean} isBlock Indicates if is block checkout.
+ * @param {Boolean} decline Indicates if payment should be declined.
  */
-export async function placeCashAppPayOrder( page, isBlock = true ) {
+export async function placeCashAppPayOrder( page, isBlock = true, decline = false ) {
 	// Wait for overlay to disappear
 	await waitForUnBlock(page);
 	if ( isBlock ) {
@@ -447,9 +448,18 @@ export async function placeCashAppPayOrder( page, isBlock = true ) {
 		await page.locator('#wc-square-cash-app').getByTestId('cap-btn').click();
 	}	
 	await page.waitForLoadState('networkidle');
-	await page.getByRole('button', { name: 'Approve' }).click();
+	if ( decline ) {
+		await page.getByRole('button', { name: 'Decline' }).click();
+	} else {
+		await page.getByRole('button', { name: 'Approve' }).click();
+	}
 	await page.waitForLoadState('networkidle');
 	await page.getByRole('button', { name: 'Done' }).click();
+	// Early return if declined.
+	if ( decline ) {
+		return;
+	}
+
 	await page.waitForLoadState('networkidle');
 	await expect(
 		await page.locator( '.entry-title' )

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -331,3 +331,131 @@ export async function deleteAllProducts( page, permanent = true ) {
 		await page.locator( '#delete_all' ).first().click();
 	}
 }
+
+
+/**
+ * Save Cash App Pay payment settings
+ *
+ * @param {Page}    page     Playwright page object
+ * @param {Object}  options  Cash App Pay payment settings
+ */
+export async function saveCashAppPaySettings(page, options) {
+	const settings = {
+		enabled: true,
+		title: 'Cash App Pay',
+		description: 'Pay securely using Cash App Pay.',
+		debugMode: 'off',
+		buttonTheme: 'dark',
+		buttonShape: 'semiround',
+		...options,
+	};
+
+	await page.goto(
+		'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=square_cash_app_pay'
+	);
+
+	// Enable/Disable
+	if (!settings.enabled) {
+		await page.locator('#woocommerce_square_cash_app_pay_enabled').uncheck();
+	} else {
+		await page.locator('#woocommerce_square_cash_app_pay_enabled').check();
+	}
+
+	// Title and Description
+	await page
+		.locator('#woocommerce_square_cash_app_pay_title')
+		.fill(settings.title);
+	await page
+		.locator('#woocommerce_square_cash_app_pay_description')
+		.fill(settings.description);
+
+	// Debug Mode and Environment
+	await page
+		.locator('#woocommerce_square_cash_app_pay_debug_mode')
+		.selectOption(settings.debugMode);
+	
+	// Button customization
+	await page
+		.locator('#woocommerce_square_cash_app_pay_button_theme')
+		.selectOption(settings.buttonTheme);
+	await page
+		.locator('#woocommerce_square_cash_app_pay_button_shape')
+		.selectOption(settings.buttonShape);
+
+	await page.getByRole('button', { name: 'Save changes' }).click();
+	await expect(page.locator('#message.updated.inline').last()).toContainText(
+		'Your settings have been saved.'
+	);
+}
+
+/**
+ * Select payment method
+ *
+ * @param {Page}    page            Playwright page object
+ * @param {string}  paymentMethod   Payment method name
+ * @param {boolean} isBlockCheckout Is block checkout?
+ */
+export async function selectPaymentMethod(
+	page,
+	paymentMethod,
+	isBlockCheckout
+) {
+	if (isBlockCheckout) {
+		await page
+			.locator(
+				`label[for="radio-control-wc-payment-method-options-${paymentMethod}"]`
+			)
+			.click();
+		await expect(
+			page.locator('.wc-block-components-loading-mask')
+		).not.toBeVisible();
+		return;
+	}
+	// Wait for overlay to disappear
+	await page
+		.locator('.blockUI.blockOverlay')
+		.last()
+		.waitFor({ state: 'detached' });
+
+	// Wait for payment method to appear
+	const payMethod = await page
+		.locator(
+			`ul.wc_payment_methods li.payment_method_${paymentMethod} label`
+		)
+		.first();
+	await expect(payMethod).toBeVisible();
+
+	// Select payment method
+	await page
+		.locator(`label[for="payment_method_${paymentMethod}"]`)
+		.waitFor();
+	await payMethod.click();
+}
+
+/**
+ * Pay using Cash App Pay
+ *
+ * @param {Object}  page    Playwright page object.
+ * @param {Boolean} isBlock Indicates if is block checkout.
+ */
+export async function placeCashAppPayOrder( page, isBlock = true ) {
+	// Wait for overlay to disappear
+	await waitForUnBlock(page);
+	if ( isBlock ) {
+		await page.locator('#wc-square-cash-app-pay').getByTestId('cap-btn').click();
+	} else {
+		await page.locator('#wc-square-cash-app').getByTestId('cap-btn').click();
+	}	
+	await page.waitForLoadState('networkidle');
+	await page.getByRole('button', { name: 'Approve' }).click();
+	await page.waitForLoadState('networkidle');
+	await page.getByRole('button', { name: 'Done' }).click();
+	await page.waitForLoadState('networkidle');
+	await expect(
+		await page.locator( '.entry-title' )
+	).toHaveText( 'Order received' );
+	const orderId = await page
+		.locator( '.woocommerce-order-overview__order strong' )
+		.innerText();
+	return orderId;
+}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR adds new E2E tests for the Cash App Pay implementation we have done in PR #53.

Closes #50 

### Steps to test the changes in this Pull Request:
1. Checkout to PR
2. Run `npm install`
3. Run `npx playwright install`
4. Run `npm run test:env:start` (Note: Please start docker before this command)
5. Add environment variables to the `/tests/e2e/config/.env` file
6. Run `npm run test:e2e-run`
7. Verify all tests run successfully.

### Changelog entry

> Dev - Added end-to-end (E2E) tests for the Cash App Pay payment method.
