### PR TITLE
[Cash App Pay] Add support for “Charge” and “Authorization” transaction types

### DIFF
--- a/includes/Framework/PaymentGateway/Admin/Payment_Gateway_Admin_Order.php
+++ b/includes/Framework/PaymentGateway/Admin/Payment_Gateway_Admin_Order.php
@@ -199,6 +199,7 @@ class Payment_Gateway_Admin_Order {
 		$can_capture_charge = false;
 		$status             = sanitize_text_field( wp_unslash( $_REQUEST['status'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown
 		if ( ! current_user_can( 'edit_shop_orders' ) || 'trash' === $status ) {
 			return $bulk_actions;
 		}
@@ -225,6 +226,7 @@ class Payment_Gateway_Admin_Order {
 	 */
 	public function hpos_process_capture_charge_bulk_order_action( $redirect_to, $action, $ids ) {
 		// bail if not processing a capture or if the user doesn't have the capability
+		// phpcs:ignore WordPress.WP.Capabilities.Unknown
 		if ( 'wc_capture_charge' !== $action || empty( $ids ) || ! current_user_can( 'edit_shop_orders' ) ) {
 			return;
 		}

--- a/includes/Framework/PaymentGateway/Handlers/Capture.php
+++ b/includes/Framework/PaymentGateway/Handlers/Capture.php
@@ -53,7 +53,7 @@ class Capture {
 		$this->gateway = $gateway;
 
 		// auto-capture on order status change if enabled
-		if ( $gateway->supports_credit_card_capture() && $gateway->is_paid_capture_enabled() ) {
+		if ( $gateway->supports_capture() && $gateway->is_paid_capture_enabled() ) {
 			add_action( 'woocommerce_order_status_changed', array( $this, 'maybe_capture_paid_order' ), 10, 3 );
 		}
 	}
@@ -142,7 +142,7 @@ class Capture {
 		try {
 
 			// notify if the gateway doesn't support captures when this is called directly
-			if ( ! $this->get_gateway()->supports_credit_card_capture() ) {
+			if ( ! $this->get_gateway()->supports_capture() ) {
 
 				$message = "{$this->get_gateway()->get_method_title()} does not support payment captures";
 
@@ -186,7 +186,7 @@ class Capture {
 				);
 			} else {
 				// attempt the capture
-				$response = $this->get_gateway()->get_api()->credit_card_capture( $order );
+				$response = $this->get_gateway()->get_api()->capture_payment( $order );
 			}
 
 			$gift_card_purchase_type = \WooCommerce\Square\Handlers\Order::get_gift_card_purchase_type( $order );
@@ -283,7 +283,7 @@ class Capture {
 		$total_captured = (float) $this->get_gateway()->get_order_meta( $order, 'capture_total' ) + (float) $order->capture->amount;
 
 		$this->get_gateway()->update_order_meta( $order, 'capture_total', Square_Helper::number_format( $total_captured ) );
-		$this->get_gateway()->update_order_meta( $order, 'charge_captured', $this->get_gateway()->supports_credit_card_partial_capture() && $this->get_gateway()->is_partial_capture_enabled() && $total_captured < (float) $this->get_order_capture_maximum( $order ) ? 'partial' : 'yes' );
+		$this->get_gateway()->update_order_meta( $order, 'charge_captured', $this->get_gateway()->supports_partial_capture() && $this->get_gateway()->is_partial_capture_enabled() && $total_captured < (float) $this->get_order_capture_maximum( $order ) ? 'partial' : 'yes' );
 
 		// add capture transaction ID
 		if ( $response && $response->get_transaction_id() ) {
@@ -359,7 +359,7 @@ class Capture {
 
 		$captured = 'yes' === $this->get_gateway()->get_order_meta( $order, 'charge_captured' );
 
-		if ( ! $captured && $this->get_gateway()->supports_credit_card_partial_capture() && $this->get_gateway()->is_partial_capture_enabled() ) {
+		if ( ! $captured && $this->get_gateway()->supports_partial_capture() && $this->get_gateway()->is_partial_capture_enabled() ) {
 			$captured = (float) $this->get_gateway()->get_order_meta( $order, 'capture_total' ) >= (float) $this->get_order_capture_maximum( $order );
 		}
 

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -97,6 +97,21 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	/** Credit Card partial capture transaction feature */
 	const FEATURE_CREDIT_CARD_PARTIAL_CAPTURE = 'partial_capture';
 
+	/** Gateway charge transaction feature */
+	const FEATURE_CHARGE = 'charge';
+
+	/** Gateway authorization transaction feature */
+	const FEATURE_AUTHORIZATION = 'authorization';
+
+	/** Gateway charge virtual-only orders feature */
+	const FEATURE_CHARGE_VIRTUAL = 'charge-virtual';
+
+	/** Gateway capture charge transaction feature */
+	const FEATURE_CAPTURE = 'capture_charge';
+
+	/** Gateway partial capture transaction feature */
+	const FEATURE_PARTIAL_CAPTURE = 'partial_capture';
+
 	/** Display detailed customer decline messages on checkout */
 	const FEATURE_DETAILED_CUSTOMER_DECLINE_MESSAGES = 'customer_decline_messages';
 
@@ -2970,6 +2985,61 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 		return $this->supports_credit_card_capture() && $this->supports( self::FEATURE_CREDIT_CARD_PARTIAL_CAPTURE );
 	}
 
+	/**
+	 * Returns true if gateway supports authorization transactions
+	 *
+	 * @since x.x.x
+	 * @return boolean true if the gateway supports authorization
+	 */
+	public function supports_authorization() {
+		return $this->supports( self::FEATURE_AUTHORIZATION );
+	}
+
+
+	/**
+	 * Returns true if gateway supports charge transactions
+	 *
+	 * @since x.x.x
+	 * @return boolean true if the gateway supports charges
+	 */
+	public function supports_charge() {
+		return $this->supports( self::FEATURE_CHARGE );
+	}
+
+
+	/**
+	 * Determines if gateway supports charging virtual-only orders.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public function supports_charge_virtual() {
+		return $this->supports( self::FEATURE_CHARGE_VIRTUAL );
+	}
+
+
+	/**
+	 * Returns true if the gateway supports capturing a charge
+	 *
+	 * @since x.x.x
+	 * @return boolean true if the gateway supports capturing a charge
+	 */
+	public function supports_capture() {
+		return $this->supports( self::FEATURE_CAPTURE );
+	}
+
+
+	/**
+	 * Determines if the gateway supports capturing a partial charge.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public function supports_partial_capture() {
+		return $this->supports( self::FEATURE_PARTIAL_CAPTURE );
+	}
+
 
 	/**
 	 * Adds any credit card authorization/charge admin fields, allowing the
@@ -2981,7 +3051,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	 */
 	protected function add_authorization_charge_form_fields( $form_fields ) {
 
-		assert( $this->supports_credit_card_authorization() && $this->supports_credit_card_charge() );
+		assert( $this->supports_authorization() && $this->supports_charge() );
 
 		$form_fields['transaction_type'] = array(
 			'title'    => esc_html__( 'Transaction Type', 'woocommerce-square' ),
@@ -2995,7 +3065,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			),
 		);
 
-		if ( $this->supports_credit_card_charge_virtual() ) {
+		if ( $this->supports_charge_virtual() ) {
 
 			$form_fields['charge_virtual_orders'] = array(
 				'label'       => esc_html__( 'Charge Virtual-Only Orders', 'woocommerce-square' ),
@@ -3005,7 +3075,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			);
 		}
 
-		if ( $this->supports_credit_card_partial_capture() ) {
+		if ( $this->supports_partial_capture() ) {
 
 			$form_fields['enable_partial_capture'] = array(
 				'label'       => esc_html__( 'Enable Partial Capture', 'woocommerce-square' ),
@@ -3015,7 +3085,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			);
 		}
 
-		if ( $this->supports_credit_card_capture() ) {
+		if ( $this->supports_capture() ) {
 
 			// get a list of the "paid" status names
 			$paid_statuses = array_map( 'wc_get_order_status_name', (array) wc_get_is_paid_statuses() );

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -73,6 +73,9 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	/** Credit card payment type */
 	const PAYMENT_TYPE_CREDIT_CARD = 'credit-card';
 
+	/** Credit card payment type */
+	const PAYMENT_TYPE_CASH_APP_PAY = 'cash_app_pay';
+
 	/** Products feature */
 	const FEATURE_PRODUCTS = 'products';
 
@@ -2481,7 +2484,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			$this->update_order_meta( $order, 'account_four', substr( $order->payment->account_number, -4 ) );
 		}
 
-		if ( $this->is_credit_card_gateway() ) {
+		if ( $this->is_credit_card_gateway() || $this->is_cash_app_pay_gateway() ) {
 
 			// credit card gateway data
 			if ( ! $is_partial && $response && $response instanceof Payment_Gateway_API_Authorization_Response ) {
@@ -2495,7 +2498,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 				if ( $order->payment_total > 0 ) {
 
 					// mark as captured
-					if ( $this->perform_credit_card_charge( $order ) ) {
+					if ( $this->perform_charge( $order ) ) {
 						$captured = 'yes';
 					} else {
 						$captured = 'no';
@@ -4098,6 +4101,16 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	 */
 	public function is_credit_card_gateway() {
 		return self::PAYMENT_TYPE_CREDIT_CARD == $this->get_payment_type();
+	}
+
+	/**
+	 * Returns true if this is a Cash App Pay gateway
+	 *
+	 * @since x.x.x
+	 * @return boolean true if this is a Cash App Pay gateway
+	 */
+	public function is_cash_app_pay_gateway() {
+		return self::PAYMENT_TYPE_CASH_APP_PAY === $this->get_payment_type();
 	}
 
 	/**

--- a/includes/Gateway/API.php
+++ b/includes/Gateway/API.php
@@ -151,19 +151,33 @@ class API extends \WooCommerce\Square\API {
 	}
 
 	/**
-	 * Performs a Cash App Pay charge for the given order.
+	 * Performs a cash app pay authorization for the given order.
 	 *
-	 * @since 4.5.0
+	 * @since x.x.x
 	 *
 	 * @param \WC_Order $order order object
 	 * @return \WooCommerce\Square\Gateway\API\Responses\Create_Payment
 	 * @throws \Exception
 	 */
-	public function cash_app_pay_charge( \WC_Order $order ) {
+	public function cash_app_pay_authorization( \WC_Order $order ) {
+		return $this->cash_app_pay_charge( $order, false );
+	}
+
+	/**
+	 * Performs a Cash App Pay charge for the given order.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param \WC_Order $order   Order object
+	 * @param bool      $capture Whether to capture the charge or not.
+	 * @return \WooCommerce\Square\Gateway\API\Responses\Create_Payment
+	 * @throws \Exception
+	 */
+	public function cash_app_pay_charge( \WC_Order $order, $capture = true ) {
 
 		$request = new API\Requests\Payments( $this->get_location_id(), $this->client );
 
-		$request->set_charge_data( $order, true, true );
+		$request->set_charge_data( $order, $capture, true );
 
 		$this->set_response_handler( API\Responses\Create_Payment::class );
 

--- a/includes/Gateway/API.php
+++ b/includes/Gateway/API.php
@@ -107,16 +107,15 @@ class API extends \WooCommerce\Square\API {
 
 
 	/**
-	 * Performs a credit card capture for a given authorized order.
+	 * Performs a capture for a given authorized order.
 	 *
-	 * @since 2.0.0
+	 * @since x.x.x
 	 *
 	 * @param \WC_Order $order order object
 	 * @return \WooCommerce\Square\API\Response
 	 * @throws \Exception
 	 */
-	public function credit_card_capture( \WC_Order $order ) {
-
+	public function capture_payment( \WC_Order $order ) {
 		$location_id = ! empty( $order->capture->location_id ) ? $order->capture->location_id : $this->get_location_id();
 
 		// use the Payments API to capture orders that were processed with Square v2.2+
@@ -131,6 +130,20 @@ class API extends \WooCommerce\Square\API {
 		$this->set_response_handler( API\Response::class );
 
 		return $this->perform_request( $request );
+	}
+
+
+	/**
+	 * Performs a credit card capture for a given authorized order.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param \WC_Order $order order object
+	 * @return \WooCommerce\Square\API\Response
+	 * @throws \Exception
+	 */
+	public function credit_card_capture( \WC_Order $order ) {
+		return $this->capture_payment( $order );
 	}
 
 	/**

--- a/includes/Gateway/API/Response.php
+++ b/includes/Gateway/API/Response.php
@@ -30,6 +30,20 @@ use WooCommerce\Square\Gateway;
 
 class Response extends \WooCommerce\Square\API\Response implements Payment_Gateway_API_Response {
 
+	/**
+	 * The transaction has been approved.
+	 */
+	const STATUS_COMPLETED = 'COMPLETED';
+
+	/**
+	 * The transaction has been approved.
+	 */
+	const STATUS_APPROVED = 'APPROVED';
+
+	/**
+	 * The transaction has been authorized but not yet captured.
+	 */
+	const STATUS_AUTHORIZED = 'AUTHORIZED';
 
 	/**
 	 * Determines if the transaction was approved.

--- a/includes/Gateway/API/Responses/Create_Payment.php
+++ b/includes/Gateway/API/Responses/Create_Payment.php
@@ -28,7 +28,14 @@ class Create_Payment extends \WooCommerce\Square\Gateway\API\Response implements
 
 		// ensure the tender is CAPTURED
 		if ( $this->get_payment() ) {
-			$held = 'AUTHORIZED' === $this->get_payment()->getCardDetails()->getStatus();
+			// Check if the card or wallet is AUTHORIZED (WALLET is for Cash App payments).
+			$card_details   = $this->get_payment()->getCardDetails();
+			$wallet_details = $this->get_payment()->getWalletDetails();
+			if ( ! empty( $card_details ) ) {
+				$held = 'AUTHORIZED' === $card_details->getStatus();
+			} elseif ( ! empty( $wallet_details ) ) {
+				$held = 'AUTHORIZED' === $wallet_details->getStatus();
+			}
 		}
 
 		return $held;
@@ -142,6 +149,16 @@ class Create_Payment extends \WooCommerce\Square\Gateway\API\Response implements
 	 */
 	public function is_cash_app_payment_completed() {
 		return $this->get_payment() && 'COMPLETED' === $this->get_payment()->getStatus();
+	}
+
+	/**
+	 * Returns true if the payment status is approved.
+	 *
+	 * @since x.x.x
+	 * @return boolean
+	 */
+	public function is_cash_app_payment_approved() {
+		return $this->get_payment() && 'APPROVED' === $this->get_payment()->getStatus();
 	}
 
 	/** No-op methods *************************************************************************************************/

--- a/includes/Gateway/API/Responses/Create_Payment.php
+++ b/includes/Gateway/API/Responses/Create_Payment.php
@@ -32,9 +32,9 @@ class Create_Payment extends \WooCommerce\Square\Gateway\API\Response implements
 			$card_details   = $this->get_payment()->getCardDetails();
 			$wallet_details = $this->get_payment()->getWalletDetails();
 			if ( ! empty( $card_details ) ) {
-				$held = 'AUTHORIZED' === $card_details->getStatus();
+				$held = self::STATUS_AUTHORIZED === $card_details->getStatus();
 			} elseif ( ! empty( $wallet_details ) ) {
-				$held = 'AUTHORIZED' === $wallet_details->getStatus();
+				$held = self::STATUS_AUTHORIZED === $wallet_details->getStatus();
 			}
 		}
 
@@ -148,7 +148,7 @@ class Create_Payment extends \WooCommerce\Square\Gateway\API\Response implements
 	 * @return boolean
 	 */
 	public function is_cash_app_payment_completed() {
-		return $this->get_payment() && 'COMPLETED' === $this->get_payment()->getStatus();
+		return $this->get_payment() && self::STATUS_COMPLETED === $this->get_payment()->getStatus();
 	}
 
 	/**
@@ -158,7 +158,7 @@ class Create_Payment extends \WooCommerce\Square\Gateway\API\Response implements
 	 * @return boolean
 	 */
 	public function is_cash_app_payment_approved() {
-		return $this->get_payment() && 'APPROVED' === $this->get_payment()->getStatus();
+		return $this->get_payment() && self::STATUS_APPROVED === $this->get_payment()->getStatus();
 	}
 
 	/** No-op methods *************************************************************************************************/

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -277,21 +277,21 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 
 		// common top form fields
 		$this->form_fields = array(
-			'enabled'      => array(
+			'enabled'     => array(
 				'title'   => esc_html__( 'Enable / Disable', 'woocommerce-square' ),
 				'label'   => esc_html__( 'Enable this gateway', 'woocommerce-square' ),
 				'type'    => 'checkbox',
 				'default' => 'no',
 			),
 
-			'title'        => array(
+			'title'       => array(
 				'title'    => esc_html__( 'Title', 'woocommerce-square' ),
 				'type'     => 'text',
 				'desc_tip' => esc_html__( 'Payment method title that the customer will see during checkout.', 'woocommerce-square' ),
 				'default'  => $this->get_default_title(),
 			),
 
-			'description'  => array(
+			'description' => array(
 				'title'    => esc_html__( 'Description', 'woocommerce-square' ),
 				'type'     => 'textarea',
 				'desc_tip' => esc_html__( 'Payment method description that the customer will see during checkout.', 'woocommerce-square' ),

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -222,6 +222,9 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 					'</a>'
 				),
 				'wc-square-enable-cash-app-pay',
+				array(
+					'always_show_on_settings' => false,
+				)
 			);
 		}
 	}

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -1121,7 +1121,7 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 			}
 		}
 
-		// Charge/Authorization the order.
+		// Charge/Authorize the order.
 		if ( $this->perform_charge( $order ) && self::CHARGE_TYPE_PARTIAL !== $this->get_charge_type() ) {
 			$response = $this->get_api()->cash_app_pay_charge( $order );
 		} else {

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -58,7 +58,7 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 			array(
 				'method_title'       => __( 'Cash App Pay (Square)', 'woocommerce-square' ),
 				'method_description' => __( 'Allow customers to securely pay with Cash App', 'woocommerce-square' ),
-				'payment_type'       => 'cash_app_pay',
+				'payment_type'       => self::PAYMENT_TYPE_CASH_APP_PAY,
 				'supports'           => array(
 					self::FEATURE_PRODUCTS,
 					self::FEATURE_REFUNDS,

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -62,6 +62,10 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 				'supports'           => array(
 					self::FEATURE_PRODUCTS,
 					self::FEATURE_REFUNDS,
+					self::FEATURE_AUTHORIZATION,
+					self::FEATURE_CHARGE,
+					self::FEATURE_CHARGE_VIRTUAL,
+					self::FEATURE_CAPTURE,
 				),
 				'countries'          => array( 'US' ),
 				'currencies'         => array( 'USD' ),
@@ -293,29 +297,35 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 				'desc_tip' => esc_html__( 'Payment method description that the customer will see during checkout.', 'woocommerce-square' ),
 				'default'  => $this->get_default_description(),
 			),
+		);
 
-			'button_theme' => array(
-				'title'    => esc_html__( 'Cash App Pay Button Theme', 'woocommerce-square' ),
-				'desc_tip' => esc_html__( 'Select the theme of the Cash App Pay button.', 'woocommerce-square' ),
-				'type'     => 'select',
-				'default'  => 'dark',
-				'class'    => 'wc-enhanced-select wc-square-cash-app-pay-options',
-				'options'  => array(
-					'dark'  => esc_html__( 'Dark', 'woocommerce-square' ),
-					'light' => esc_html__( 'Light', 'woocommerce-square' ),
-				),
+		// Both authorization & charge supported.
+		if ( $this->supports_authorization() && $this->supports_charge() ) {
+			$this->form_fields = $this->add_authorization_charge_form_fields( $this->form_fields );
+		}
+
+		// Cash App Pay button theme and shape
+		$this->form_fields['button_theme'] = array(
+			'title'    => esc_html__( 'Cash App Pay Button Theme', 'woocommerce-square' ),
+			'desc_tip' => esc_html__( 'Select the theme of the Cash App Pay button.', 'woocommerce-square' ),
+			'type'     => 'select',
+			'default'  => 'dark',
+			'class'    => 'wc-enhanced-select wc-square-cash-app-pay-options',
+			'options'  => array(
+				'dark'  => esc_html__( 'Dark', 'woocommerce-square' ),
+				'light' => esc_html__( 'Light', 'woocommerce-square' ),
 			),
+		);
 
-			'button_shape' => array(
-				'title'    => esc_html__( 'Cash App Pay Button Shape', 'woocommerce-square' ),
-				'desc_tip' => esc_html__( 'Select the shape of the Cash App Pay button.', 'woocommerce-square' ),
-				'type'     => 'select',
-				'default'  => 'semiround',
-				'class'    => 'wc-enhanced-select wc-square-cash-app-pay-options',
-				'options'  => array(
-					'semiround' => esc_html__( 'Semiround', 'woocommerce-square' ),
-					'round'     => esc_html__( 'Round', 'woocommerce-square' ),
-				),
+		$this->form_fields['button_shape'] = array(
+			'title'    => esc_html__( 'Cash App Pay Button Shape', 'woocommerce-square' ),
+			'desc_tip' => esc_html__( 'Select the shape of the Cash App Pay button.', 'woocommerce-square' ),
+			'type'     => 'select',
+			'default'  => 'semiround',
+			'class'    => 'wc-enhanced-select wc-square-cash-app-pay-options',
+			'options'  => array(
+				'semiround' => esc_html__( 'Semiround', 'woocommerce-square' ),
+				'round'     => esc_html__( 'Round', 'woocommerce-square' ),
 			),
 		);
 

--- a/tests/e2e/specs/d3.cash-app-pay-trasaction-type.spec.js
+++ b/tests/e2e/specs/d3.cash-app-pay-trasaction-type.spec.js
@@ -1,0 +1,193 @@
+import { test, expect, devices, chromium } from '@playwright/test';
+import {
+	clearCart,
+	createProduct,
+	doesProductExist,
+	fillAddressFields,
+	gotoOrderEditPage,
+	placeCashAppPayOrder,
+	saveCashAppPaySettings,
+	selectPaymentMethod,
+	visitCheckout,
+} from '../utils/helper';
+const iPhone = devices['iPhone 14 Pro Max'];
+
+test.describe('Cash App Pay Tests', () => {
+	test.beforeAll('Setup', async ({ baseURL }) => {
+		const browser = await chromium.launch();
+		const page = await browser.newPage();
+
+		// Create a product if it doesn't exist.
+		if (!(await doesProductExist(baseURL, 'simple-product'))) {
+			await createProduct(page, {
+				name: 'Simple Product',
+				regularPrice: '14.99',
+				sku: 'simple-product',
+			});
+
+			await expect(
+				await page.getByText('Product published')
+			).toBeVisible();
+		}
+
+		// Create Virtual product.
+		if (!(await doesProductExist(baseURL, 'virtual-product'))) {
+			await createProduct(
+				page,
+				{
+					name: 'Virtual Product',
+					regularPrice: '7.99',
+					sku: 'virtual-product',
+				},
+				false
+			);
+			await page.locator('#_virtual').check();
+			await page.waitForTimeout(2000);
+			await page.locator('#publish').click();
+			await expect(
+				await page.getByText('Product published')
+			).toBeVisible();
+		}
+
+		// Set authorization transaction type.
+		await saveCashAppPaySettings(page, {
+			transactionType: 'authorization',
+		});
+
+		await clearCart(page);
+		await browser.close();
+	});
+
+	test.afterAll( async () => {
+		const browser = await chromium.launch();
+		const page = await browser.newPage();
+
+		// Set authorization transaction type.
+		await saveCashAppPaySettings(page, {
+			transactionType: 'charge',
+		});
+
+		await clearCart( page );
+		await browser.close();
+	} );
+
+	const isBlockCheckout = [true, false];
+
+	for (const isBlock of isBlockCheckout) {
+		const title = isBlock ? '[Block]:' : '[non-Block]:';
+
+		test(
+			title +
+				'Store owner should able to set transaction type "Authorization" - @foundational',
+			async ({ browser }) => {
+				const context = await browser.newContext({
+					...iPhone,
+				});
+				const page = await context.newPage();
+				await page.goto('/product/simple-product');
+				await page.locator('.single_add_to_cart_button').click();
+				await visitCheckout(page, isBlock);
+				await fillAddressFields(page, isBlock);
+				await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
+				const orderId = await placeCashAppPayOrder(page, isBlock);
+
+				await gotoOrderEditPage(page, orderId);
+				await expect(page.locator('#order_status')).toHaveValue(
+					'wc-on-hold'
+				);
+				await expect(
+					page.getByText(
+						'Cash App Pay (Square) Test Authorization Approved for an amount of'
+					)
+				).toBeVisible();
+
+				page.on('dialog', dialog => dialog.accept());
+				await page.locator('button.wc-square-cash-app-pay-capture').click();
+
+				// Verify order status and capture status.
+				await expect(page.locator('#order_status')).toHaveValue(
+					'wc-processing'
+				);
+				await expect(
+					page.getByText('Cash App Pay (Square) Capture total of')
+				).toBeVisible();
+			}
+		);
+	}
+
+	test('Store owner should able to set transaction type "Authorization" and charge virtual-only orders - @foundational', async ({
+		browser,
+	}) => {
+		const context = await browser.newContext({
+			...iPhone,
+		});
+		const isBlock = true;
+		const page = await context.newPage();
+
+		// Set authorization transaction type.
+		await saveCashAppPaySettings(page, {
+			transactionType: 'authorization',
+			chargeVirtualOrders: true,
+		});
+
+		await page.goto('/product/virtual-product');
+		await page.locator('.single_add_to_cart_button').click();
+		await visitCheckout(page, isBlock);
+		await fillAddressFields(page, isBlock);
+		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
+		const orderId = await placeCashAppPayOrder(page, isBlock);
+
+		await gotoOrderEditPage(page, orderId);
+		await expect(page.locator('#order_status')).toHaveValue(
+			'wc-processing'
+		);
+		await expect(
+			page.getByText(
+				'Cash App Pay (Square) Test Charge Approved for an amount of'
+			)
+		).toBeVisible();	
+	});
+
+	test('Store owner should able to set transaction type "Authorization" and capture paid orders - @foundational', async ({
+		browser,
+	}) => {
+		const context = await browser.newContext({
+			...iPhone,
+		});
+		const isBlock = true;
+		const page = await context.newPage();
+
+		// Set authorization transaction type.
+		await saveCashAppPaySettings(page, {
+			transactionType: 'authorization',
+			capturePaidOrders: true,
+		});
+
+		await page.goto('/product/simple-product');
+		await page.locator('.single_add_to_cart_button').click();
+		await visitCheckout(page, isBlock);
+		await fillAddressFields(page, isBlock);
+		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
+		const orderId = await placeCashAppPayOrder(page, isBlock);
+
+		await gotoOrderEditPage(page, orderId);
+		await expect(page.locator('#order_status')).toHaveValue('wc-on-hold');
+		await expect(
+			page.getByText(
+				'Cash App Pay (Square) Test Authorization Approved for an amount of'
+			)
+		).toBeVisible();
+
+		// Update order status to processing.
+		await page.locator('#order_status').selectOption('wc-processing');
+		await page.locator('button.save_order').click();
+
+		// Verify order status.
+		await expect(page.locator('#order_status')).toHaveValue(
+			'wc-processing'
+		);
+		await expect(
+			page.getByText('Cash App Pay (Square) Capture total of')
+		).toBeVisible();
+	});
+});

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -350,6 +350,9 @@ export async function saveCashAppPaySettings(page, options) {
 		debugMode: 'off',
 		buttonTheme: 'dark',
 		buttonShape: 'semiround',
+		transactionType: 'charge',
+		chargeVirtualOrders: false,
+		capturePaidOrders: false,
 		...options,
 	};
 
@@ -371,6 +374,26 @@ export async function saveCashAppPaySettings(page, options) {
 	await page
 		.locator('#woocommerce_square_cash_app_pay_description')
 		.fill(settings.description);
+
+	// Transaction Type
+	await page
+		.locator('#woocommerce_square_cash_app_pay_transaction_type')
+		.selectOption(settings.transactionType);
+	if ( settings.transactionType === 'authorization' ) {
+		const chargeVirtualOrders = await page.locator('#woocommerce_square_cash_app_pay_charge_virtual_orders');
+		const capturePaidOrders = await page.locator('#woocommerce_square_cash_app_pay_enable_paid_capture');
+		if ( settings.chargeVirtualOrders ) {
+			await chargeVirtualOrders.check();
+		} else {
+			await chargeVirtualOrders.uncheck();
+		}
+
+		if ( settings.capturePaidOrders ) {
+			await capturePaidOrders.check();
+		} else {
+			await capturePaidOrders.uncheck();
+		}
+	}
 
 	// Debug Mode and Environment
 	await page

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -309,7 +309,10 @@ export async function gotoOrderEditPage( page, orderId ) {
 export async function doSquareRefund( page, amount = '' ) {
 	await page.locator( '.refund-items' ).click();
 	await page.locator( '.refund_order_item_qty' ).fill( '1' );
-	await page.locator( '#refund_amount' ).fill( '' );
+	if ( await page.locator( '#refund_amount' ).isEditable() ) {
+		await page.locator( '#refund_amount' ).fill( '' );
+	}
+	await page.locator( '.refund_line_total' ).fill('');
 	await page.locator( '.refund_line_total' ).fill( amount );
 	await page.locator( '.do-api-refund' ).click();
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR adds support for the Transaction type for the Cash App Pay payment method. Merchants should now be able to select either "Charge" or "Authorization" as a transaction type based on their requirements and should be able to capture the charge later from the backend.

This PR also fixes the "Capture Charge" button and the "Capture charge" bulk action issue in HPOS. 

![image](https://github.com/woocommerce/woocommerce-square/assets/10613171/1e6798e5-6bdb-4f81-ba71-5d607ab60f90)


Closes #60 

@qasumitbagthariya We need to update the critical flow wiki to cover this transaction type support.

**Note:**
There is one PHPCS error due to the `@since` statement on the filter, which will be set appropriately during the release process so that error can be ignored for now.

### Steps to test the changes in this Pull Request:
The testing process will be similar to Square credit card gateway transaction type.

1. Navigate to WooCommerce > Settings > Payments > Cash App Pay (Square).
1. Select "Authorization" as the Transaction type and save the settings.
1. Place an order with Cash App Pay.
1. Go to Edit order and verify that the order status is "On Hold," and the order notes contain the note `Cash App Pay (Square) Test Authorization Approved for an amount of xx.xx.`
1. Click the "Capture Charge" button and verify that it captures the payment, updating the order status accordingly.
1. Navigate to WooCommerce > Settings > Payments > Cash App Pay (Square).
1. Select "Authorization" as the Transaction type, check "Charge Virtual-Only Orders," and save the settings.
1. Add a virtual product to the cart and place an order with Cash App Pay.
1. Go to Edit order and verify that the order payment is already charged, and the order status is updated accordingly.
1. Navigate to WooCommerce > Settings > Payments > Cash App Pay (Square).
1. Select "Authorization" as the Transaction type, check "Capture Paid Orders," and save the settings.
1. Place an order with Cash App Pay.
1. Go to Edit order, update the order status to "processing" or "Completed," and verify that the charge for the order is captured.

### Changelog entry
> Add - Support for the “Charge” and “Authorization” transaction types in the Cash App Pay payment method.
