### PR TITLE
Fix/66: Fix the repetitive creation of 'wc_square_init_payment_token_migration' actions in the payment token migration process.

### DIFF
--- a/includes/Framework/PaymentGateway/PaymentTokens/Payment_Gateway_Payment_Tokens_Handler.php
+++ b/includes/Framework/PaymentGateway/PaymentTokens/Payment_Gateway_Payment_Tokens_Handler.php
@@ -58,10 +58,8 @@ class Payment_Gateway_Payment_Tokens_Handler {
 
 		$this->environment_id = $gateway->get_environment();
 
-		add_action( 'wc_square_init_payment_token_migration', array( $this, 'register_payment_tokens_migration_scheduler' ) );
 		add_action( 'woocommerce_payment_token_deleted', array( $this, 'remove_token' ), 25, 2 );
 		add_action( 'wc_payment_gateway_' . $gateway->get_id() . '_payment_method_added', array( $this, 'clear_cache_for_new_token' ), 10, 2 );
-		add_action( 'action_scheduler_init', array( $this, 'schedule_token_migration_job' ) );
 		add_filter( 'woocommerce_get_customer_payment_tokens_limit', array( $this, 'increase_query_limit_for_payment_methods' ) );
 	}
 
@@ -73,21 +71,6 @@ class Payment_Gateway_Payment_Tokens_Handler {
 	 */
 	public function clear_cache_for_new_token( $token_id, $user_id ) {
 		$this->clear_transient( $user_id );
-	}
-
-	/**
-	 * Schedules the migration of payment tokens.
-	 *
-	 * @since 3.8.0
-	 */
-	public function schedule_token_migration_job() {
-		if ( false !== get_option( 'wc_square_payment_token_migration_complete' ) ) {
-			return;
-		}
-
-		if ( false === as_has_scheduled_action( 'wc_square_init_payment_token_migration' ) ) {
-			as_enqueue_async_action( 'wc_square_init_payment_token_migration', array( 'page' => 1 ) );
-		}
 	}
 
 	/**
@@ -103,59 +86,6 @@ class Payment_Gateway_Payment_Tokens_Handler {
 	public function increase_query_limit_for_payment_methods() {
 		return 30;
 	}
-
-	/**
-	 * Migrates payment token from user_meta to WC_Payment_Token_CC.
-	 *
-	 * @param integer $page Pagination number.
-	 * @since 3.8.0
-	 */
-	public function register_payment_tokens_migration_scheduler( $page ) {
-		// Get 5 users in a batch.
-		$users = get_users(
-			array(
-				'fields' => array( 'ID' ),
-				'number' => 5,
-				'paged'  => $page,
-			)
-		);
-
-		// If users array is empty, then set status in options to indicate migration is complete.
-		if ( empty( $users ) ) {
-			$this->clear_all_transients();
-			update_option( 'wc_square_payment_token_migration_complete', true );
-			return;
-		}
-
-		// Re-run scheduler for the next page of users.
-		as_enqueue_async_action( 'wc_square_init_payment_token_migration', array( 'page' => $page + 1 ) );
-
-		foreach ( $users as $user ) {
-			$user_payment_tokens = get_user_meta( $user->id, $this->get_user_meta_name(), true );
-
-			if ( ! is_array( $user_payment_tokens ) || empty( $user_payment_tokens ) ) {
-				continue;
-			}
-
-			foreach ( $user_payment_tokens as $token => $user_payment_token_data ) {
-				$payment_token = new Square_Credit_Card_Payment_Token();
-				$payment_token->set_token( $token );
-				$payment_token->set_card_type( $user_payment_token_data['card_type'] );
-				$payment_token->set_last4( $user_payment_token_data['last_four'] );
-				$payment_token->set_expiry_month( $user_payment_token_data['exp_month'] );
-				$payment_token->set_expiry_year( $user_payment_token_data['exp_year'] );
-				$payment_token->set_user_id( $user->id );
-				$payment_token->set_gateway_id( wc_square()->get_gateway()->get_id() );
-
-				if ( isset( $user_payment_token_data['nickname'] ) ) {
-					$payment_token->set_nickname( $user_payment_token_data['nickname'] );
-				}
-
-				$payment_token->save();
-			}
-		}
-	}
-
 
 	/**
 	 * A factory method to build and return a payment token object for the

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -415,6 +415,15 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 		return array();
 	}
 
+	/**
+	 * Initialize payment tokens handler.
+	 *
+	 * @since x.x.x
+	 */
+	protected function init_payment_tokens_handler() {
+		// No payment tokens for Cash App Pay, do nothing.
+	}
+
 
 	/**
 	 * Gets a user's stored customer ID.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -983,6 +983,11 @@ class Plugin extends Payment_Gateway_Plugin {
 			}
 
 			foreach ( $user_payment_tokens as $token => $user_payment_token_data ) {
+				// Check if token already exists in WC_Payment_Token_CC.
+				if ( $payment_tokens_handler->user_has_token( $user->id, $token ) ) {
+					continue;
+				}
+
 				$payment_token = new Square_Credit_Card_Payment_Token();
 				$payment_token->set_token( $token );
 				$payment_token->set_card_type( $user_payment_token_data['card_type'] );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -930,10 +930,9 @@ class Plugin extends Payment_Gateway_Plugin {
 		}
 
 		// Remove all OLD scheduled actions to cleanup DB.
-		// TODO: Remove this in next release. 
+		// TODO: Remove this in next release.
 		global $wpdb;
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = 'wc_square_init_payment_token_migration'" );
-
 
 		if ( false === as_has_scheduled_action( 'wc_square_init_payment_token_migration_v2' ) ) {
 			as_enqueue_async_action( 'wc_square_init_payment_token_migration_v2', array( 'page' => 1 ) );
@@ -953,15 +952,15 @@ class Plugin extends Payment_Gateway_Plugin {
 		// Get 5 users in a batch.
 		$users = get_users(
 			array(
-				'fields' => array( 'ID' ),
-				'number' => 5,
-				'paged'  => $page,
-				'meta_query' => array(
+				'fields'     => array( 'ID' ),
+				'number'     => 5,
+				'paged'      => $page,
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					array(
 						'key'     => $meta_key,
 						'compare' => 'EXISTS',
 					),
-				)
+				),
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR fixes the repetitive creation of 'wc_square_init_payment_token_migration' scheduled actions, which is used for migrating payment tokens from user_meta to WC_Payment_Token_CC.

**Root cause:**
Currently, the payment token migration function processes users in batches (5 users per batch) and schedules a new action to process the next batch of users until no pending users remain. This migration action hook was added in the payment tokens handler class. In the 4.5.0 release, we added a new payment gateway. With the addition of the new gateway, the payment tokens handler class gets registered twice, and the migration function is called twice for a single scheduled action. This results in registering too many actions if the site has a good number of users.

**Note:** This issue only affects the sites that upgrade the plugin from version <3.7.1 to 4.5.0 and the fresh installations.

The PR resolves the issue by relocating the migration function to the Plugin class. In addition to moving the action hook and migration function, the PR also cleans up the existing scheduled actions for migrations to tidy up the database and the processing. It updates the action name by appending `_v2` to prevent any conflicts. Also, updates get users query to get users with tokens only.

Closes #66 

### Steps to test the changes in this Pull Request:
1. Checkout to the `trunk` branch.
1. Make sure the site has enough number of users (30-40 will be fine) to reproduce the issue.
1. Go to the options table and remove option `wc_square_payment_token_migration_complete` from db. It will help to initiate the migration process. OR create a completely new site setup and install the Square plugin.
1. Go to `Tools` > `Scheduled Actions`, Refresh it 2-3 times
1. Notice there is multiple actions are created with the `wc_square_init_payment_token_migration` action hook with the same arguments `'page' => x`
1. Checkout to the `fix/66` branch.
1. Go to `Tools` > `Scheduled Actions`
1. Verify that created actions are cleared and payment token is migrated successfully for all users.
1. You can remove the `wc_square_payment_token_migration_complete` option again to initiate the migration process for the beginning and verify there are no multiple actions created with the fix branch.

### Changelog entry
> Fix - Address the repetitive creation of `wc_square_init_payment_token_migration` actions in the payment token migration process.
