### PR TITLE
fix/93: fixes issue with connection warning

### DIFF
--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -1186,11 +1186,14 @@ class Gateway extends Payment_Gateway_Direct {
 	 * @return array
 	 */
 	public function filter_available_gateways( $gateways ) {
-		$location_id = $this->get_plugin()->get_settings_handler()->get_location_id();
+		$location_id  = $this->get_plugin()->get_settings_handler()->get_location_id();
+		$is_connected = $this->get_plugin()->get_settings_handler()->is_connected();
 
-		foreach ( $this->get_plugin()->get_settings_handler()->get_locations() as $location ) {
-			if ( $location_id === $location->getId() && get_woocommerce_currency() !== $location->getCurrency() ) {
-				unset( $gateways[ Plugin::GATEWAY_ID ] );
+		if ( $is_connected ) {
+			foreach ( $this->get_plugin()->get_settings_handler()->get_locations() as $location ) {
+				if ( $location_id === $location->getId() && get_woocommerce_currency() !== $location->getCurrency() ) {
+					unset( $gateways[ Plugin::GATEWAY_ID ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a check to see if the site is connected to Square before fetching locations.

Closes #93 

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. On `trunk`, disconnect from Square.
2. Delete the `wc_square_refresh_failed` option if it exists.
3. Reconnect to production and observe the warning exists.
4. Switch to the `fix/93` branch.
5. Disconnect and repeat step (2).
6. Connect to production and observe the warning is no longer visible.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Problem with connection to Square warning.
