### PR TITLE
update contributors listing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WooCommerce Square ===
-Contributors: woocommerce, automattic, royho, woothemes, bor0, mattdallan, menakas, chickenn00dle, jorgeatorres, jamesgallan, achyuthajoy
+Contributors: woocommerce, automattic
 Tags: credit card, square, woocommerce, inventory sync
 Requires at least: 6.3
 Tested up to: 6.5


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR trims the list of Contributors to WooCommerce and Automattic.  The rationale here, in discussing with @beaulebens, was to limit those who are [exposed on the WP.org plugin page](https://wordpress.org/plugins/woocommerce-square/) and potentially hassled for issues in GitHub or support requests on WP.org.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Preview the readme.txt file on the [readme validator](https://wordpress.org/plugins/developers/readme-validator/)
1. See that only Woo and A8C are listed as Contributors

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Tweak - Update contributors.

Note that I put the `changelog:none` label on this PR as this is something that can probably be skipped in the changelog / release notes.