### PR TITLE
Fix fatal error when running incompatible version of WooCommerce.

### DIFF
--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -345,11 +345,13 @@ class WooCommerce_Square_Loader {
 	 * @return bool
 	 */
 	public function is_environment_compatible() {
+		$is_wc_compatible        = $this->is_wc_compatible();
+		$is_wp_compatible        = $this->is_wp_compatible();
 		$is_php_valid            = $this->is_php_version_valid();
 		$is_opcache_config_valid = $this->is_opcache_save_message_enabled();
 		$error_message           = '';
 
-		if ( ! $is_php_valid || ! $is_opcache_config_valid ) {
+		if ( ! $is_php_valid || ! $is_opcache_config_valid || ! $is_wc_compatible || ! $is_wp_compatible ) {
 			$error_message .= sprintf(
 				// translators: plugin name
 				__( '<strong>All features in %1$s have been disabled</strong> due to unsupported settings:<br>', 'woocommerce-square' ),
@@ -374,6 +376,38 @@ class WooCommerce_Square_Loader {
 			);
 		}
 
+		if ( ! $is_wc_compatible ) {
+			if ( ! defined( 'WC_VERSION' ) ) {
+				$error_message .= sprintf(
+					// translators: 1: Minimum required WooCommerce version.
+					__( '&bull;&nbsp;<strong>WooCommerce is not installed: </strong>The plugin requires WooCommerce version %1$s or later be installed.<br>', 'woocommerce-square' ),
+					self::MINIMUM_WC_VERSION
+				);
+			} else {
+				$error_message .= sprintf(
+					// translators: 1: Plugin name, 2: Minimum required WooCommerce version, 3: Opening link to upgrade screen, 4: Closing link, 5: Opening link to download page, 6: Closing link.
+					'&bull;&nbsp;%1$s requires WooCommerce version %2$s or higher. Please %3$supdate WooCommerce%4$s to the latest version, or %5$sdownload the minimum required version &raquo;%6$s<br>',
+					'<strong>' . self::PLUGIN_NAME . '</strong>',
+					self::MINIMUM_WC_VERSION,
+					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
+					'</a>',
+					'<a href="' . esc_url( 'https://downloads.wordpress.org/plugin/woocommerce.' . self::MINIMUM_WC_VERSION . '.zip' ) . '">',
+					'</a>'
+				);
+			}
+		}
+
+		if ( ! $is_wp_compatible ) {
+			$error_message .= sprintf(
+				// translators: 1: Plugin name, 2: Minimum required WordPress version, 3: Opening link to upgrade screen, 4: Closing link.
+				'&bull;&nbsp;%s requires WordPress version %s or higher. Please %supdate WordPress &raquo;%s<br>',
+				'<strong>' . self::PLUGIN_NAME . '</strong>',
+				self::MINIMUM_WP_VERSION,
+				'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
+				'</a>'
+			);
+		}
+
 		if ( ! empty( $error_message ) ) {
 			$this->add_admin_notice(
 				'bad_environment',
@@ -382,7 +416,7 @@ class WooCommerce_Square_Loader {
 			);
 		}
 
-		return $is_php_valid && $is_opcache_config_valid;
+		return $is_php_valid && $is_opcache_config_valid && $is_wc_compatible && $is_wp_compatible;
 	}
 
 	/**

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -81,12 +81,12 @@ class WooCommerce_Square_Loader {
 	 */
 	protected function __construct() {
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
+		add_action( 'before_woocommerce_init', array( $this, 'declare_hpos_compatibility' ) );
 
 		// if the environment check fails, don't initialize the plugin.
 		if ( $this->is_environment_compatible() ) {
 			add_action( 'plugins_loaded', array( $this, 'init_plugin' ) );
 			add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_block_integrations' ), 5, 1 );
-			add_action( 'before_woocommerce_init', array( $this, 'declare_hpos_compatibility' ) );
 		}
 	}
 

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -80,7 +80,6 @@ class WooCommerce_Square_Loader {
 	 * @since 2.0.0
 	 */
 	protected function __construct() {
-		add_action( 'admin_init', array( $this, 'add_plugin_notices' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
 
 		// if the environment check fails, don't initialize the plugin.
@@ -182,41 +181,11 @@ class WooCommerce_Square_Loader {
 	 * Adds notices for out-of-date WordPress and/or WooCommerce versions.
 	 *
 	 * @since 2.0.0
+	 * @deprecated x.x.x Use \WooCommerce_Square_Loader::is_environment_compatible() instead.
 	 */
 	public function add_plugin_notices() {
-
-		if ( ! $this->is_wp_compatible() ) {
-
-			$this->add_admin_notice(
-				'update_wordpress',
-				'error',
-				sprintf(
-					'%s requires WordPress version %s or higher. Please %supdate WordPress &raquo;%s',
-					'<strong>' . self::PLUGIN_NAME .
-					'</strong>',
-					self::MINIMUM_WP_VERSION,
-					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
-					'</a>'
-				)
-			);
-		}
-
-		if ( ! $this->is_wc_compatible() ) {
-
-			$this->add_admin_notice(
-				'update_woocommerce',
-				'error',
-				sprintf(
-					'%1$s requires WooCommerce version %2$s or higher. Please %3$supdate WooCommerce%4$s to the latest version, or %5$sdownload the minimum required version &raquo;%6$s',
-					'<strong>' . self::PLUGIN_NAME . '</strong>',
-					self::MINIMUM_WC_VERSION,
-					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
-					'</a>',
-					'<a href="' . esc_url( 'https://downloads.wordpress.org/plugin/woocommerce.' . self::MINIMUM_WC_VERSION . '.zip' ) . '">',
-					'</a>'
-				)
-			);
-		}
+		_deprecated_function( __METHOD__, 'x.x.x', '\WooCommerce_Square_Loader::is_environment_compatible()' );
+		$this->is_environment_compatible();
 	}
 
 
@@ -224,12 +193,13 @@ class WooCommerce_Square_Loader {
 	 * Determines if the required plugins are compatible.
 	 *
 	 * @since 2.0.0
+	 * @deprecated x.x.x Use \WooCommerce_Square_Loader::is_environment_compatible() instead.
 	 *
 	 * @return bool
 	 */
 	protected function plugins_compatible() {
-
-		return $this->is_wp_compatible() && $this->is_wc_compatible();
+		_deprecated_function( __METHOD__, 'x.x.x', '\WooCommerce_Square_Loader::is_environment_compatible()' );
+		return $this->is_environment_compatible();
 	}
 
 

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -82,12 +82,13 @@ class WooCommerce_Square_Loader {
 	protected function __construct() {
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
 		add_action( 'before_woocommerce_init', array( $this, 'declare_hpos_compatibility' ) );
-
-		// if the environment check fails, don't initialize the plugin.
-		if ( $this->is_environment_compatible() ) {
-			add_action( 'plugins_loaded', array( $this, 'init_plugin' ) );
-			add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_block_integrations' ), 5, 1 );
-		}
+		/*
+		 * Bootstrap the extension on plugins_loaded.
+		 *
+		 * This ensures that the extension is loaded after WooCommerce Core and to
+		 * ensure the WC_VERSION constant is defined prior to checking for compatibility.
+		 */
+		add_action( 'plugins_loaded', array( $this, 'init_plugin' ) );
 	}
 
 
@@ -138,6 +139,8 @@ class WooCommerce_Square_Loader {
 
 		// fire it up!
 		wc_square();
+
+		add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_block_integrations' ), 5, 1 );
 	}
 
 

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -364,7 +364,7 @@ class WooCommerce_Square_Loader {
 					self::MINIMUM_WC_VERSION,
 					'<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">',
 					'</a>',
-					'<a href="' . esc_url( 'https://downloads.wordpress.org/plugin/woocommerce.' . self::MINIMUM_WC_VERSION . '.zip' ) . '">',
+					'<a href="' . esc_url( $this->get_woocommerce_download_link( 'minimum' ) ) . '">',
 					'</a>'
 				);
 			}
@@ -390,6 +390,55 @@ class WooCommerce_Square_Loader {
 		}
 
 		return $is_php_valid && $is_opcache_config_valid && $is_wc_compatible && $is_wp_compatible;
+	}
+
+	/**
+	 * Get the WooCommerce download link for a specific version.
+	 *
+	 * Ensures the download link is correct for major versions of WooCommerce by
+	 * ensuring that specific download links match the tagged version and include
+	 * three parts in the version number.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string|int|float $version The version of WooCommerce to get the download link for.
+	 *                                  Accepts a version number in the forms of 'x', 'x.x' or 'x.x.x'.
+	 *                                  Accepts the strings 'minimum' and 'latest'.
+	 *                                  Defaults to 'latest'.
+	 * @return string The download link for the WooCommerce version.
+	 */
+	public function get_woocommerce_download_link( $version = 'latest' ) {
+		$version = (string) $version;
+		$version = strtolower( $version );
+
+		if ( preg_match( '/^(\d+\.)*(\d+)$/', $version ) || 'minimum' === $version ) {
+			if ( 'minimum' === $version ) {
+				$version_download_string = self::MINIMUM_WC_VERSION;
+			} else {
+				$version_download_string = $version;
+			}
+			$version_parts = explode( '.', $version_download_string );
+			/*
+			 * Ensure the version string has at least 3 parts.
+			 *
+			 * Publicly major versions are listed as two parts, eg 6.7, but the
+			 * tag published to the WordPress.org repository uses three parts,
+			 * eg 6.7.0.
+			 *
+			 * This is to ensure the download link is correct.
+			 */
+			$version_part_count = count( $version_parts ); // Coding standards don't allow for count() in the while condition.
+			while ( $version_part_count < 3 ) {
+				$version_parts[]    = '0';
+				$version_part_count = count( $version_parts );
+			}
+			$version_download_string = implode( '.', $version_parts );
+		} else {
+			// Default to latest version.
+			$version_download_string = 'latest-stable';
+		}
+
+		return "https://downloads.wordpress.org/plugin/woocommerce.{$version_download_string}.zip";
 	}
 
 	/**

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -122,7 +122,7 @@ class WooCommerce_Square_Loader {
 	 */
 	public function init_plugin() {
 
-		if ( ! $this->plugins_compatible() ) {
+		if ( ! $this->is_environment_compatible() ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Modify the bootstrapping of the plugin to include compatibility checks for:
* PHP Version (existing)
* OPcache config (existing)
* WooCommerce version (new/expanded)
* WordPress version (new/expanded)

`WooCommerce_Square_Loader::add_plugin_notices()` and `WooCommerce_Square_Loader::plugins_compatible()` are deprecated in favour of the `WooCommerce_Square_Loader::is_environment_compatible()` method. This ensures that all paths for bootstrapping the extension are using the same checks.

The HPOS compatibility declaration is modified to bypass the environment check to avoid false incompatibility warnings on old versions of WooCommerce. While not related to the fatal error it is related to the various warnings not working as expected.

TODO:

* [ ] Update all instances of version `x.x.x` with the version number this is to be released in. 

Closes #135 .

### Steps to test the changes in this Pull Request:

1. Install the latest version of WordPress
2. Install and activate WooCommerce 8.6.1
3. Install and activate WooCommerce Square from this branch
4. A notice should be displayed warning the extension is disabled (on trunk a fatal error is triggered). The notice will indicate WooCommerce requires an upgrade.
5. Downgrade WordPress to 6.2.4 ([zip download here](https://github.com/WordPress/WordPress/archive/refs/tags/6.2.5.zip))
6. Reload the WP Dashboard
7. The notice should indicate both WordPress and WooCommerce require an upgrade


### Changelog entry
> Fix - A fatal error could occur when running incompatible versions of WooCommerce.
