### PR TITLE
Unblock checkout form following unsuccessful express payment attempt.

### DIFF
--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -20,7 +20,7 @@ const ButtonComponent = () => {
 	const [googlePayBtn, setGooglePayBtn] = useState(null);
 	const [applePayBtn, setApplePayBtn] = useState(null);
 	const [clickedButton, setClickedButton] = useState(null);
-	const { billing, onClick, onSubmit, eventRegistration, paymentStatus } =
+	const { billing, onClick, onSubmit, onClose, eventRegistration, paymentStatus } =
 		props;
 	const { onPaymentSetup } = eventRegistration;
 	const googlePaybuttonRef = useRef();
@@ -85,9 +85,16 @@ const ButtonComponent = () => {
 		}
 
 		const verificationDetails = buildVerificationDetails(billing);
-		const unsubscribe = onPaymentSetup(() =>
-			initiateCheckout(payments, verificationDetails, clickedButton)
-		);
+		const unsubscribe = onPaymentSetup(() => {
+			const checkout = initiateCheckout(payments, verificationDetails, clickedButton)
+			checkout.then((response) => {
+				if ( response.type === 'failure' ) {
+					setClickedButton(null);
+					onClose();
+				}
+			});
+			return checkout;
+		} );
 		return unsubscribe;
 	}, [googlePayBtn, applePayBtn, onPaymentSetup, paymentStatus.isStarted]);
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WIP

* [x] Unblock form
* [ ] ~Prevent validation errors from displaying~ _To be actioned in a follow up ticket, see https://github.com/woocommerce/woocommerce-square/issues/133#issuecomment-2145484610_

Closes #133 .

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Test the checkout process in Google Chrome while logged in to a Google Account with Google Pay configured. This will give you access to the test credit cards
2. Configure Square in test mode, ensuring you check the option to `Enable digital wallets`
3. Configure your cart and checkout pages to use blocks
4. Create and publish a simple product
5. In Chrome, add the product to the cart
6. Go the the cart (blocks) page
7. Click the Google Pay button
8. Once Google Pay has loaded, click the `x` icon to cancel the transaction
9. Ensure the buttons for Google Pay and Proceed to Checkout are enabled
10. Go to the checkout (blocks) page
11. Click the Google Pay button
12. Once Google Pay has loaded, click the `x` icon to cancel the transaction
13. Note: Ignore any validation errors that appear following the above step. This is the issue to be targeted in a follow up ticket
14. Ensure the buttons for Google Pay and Place Order are enabled
15. Fill in the checkout form with name, address and a [sample credit card](https://developer.squareup.com/docs/devtools/sandbox/payments#card-not-present-success-state-values)
16. Click the place order button, you should then be presented with the order received page


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent cancelling Digital Wallet payments from blocking the Checkout form.
