### PR TITLE
Minor fix for Close button in Onboarding Wizard

### DIFF
--- a/assets/new-user-experience/components/onboarding-header/index.js
+++ b/assets/new-user-experience/components/onboarding-header/index.js
@@ -14,7 +14,7 @@ import { useSteps } from './../../onboarding/hooks';
 import { queueRecordEvent, ONBOARDING_TRACK_EVENTS } from '../../../tracks';
 
 export const OnboardingHeader = () => {
-	const { setStep, getBackStep } = useSteps();
+	const { stepData, setStep, getBackStep } = useSteps();
 
 	const backStep = getBackStep();
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?


### Steps to test the changes in this Pull Request:

* The close button in the onboarding wizard should be working and redirecting to the dashboard page.

### Changelog entry
> Fix - Close button in Onboarding Wizard not working
