### PR TITLE
Exclude the `@since` existence check sniff rule

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -51,4 +51,9 @@
 	<rule ref="PHPCompatibilityWP">
 		<exclude name="PHPCompatibilityWP"/>
 	</rule>
+
+	<rule ref="WooCommerce.Commenting">
+		<!-- It wants @since to contain defined version and does not allow just x.x.x -->
+		<exclude name="WooCommerce.Commenting.CommentHooks.MissingSinceVersionComment"/>
+	</rule>	
 </ruleset>


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR excludes the `@since` existence check sniff to avoid errors when x.x.x is set.

Closes #159.

See the reproduction steps in the linked Issue.

### Changelog entry

> Dev - Exclude the Woo Comment Hook `@since` sniff.