### PR TITLE
Bump WordPress Tested up to version 6.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: credit card, square, woocommerce, inventory sync
 Requires at least: 6.4
-Tested up to: 6.5
+Tested up to: 6.6
 Requires PHP: 7.4
 Stable tag: 4.7.0
 License: GPL-3.0-or-later

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -5,7 +5,7 @@
  * Version: 4.7.0
  * Plugin URI: https://woocommerce.com/products/square/
  * Requires at least: 6.4
- * Tested up to: 6.5
+ * Tested up to: 6.6
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
  *


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Bump WordPress Tested up to version 6.5 to 6.6


Closes #164 

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR.
2. All tests should be passed.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WordPress "tested up to" version 6.6.
