### PR TITLE
Ensure the "Uncaught TypeError" JavaScript console error does not occur for out-of-stock products.

### DIFF
--- a/assets/js/frontend/wc-square-digital-wallet.js
+++ b/assets/js/frontend/wc-square-digital-wallet.js
@@ -25,7 +25,7 @@ jQuery( document ).ready( ( $ ) => {
 
 			this.args = args;
 			this.payment_request = args.payment_request;
-			this.total_amount = args.payment_request.total.amount;
+			this.total_amount = args.payment_request.total?.amount;
 			this.isPayForOrderPage = args.is_pay_for_order_page;
 			this.orderId = args.order_id;
 			this.id_dasherized = args.gateway_id_dasherized;
@@ -60,7 +60,7 @@ jQuery( document ).ready( ( $ ) => {
 			this.get_payment_request().then(
 				( response ) => {
 					this.payment_request = JSON.parse( response );
-					this.total_amount = this.payment_request.total.amount;
+					this.total_amount = this.payment_request.total?.amount;
 					this.load_square_form();
 				},
 				( message ) => {
@@ -693,7 +693,7 @@ jQuery( document ).ready( ( $ ) => {
 			return new Promise( ( resolve, reject ) => {
 				return $.post( this.get_ajax_url( 'recalculate_totals' ), data, ( response ) => {
 					if ( response.success ) {
-						this.total_amount = response.data.total.amount;
+						this.total_amount = response.data.total?.amount;
 						return resolve( response.data );
 					}
 					return reject( response.data );


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR makes minor changes to fix the "Uncaught TypeError" reported in issue #136. The error occurred because the JS code was trying to access the amount property of an undefined object.

> [!NOTE]
> A customer also reported an issue with the product image, but this issue is not reproducible by me or the reporter. It seems to be related to a specific theme only. Therefore, this PR fixes the "Uncaught TypeError" as the root issue to resolve.

Closes #136 

### Steps to test the changes in this Pull Request:
1. Enable digital wallets in your Square settings.
2. Set a product to be out of stock.
3. Visit the shop or product page.
4. Verify there is no console error as reported in #136

### Changelog entry
> Fix - Ensure the "Uncaught TypeError" JavaScript console error does not occur for out-of-stock products.
