### PR TITLE
Ensure the product category syncs properly between the Square and WooCommerce store

### DIFF
--- a/includes/Handlers/Category.php
+++ b/includes/Handlers/Category.php
@@ -239,23 +239,23 @@ class Category {
 	 * @return string|null
 	 */
 	public static function get_square_category_id( $catalog_item ) {
-		$catelog_category_id = null;
+		$catalog_category_id = null;
 		// Try to get the category from the reporting category first.
-		$catelog_category = $catalog_item->getReportingCategory();
+		$catalog_category = $catalog_item->getReportingCategory();
 
 		// If no reporting category, try to get the first category from the categories list.
-		if ( empty( $catelog_category ) ) {
-			$catelog_categories = $catalog_item->getCategories();
-			if ( ! empty( $catelog_categories ) ) {
-				$catelog_category = $catelog_categories[0];
+		if ( empty( $catalog_category ) ) {
+			$catalog_categories = $catalog_item->getCategories();
+			if ( ! empty( $catalog_categories ) ) {
+				$catalog_category = $catalog_categories[0];
 			}
 		}
 
 		// If we have a category, get the ID.
-		if ( ! empty( $catelog_category ) ) {
-			$catelog_category_id = $catelog_category->getId();
+		if ( ! empty( $catalog_category ) ) {
+			$catalog_category_id = $catalog_category->getId();
 		}
 
-		return $catelog_category_id;
+		return $catalog_category_id;
 	}
 }

--- a/includes/Handlers/Category.php
+++ b/includes/Handlers/Category.php
@@ -231,4 +231,31 @@ class Category {
 			)
 		);
 	}
+
+	/**
+	 * Get category ID from ITEM catalog object.
+	 *
+	 * @param \Square\Models\CatalogItem $catalog_item the catalog item object
+	 * @return string|null
+	 */
+	public static function get_square_category_id( $catalog_item ) {
+		$catelog_category_id = null;
+		// Try to get the category from the reporting category first.
+		$catelog_category = $catalog_item->getReportingCategory();
+
+		// If no reporting category, try to get the first category from the categories list.
+		if ( empty( $catelog_category ) ) {
+			$catelog_categories = $catalog_item->getCategories();
+			if ( ! empty( $catelog_categories ) ) {
+				$catelog_category = $catelog_categories[0];
+			}
+		}
+
+		// If we have a category, get the ID.
+		if ( ! empty( $catelog_category ) ) {
+			$catelog_category_id = $catelog_category->getId();
+		}
+
+		return $catelog_category_id;
+	}
 }

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -248,7 +248,8 @@ class Product {
 			$product->set_description( $product_description );
 		}
 
-		$category_id = Category::get_category_id_by_square_id( $catalog_item->getCategoryId() );
+		$square_category_id = Category::get_square_category_id( $catalog_item );
+		$category_id        = Category::get_category_id_by_square_id( $square_category_id );
 
 		if ( $category_id ) {
 			wp_set_object_terms( $product->get_id(), intval( $category_id ), 'product_cat' );
@@ -256,7 +257,7 @@ class Product {
 			$message = sprintf(
 				/* translators: Placeholder: %s category ID */
 				__( 'Square category with id (%s) was not imported to your Store. Please run Import Products from Square settings.', 'woocommerce-square' ),
-				$catalog_item->getCategoryId()
+				$square_category_id
 			);
 
 			$records = Records::get_records();

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -74,7 +74,11 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 
 		// if a category with a Square ID was found
 		if ( $square_category_id ) {
-			$item_data->setCategoryId( $square_category_id );
+			$square_category = new \Square\Models\CatalogObjectCategory();
+			$square_category->setId( $square_category_id );
+			$item_data->setCategories( array( $square_category ) );
+			// Set the reporting category.
+			$item_data->setReportingCategory( $square_category );
 		}
 
 		$catalog_variations = $item_data->getVariations() ?: array();

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -161,7 +161,7 @@ class Product_Import extends Stepped_Job {
 			}
 
 			// import or update categories related to the products that are being imported
-			$catelog_category_id = $catalog_object->getItemData()->getCategoryId();
+			$catelog_category_id = Category::get_square_category_id( $catalog_object->getItemData() );
 
 			if ( $catelog_category_id && isset( $categories[ $catelog_category_id ] ) ) {
 				Category::import_or_update( $categories[ $catelog_category_id ] );
@@ -532,7 +532,8 @@ class Product_Import extends Stepped_Job {
 			return null;
 		}
 
-		$category_id = Category::get_category_id_by_square_id( $catalog_object->getItemData()->getCategoryId() );
+		$square_category_id = Category::get_square_category_id( $catalog_object->getItemData() );
+		$category_id        = Category::get_category_id_by_square_id( $square_category_id );
 
 		$data = array(
 			'title'       => $catalog_object->getItemData()->getName(),

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -161,11 +161,11 @@ class Product_Import extends Stepped_Job {
 			}
 
 			// import or update categories related to the products that are being imported
-			$catelog_category_id = Category::get_square_category_id( $catalog_object->getItemData() );
+			$catalog_category_id = Category::get_square_category_id( $catalog_object->getItemData() );
 
-			if ( $catelog_category_id && isset( $categories[ $catelog_category_id ] ) ) {
-				Category::import_or_update( $categories[ $catelog_category_id ] );
-				unset( $categories[ $catelog_category_id ] ); // don't import/update the same category multiple times per batch
+			if ( $catalog_category_id && isset( $categories[ $catalog_category_id ] ) ) {
+				Category::import_or_update( $categories[ $catalog_category_id ] );
+				unset( $categories[ $catalog_category_id ] ); // don't import/update the same category multiple times per batch
 			}
 
 			$data = $this->extract_product_data( $catalog_object, $product );

--- a/tests/e2e/specs/c4.product-import.spec.js
+++ b/tests/e2e/specs/c4.product-import.spec.js
@@ -12,7 +12,8 @@ import {
 	createCatalogObject,
 	updateCatalogItemInventory,
 	importProducts,
-	clearSync
+	clearSync,
+	createCategory,
 } from '../utils/square-sandbox';
 
 let itemId = 0;
@@ -23,7 +24,9 @@ test.beforeAll( 'Setup', async () => {
 
 	await deleteAllProducts( page );
 	await deleteAllCatalogItems();
-	const response = await createCatalogObject( 'Cap', 'cap', 1350, 'This is a very good cap, no cap.' );
+	const categoryResponse = await createCategory('Hats');
+	const categoryId = categoryResponse.catalog_object?.id || '';
+	const response = await createCatalogObject( 'Cap', 'cap', 1350, 'This is a very good cap, no cap.', categoryId );
 	itemId = response.catalog_object.item_data.variations[0].id;
 
 	await updateCatalogItemInventory( itemId, '53' );
@@ -67,6 +70,7 @@ test( 'Import Cap from Square', async ( { page, baseURL } ) => {
 	await expect( await page.locator( '.entry-summary .sku_wrapper' ) ).toHaveText( 'SKU: cap-regular' );
 	await expect( await page.getByText( 'This is a very good cap, no cap.' ) ).toBeVisible();
 	await expect( await page.getByText( '53 in stock' ) ).toBeVisible();
+	await expect( await page.getByText( 'Category: Hats' ) ).toBeVisible();
 } );
 
 test('Sync Inventory stock from Square on the product edit screen - (SOR Square)', async ({

--- a/tests/e2e/specs/c5.product-import-and-update.spec.js
+++ b/tests/e2e/specs/c5.product-import-and-update.spec.js
@@ -14,6 +14,7 @@ import {
 } from '../utils/square-sandbox';
 
 let createdCatalogObject = {};
+const squareVersion = '2024-03-20';
 
 test.beforeAll( 'Setup', async () => {
 	const browser = await chromium.launch();
@@ -44,7 +45,7 @@ test( 'Import Scarf from Square and Update', async ( { page, baseURL } ) => {
 	const url = 'https://connect.squareupsandbox.com/v2/catalog/object';
 	const method = 'POST';
 	const headers = {
-		'Square-Version': '2023-09-25',
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
 		'Content-Type': 'application/json'
 	};

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -60,11 +60,22 @@ export async function visitCheckout( page, isBlock = true ) {
  * @param {Boolean} save Indicates if the product should be published.
  */
 export async function createProduct( page, product, save = true ) {
-	await page.goto( '/wp-admin/post-new.php?post_type=product' );
+	let url = '/wp-admin/post-new.php?post_type=product';
+	if (product.content) {
+		url += '&content=' + encodeURIComponent(product.content);
+	}
+	await page.goto( url );
 	await page.locator( '#title' ).fill( product.name );
 	await page.locator( '#_regular_price' ).fill( product.regularPrice );
 	await page.locator( '.inventory_options' ).click();
 	await page.locator( '#_sku' ).fill( product.sku );
+
+	if (product.category) {
+		await page.locator('#product_cat-add-toggle').click();
+		await page.locator('#newproduct_cat').fill(product.category);
+		await page.locator('#product_cat-add-submit').click();
+		await page.waitForTimeout(2000);
+	}
 
 	if ( save ) {
 		await page.waitForTimeout( 2000 );

--- a/tests/e2e/utils/square-sandbox.js
+++ b/tests/e2e/utils/square-sandbox.js
@@ -153,7 +153,7 @@ export function extractCatalogInfo( catalogObject = {} ) {
  * @param {String} price Price of the variation.
  * @returns {Object}
  */
-export async function createCatalogObject( name, sku, price, description = '' ) {
+export async function createCatalogObject( name, sku, price, description = '', categoryId = '' ) {
 	const url = 'https://connect.squareupsandbox.com/v2/catalog/object';
 	const method = 'POST';
 	const headers = {
@@ -189,10 +189,51 @@ export async function createCatalogObject( name, sku, price, description = '' ) 
 		}
 	};
 
+	if (categoryId) {
+		data.object.item_data.categories = [{ id: categoryId }];
+		data.object.item_data.reporting_category = { id: categoryId };
+	}
+
 	const response = await fetch(url, {
 		method: method,
 		headers: headers,
 		body: JSON.stringify(data)
+	});
+
+	return await response.json();
+}
+
+/**
+ * Create a Category to be used in the catalog.
+ *
+ * @param {String} name Name of the category.
+ * @returns {Object}
+ */
+export async function createCategory(name) {
+	const url = 'https://connect.squareupsandbox.com/v2/catalog/object';
+	const method = 'POST';
+	const headers = {
+		'Square-Version': squareVersion,
+		Authorization: `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
+		'Content-Type': 'application/json',
+	};
+
+	const data = {
+		idempotency_key: uuidv4(),
+		object: {
+			type: 'CATEGORY',
+			category_data: {
+				name,
+			},
+			id: `#${name}Category`,
+			present_at_all_locations: true,
+		},
+	};
+
+	const response = await fetch(url, {
+		method,
+		headers,
+		body: JSON.stringify(data),
 	});
 
 	return await response.json();

--- a/tests/e2e/utils/square-sandbox.js
+++ b/tests/e2e/utils/square-sandbox.js
@@ -1,6 +1,8 @@
 import fetch from 'node-fetch';
 import { v4 as uuidv4 } from 'uuid';
 
+const squareVersion = '2024-03-20';
+
 /**
  * Returns an object that contains an array of catalog objects.
  *
@@ -9,7 +11,7 @@ import { v4 as uuidv4 } from 'uuid';
 export async function listCatalog() {
 	const url = 'https://connect.squareupsandbox.com/v2/catalog/list?types=ITEM';
 	const headers = {
-		'Square-Version': '2023-09-25',
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
 		'Content-Type': 'application/json'
 	};
@@ -17,6 +19,27 @@ export async function listCatalog() {
 	const response = await fetch( url, {
 		method: 'GET',
 		headers: headers
+	} );
+
+	return await response.json();
+}
+
+/**
+ * Returns an object that contains an array of category objects.
+ *
+ * @returns {Object} Response object.
+ */
+export async function listCategories() {
+	const url = 'https://connect.squareupsandbox.com/v2/catalog/list?types=CATEGORY';
+	const headers = {
+		'Square-Version': squareVersion,
+		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
+		'Content-Type': 'application/json',
+	};
+
+	const response = await fetch( url, {
+		method: 'GET',
+		headers,
 	} );
 
 	return await response.json();
@@ -31,7 +54,7 @@ export async function listCatalog() {
 export async function batchDeleteCatalogItem( ids = [] ) {
 	const url = `https://connect.squareupsandbox.com/v2/catalog/batch-delete`;
 	const headers = {
-		'Square-Version': '2023-09-25',
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
 		'Content-Type': 'application/json'
 	};
@@ -75,7 +98,7 @@ export async function deleteAllCatalogItems() {
 export async function retrieveInventoryCount( variationId ) {
 	const url = `https://connect.squareupsandbox.com/v2/inventory/${variationId}?location_ids=${process.env.SQUARE_LOCATION_ID}`;
 	const headers = {
-		'Square-Version': '2023-09-25',
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
 		'Content-Type': 'application/json'
 	};
@@ -97,6 +120,15 @@ export async function retrieveInventoryCount( variationId ) {
 export function extractCatalogInfo( catalogObject = {} ) {
 	const catalogId = catalogObject.id;
 	const name = catalogObject.item_data.name;
+	const description =
+		catalogObject.item_data.description ||
+		catalogObject.item_data.description_html ||
+		'';
+	let category = catalogObject.item_data.reporting_category?.id;
+	if (!category) {
+		category = catalogObject.categories[0]?.id;
+	}
+
 	const variations = catalogObject.item_data.variations.map( variation => {
 		return {
 			id: variation.id,
@@ -108,7 +140,9 @@ export function extractCatalogInfo( catalogObject = {} ) {
 	return {
 		catalogId,
 		name,
-		variations
+		category,
+		description,
+		variations,
 	}
 }
 
@@ -123,7 +157,7 @@ export async function createCatalogObject( name, sku, price, description = '' ) 
 	const url = 'https://connect.squareupsandbox.com/v2/catalog/object';
 	const method = 'POST';
 	const headers = {
-		'Square-Version': '2023-09-25',
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
 		'Content-Type': 'application/json'
 	};
@@ -168,7 +202,7 @@ export async function updateCatalogItemInventory( catalogId, inventoryCount ) {
 	const url = 'https://connect.squareupsandbox.com/v2/inventory/changes/batch-create';
 	const method = 'POST';
 	const headers = {
-		'Square-Version': '2023-09-25',
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
 		'Content-Type': 'application/json'
 	};
@@ -236,8 +270,8 @@ export async function importProducts( page, update = false ) {
 export async function getGiftCard( gan = '' ) {
 	const url = 'https://connect.squareupsandbox.com/v2/gift-cards/from-gan';
 	const headers = {
+		'Square-Version': squareVersion,
 		'Authorization': `Bearer ${process.env.SQUARE_ACCESS_TOKEN}`,
-		'Square-Version': '2023-09-25',
 		'Content-Type': 'application/json'
 	};
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
The PR fixes the category reverting issue reported in #156. This issue was introduced due to the Square SDK upgrade, which updated the Square API version. The update added [support for multiple categories and deprecated the category_id field](https://developer.squareup.com/docs/changelog/connect-logs/2023-12-13). As a result, retrieving the category ID failed, causing categories to revert to the default WooCommerce category during sync. The PR makes the necessary changes to get the category from the Square catalog item and sync it with the Woo store.

Since Square now supports multiple categories, the plugin first looks for the reporting category to import. If the reporting category is not set, it uses the first category from the categories array of the catalog item.

> [!NOTE]
> - The PR does not add support for syncing multiple categories; it fixes the issue with single category sync, ensuring it works as intended. Opened separate issue for adding support for sync multiple categories - https://github.com/woocommerce/woocommerce-square/issues/173
> - The newly added fields `categories` and `reporting_category` are still in **BETA**, but the previous `category_id` field has been removed from the API. Therefore, I have used the newly added fields as suggested in the documentation.

Closes #156

### Steps to test the changes in this Pull Request:
1. Checkout to this PR branch.
1. Set up SOR to Square.
1. Import products by clicking on the "Import Products From Square" button.
1. Verify that the product category does not revert and continues syncing properly.
1. Test sync thoroughly for all fields (title, price, description, image, category, inventory, etc.) in all types of sync:
    - Product Import
    - Manual Sync
    - Interval polling
1. Set up WooCommerce as the SOR.
1. Test sync thoroughly for all fields (title, price, description, image, category, inventory, etc.) in all types of sync:
    - Product create/update in WooCommerce store
    - Manual Sync
    - Interval polling

### Changelog entry
> Fix - Ensure the product category syncs properly between the Square and WooCommerce store.
