### PR TITLE
Add support for buttonAttributes and set default height to 48px

### DIFF
--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -33,6 +33,7 @@ const ButtonComponent = () => {
 		onClose,
 		eventRegistration,
 		paymentStatus,
+		buttonAttributes,
 	} = props;
 	const { onPaymentSetup } = eventRegistration;
 	const googlePaybuttonRef = useRef();
@@ -148,10 +149,12 @@ const ButtonComponent = () => {
 	const isApplePayDisabled =
 		getSquareServerData().hideButtonOptions.includes('apple');
 
+	const buttonHeight = buttonAttributes?.height || '48';
 	return (
 		<>
 			{!isApplePayDisabled && (
 				<div
+					style={{ height: buttonHeight }}
 					tabIndex={0}
 					role="button"
 					id="apple-pay-button"
@@ -171,6 +174,7 @@ const ButtonComponent = () => {
 			)}
 			{!isGooglePayDisabled && (
 				<div
+					style={{ height: `${buttonHeight}px` }}
 					tabIndex={0}
 					role="button"
 					ref={googlePaybuttonRef}

--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -149,7 +149,12 @@ const ButtonComponent = () => {
 	const isApplePayDisabled =
 		getSquareServerData().hideButtonOptions.includes('apple');
 
-	const buttonHeight = buttonAttributes?.height || '48';
+	// Default button height aligns with Woo defaults
+	let buttonHeight = '48';
+	if (typeof buttonAttributes !== 'undefined') {
+		buttonHeight = buttonAttributes?.height || buttonHeight;
+	}
+
 	return (
 		<>
 			{!isApplePayDisabled && (

--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -152,7 +152,7 @@ const ButtonComponent = () => {
 
 	// Default button height aligns with Woo defaults
 	let buttonHeight = '48';
-	if (typeof buttonAttributes !== 'undefined' && buttonAttributes !== null) {
+	if (typeof buttonAttributes !== 'undefined') {
 		buttonHeight = buttonAttributes?.height || buttonHeight;
 	}
 

--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -20,6 +20,7 @@ import {
 } from './submission-handler';
 
 import { getSquareServerData } from '../square-utils';
+import { button } from '@wordpress/icons';
 
 const ButtonComponent = () => {
 	const { payments, props } = useContext(DigitalWalletContext);
@@ -151,7 +152,7 @@ const ButtonComponent = () => {
 
 	// Default button height aligns with Woo defaults
 	let buttonHeight = '48';
-	if (typeof buttonAttributes !== 'undefined') {
+	if (typeof buttonAttributes !== 'undefined' && buttonAttributes !== null) {
 		buttonHeight = buttonAttributes?.height || buttonHeight;
 	}
 

--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -159,7 +159,7 @@ const ButtonComponent = () => {
 		<>
 			{!isApplePayDisabled && (
 				<div
-					style={{ height: buttonHeight }}
+					style={{ height: `${buttonHeight}px` }}
 					tabIndex={0}
 					role="button"
 					id="apple-pay-button"

--- a/assets/blocks/digital-wallets/button-component.js
+++ b/assets/blocks/digital-wallets/button-component.js
@@ -20,7 +20,6 @@ import {
 } from './submission-handler';
 
 import { getSquareServerData } from '../square-utils';
-import { button } from '@wordpress/icons';
 
 const ButtonComponent = () => {
 	const { payments, props } = useContext(DigitalWalletContext);


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds a default button height of `48px` to match the [payment design guidelines](https://developer.woocommerce.com/docs/user-experience-guidelines-payment-button-size-and-anatomy/) and Woo defaults. If this height is not set explicitly on the container, the buttons default to `40px` and look smaller than other buttons in the express checkout area. We also get the height from the new `buttonAttributes` API if available.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Activate the plugin and make sure the express payment button is rendering
2. Add an item to your cart and view the checkout block. 
3. The button should have a height of 48px, and should align with other express payment methods when activated

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->
> Fix - Inconsistency in the height of Express Payment Button and compliance with the new Woo Express Payment Method Styling API.

