### PR TITLE
Remove double encoding in the redirect url from the OAuth flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce Square Changelog ***
 
+= 4.7.1 - xxxx-xx-xx =
+* Fix - Remove double encoding from the redirect_url param in the oauth connect url.
+* Dev - Bump WordPress "tested up to" version 6.6.
+
 = 4.7.0 - 2024-06-27 =
 * Add - New Merchant Onboarding experience with a new wizard flow & settings pages.
 * Add - Support for WooCommerce Product Blocks.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -456,7 +456,7 @@ class Connection {
 		}
 
 		$args = array(
-			'redirect' => urlencode( urlencode( $redirect_url ) ),
+			'redirect' => rawurlencode( $redirect_url ),
 			'scopes'   => implode( ',', $this->get_scopes() ),
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,10 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
+= 4.7.1 - xxxx-xx-xx =
+* Fix - Remove double encoding from the redirect_url param in the oauth connect url.
+* Dev - Bump WordPress "tested up to" version 6.6.
+
 = 4.7.0 - 2024-06-27 =
 * Add - New Merchant Onboarding experience with a new wizard flow & settings pages.
 * Add - Support for WooCommerce Product Blocks.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the double encoding in the `redirect_url` from the oauth connect url.

This is needed after the `validateUrl()`  changes from Jul 17th on `api.woocommerce.com`.

Closes #181

### Steps to test the changes in this Pull Request:
1. Navigate to `WP-Admin > WooCommerce > Settings`
2. Click on the `Square` tab
3. If already connected to Square, disconnect by clicking on the `Disconnect from Square` button
4. Click on the `Connect to Square` button
5. Complete the OAuth flow with your Square credentials
6. Check that the redirect page loads correctly:
    <img width="664" alt="Screenshot 2024-07-21 at 11 09 28 PM" src="https://github.com/user-attachments/assets/86a8bb47-8608-421b-880e-3d16b7956145">
7. Click `That's my site - redirect me`
8. Check the Account was correctly connected
    <img width="849" alt="Screenshot 2024-07-21 at 11 07 36 PM" src="https://github.com/user-attachments/assets/164c96ad-0e3d-42c1-8e64-1e47386e8653">

### Changelog entry
> Fix - Remove double encoding from the redirect_url param in the oauth connect url.
