### PR TITLE
fix/30: Prevent Gift Card image from being forced upon a site

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -26,6 +26,7 @@ namespace WooCommerce\Square;
 defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Square\Admin\Analytics\Revenue;
+use WooCommerce\Square\Handlers\Products;
 use WooCommerce\Square\Handlers\Product;
 
 /**
@@ -161,6 +162,8 @@ class Admin {
 				Plugin::VERSION
 			);
 
+			wp_enqueue_media();
+
 			wp_enqueue_script(
 				'wc-square-admin-settings',
 				$this->get_plugin()->get_plugin_url() . '/build/assets/admin/wc-square-admin-settings.js',
@@ -233,15 +236,22 @@ class Admin {
 				)
 			);
 
+			$gift_card_placeholder_url = Products::get_gift_card_default_placeholder_url();
+
+			if ( empty( $gift_card_placeholder_url ) ) {
+				$gift_card_placeholder_url = WC_SQUARE_PLUGIN_URL . 'build/images/gift-card-featured-image.png';
+			}
+
 			wp_localize_script(
 				'woocommerce-square-settings-js',
 				'wcSquareSettings',
 				array(
-					'nonce'     => wp_create_nonce( 'wc_square_settings' ),
-					'homeUrl'   => home_url(),
-					'adminUrl'  => admin_url(),
-					'ajaxUrl'   => admin_url( 'admin-ajax.php' ),
-					'depsCheck' => $this->get_plugin()->get_dependency_handler()->meets_php_dependencies(),
+					'nonce'            => wp_create_nonce( 'wc_square_settings' ),
+					'homeUrl'          => home_url(),
+					'adminUrl'         => admin_url(),
+					'ajaxUrl'          => admin_url( 'admin-ajax.php' ),
+					'depsCheck'        => $this->get_plugin()->get_dependency_handler()->meets_php_dependencies(),
+					'gcPlaceholderUrl' => esc_url( $gift_card_placeholder_url ),
 				)
 			);
 

--- a/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
@@ -75,17 +75,17 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 				'callback'            => array( $this, 'save_settings' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
-					'enabled'     => array(
+					'enabled'                => array(
 						'description'       => __( 'Enable Square payment gateway.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => '',
 					),
-					'title'       => array(
+					'title'                  => array(
 						'description'       => __( 'Square payment gateway title.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => '',
 					),
-					'description' => array(
+					'description'            => array(
 						'description'       => __( 'Square payment gateway description.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => '',
@@ -95,7 +95,7 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 						'type'              => 'string',
 						'sanitize_callback' => '',
 					),
-					'placeholder_id' => array(
+					'placeholder_id'         => array(
 						'description'       => __( 'ID of the placeholder media.', 'woocommerce-square' ),
 						'type'              => 'integer',
 						'sanitize_callback' => '',

--- a/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
@@ -48,6 +48,7 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 			'title',
 			'description',
 			'is_default_placeholder',
+			'placeholder_id',
 		);
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
@@ -92,6 +93,11 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 					'is_default_placeholder' => array(
 						'description'       => __( 'Indicates if a Gift card product should use the default placeholder provided by the plugin.', 'woocommerce-square' ),
 						'type'              => 'string',
+						'sanitize_callback' => '',
+					),
+					'placeholder_id' => array(
+						'description'       => __( 'ID of the placeholder media.', 'woocommerce-square' ),
+						'type'              => 'integer',
 						'sanitize_callback' => '',
 					),
 				),

--- a/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
@@ -126,6 +126,14 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 		}
 
 		update_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $settings );
+
+		/**
+		 * Action triggered when the Gift card payment settings are updated.
+		 *
+		 * @since x.x.x
+		 */
+		do_action( 'wc_square_' . self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME . '_settings_updated', $settings );
+
 		wp_send_json_success();
 	}
 }

--- a/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
@@ -5,6 +5,7 @@
 
 namespace WooCommerce\Square\Admin\Rest;
 
+use WooCommerce\Square\Gateway\Gift_Card;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -17,13 +18,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 4.7.0
  */
 class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_Controller {
-
-	/**
-	 * Square settings option name.
-	 *
-	 * @var string
-	 */
-	const SQUARE_PAYMENT_SETTINGS_OPTION_NAME = 'woocommerce_gift_cards_pay_settings';
 
 	/**
 	 * Endpoint path.
@@ -111,7 +105,7 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 	 * @return WP_REST_Response
 	 */
 	public function get_settings() {
-		$square_settings   = get_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
+		$square_settings   = get_option( Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
 		$filtered_settings = array_intersect_key( $square_settings, array_flip( $this->allowed_params ) );
 
 		return new WP_REST_Response( $filtered_settings );
@@ -131,14 +125,14 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 			$settings[ $key ] = $new_value;
 		}
 
-		update_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $settings );
+		update_option( Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $settings );
 
 		/**
 		 * Action triggered when the Gift card payment settings are updated.
 		 *
 		 * @since x.x.x
 		 */
-		do_action( 'wc_square_' . self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME . '_settings_updated', $settings );
+		do_action( 'wc_square_' . Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME . '_settings_updated', $settings );
 
 		wp_send_json_success();
 	}

--- a/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Gift_Cards_Settings_Controller.php
@@ -47,6 +47,7 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 			'enabled',
 			'title',
 			'description',
+			'is_default_placeholder',
 		);
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
@@ -85,6 +86,11 @@ class WC_REST_Square_Gift_Cards_Settings_Controller extends WC_Square_REST_Base_
 					),
 					'description' => array(
 						'description'       => __( 'Square payment gateway description.', 'woocommerce-square' ),
+						'type'              => 'string',
+						'sanitize_callback' => '',
+					),
+					'is_default_placeholder' => array(
+						'description'       => __( 'Indicates if a Gift card product should use the default placeholder provided by the plugin.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => '',
 					),

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -202,6 +202,10 @@ class Gift_Card extends Payment_Gateway {
 	 * @since 4.2.0
 	 */
 	public function add_gift_card_image_placeholder() {
+		if ( ! \WooCommerce\Square\Handlers\Products::should_use_default_gift_card_placeholder_image() ) {
+			return;
+		}
+
 		$placeholder_image = get_option( 'wc_square_gift_card_placeholder_id', false );
 
 		if ( ! empty( $placeholder_image ) ) {

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -14,6 +14,13 @@ use WooCommerce\Square\Gateway;
 
 class Gift_Card extends Payment_Gateway {
 	/**
+	 * Square settings option name.
+	 *
+	 * @var string
+	 */
+	const SQUARE_PAYMENT_SETTINGS_OPTION_NAME = 'woocommerce_gift_cards_pay_settings';
+
+	/**
 	 * @var API API base instance
 	 */
 	private $api;
@@ -228,7 +235,7 @@ class Gift_Card extends Payment_Gateway {
 
 		if ( ! file_exists( $filename ) ) {
 			$settings['placeholder_id'] = 0;
-			update_option( 'woocommerce_gift_cards_pay_settings', $settings );
+			update_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $settings );
 			return;
 		}
 
@@ -245,12 +252,12 @@ class Gift_Card extends Payment_Gateway {
 
 		if ( is_wp_error( $attach_id ) ) {
 			$settings['placeholder_id'] = 0;
-			update_option( 'woocommerce_gift_cards_pay_settings', $settings );
+			update_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $settings );
 			return;
 		}
 
 		$settings['placeholder_id'] = $attach_id;
-		update_option( 'woocommerce_gift_cards_pay_settings', $settings );
+		update_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $settings );
 
 		// Make sure that this file is included, as wp_generate_attachment_metadata() depends on it.
 		require_once ABSPATH . 'wp-admin/includes/image.php';
@@ -270,7 +277,7 @@ class Gift_Card extends Payment_Gateway {
 	 */
 	public function delete_gift_card_image_placeholder( $post_id ) {
 		$attachment_id      = Products::get_gift_card_default_placeholder_id();
-		$gift_card_settings = get_option( 'woocommerce_gift_cards_pay_settings', array() );
+		$gift_card_settings = get_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
 
 		if ( $attachment_id !== $post_id ) {
 			return;
@@ -280,7 +287,7 @@ class Gift_Card extends Payment_Gateway {
 			$gift_card_settings['is_default_placeholder'] = 'no';
 			$gift_card_settings['placeholder_id']         = 0;
 
-			update_option( 'woocommerce_gift_cards_pay_settings', $gift_card_settings );
+			update_option( self::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, $gift_card_settings );
 		}
 	}
 

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -1268,7 +1268,7 @@ class Products {
 			return $image;
 		}
 
-		$placeholder_image_id = get_option( 'wc_square_gift_card_placeholder_id', 0 );
+		$placeholder_image_id = self::get_gift_card_default_placeholder_id();
 
 		$default_attr = array(
 			'class' => 'woocommerce-placeholder wp-post-image',
@@ -1322,7 +1322,7 @@ class Products {
 			return $html;
 		}
 
-		$placeholder_image_id = get_option( 'wc_square_gift_card_placeholder_id', false );
+		$placeholder_image_id = self::get_gift_card_default_placeholder_id();
 
 		if ( wp_attachment_is_image( $placeholder_image_id ) ) {
 			$html = wc_get_gallery_image_html( $placeholder_image_id, true );
@@ -1530,7 +1530,7 @@ class Products {
 		}
 
 		if ( empty( $image_id ) ) {
-			$placeholder_image_id = get_option( 'wc_square_gift_card_placeholder_id', 0 );
+			$placeholder_image_id = self::get_gift_card_default_placeholder_id();
 
 			if ( $placeholder_image_id ) {
 				$image_id = $placeholder_image_id;
@@ -1563,5 +1563,41 @@ class Products {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Returns the default placeholder image ID for gift card products.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return int
+	 */
+	public static function get_gift_card_default_placeholder_id() {
+		$settings = get_option( 'woocommerce_gift_cards_pay_settings', array() );
+
+		return (int) ( $settings['placeholder_id'] ?? 0 );
+	}
+
+	/**
+	 * Returns the default placeholder image URL for gift card products.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string|bool
+	 */
+	public static function get_gift_card_default_placeholder_url() {
+		$placeholder_id = self::get_gift_card_default_placeholder_id();
+
+		if ( ! $placeholder_id ) {
+			return '';
+		}
+
+		$attachment = get_post( $placeholder_id );
+
+		if ( ! $attachment ) {
+			return '';
+		}
+
+		return wp_get_attachment_url( $attachment->ID );
 	}
 }

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -1256,6 +1256,10 @@ class Products {
 	 * @return string
 	 */
 	public function filter_gift_card_product_featured_image_placeholder( $image, $product, $size ) {
+		if ( ! self::should_use_default_gift_card_placeholder_image() ) {
+			return $image;
+		}
+
 		if ( has_post_thumbnail( $product->get_id() ) ) {
 			return $image;
 		}
@@ -1294,6 +1298,10 @@ class Products {
 	 * @return string
 	 */
 	public function filter_single_product_featured_image_placeholder( $html ) {
+		if ( ! self::should_use_default_gift_card_placeholder_image() ) {
+			return $html;
+		}
+
 		$product_id = get_the_ID();
 
 		if ( ! $product_id ) {
@@ -1509,6 +1517,10 @@ class Products {
 	 * @return string
 	 */
 	public function gift_card_product_image_id( $image_id, $product ) {
+		if ( ! self::should_use_default_gift_card_placeholder_image() ) {
+			return $image_id;
+		}
+
 		if ( ! Product::is_gift_card( $product ) ) {
 			return $image_id;
 		}
@@ -1526,5 +1538,30 @@ class Products {
 		}
 
 		return $image_id;
+	}
+
+	/**
+	 * Returns true if a gift card product should use the provided
+	 * default placeholder image.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public static function should_use_default_gift_card_placeholder_image() {
+		$settings   = get_option( 'woocommerce_gift_cards_pay_settings', array() );
+		$is_enabled = isset( $settings['enabled'] ) && 'yes' === $settings['enabled'];
+
+		if ( ! $is_enabled ) {
+			return false;
+		}
+
+		$should_use_placeholder = isset( $settings['is_default_placeholder'] ) && 'yes' === $settings['is_default_placeholder'];
+
+		if ( ! $should_use_placeholder ) {
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -79,7 +79,7 @@ class Products {
 		);
 
 		// Get gift card features status.
-		$gift_card_settings      = get_option( 'woocommerce_gift_cards_pay_settings', array() );
+		$gift_card_settings      = get_option( Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
 		$this->gift_card_enabled = $gift_card_settings['enabled'] ?? 'no';
 
 		add_action( 'current_screen', array( $this, 'add_tabs' ), 99 );
@@ -1549,7 +1549,7 @@ class Products {
 	 * @return bool
 	 */
 	public static function should_use_default_gift_card_placeholder_image() {
-		$settings   = get_option( 'woocommerce_gift_cards_pay_settings', array() );
+		$settings   = get_option( Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
 		$is_enabled = isset( $settings['enabled'] ) && 'yes' === $settings['enabled'];
 
 		if ( ! $is_enabled ) {
@@ -1573,7 +1573,7 @@ class Products {
 	 * @return int
 	 */
 	public static function get_gift_card_default_placeholder_id() {
-		$settings = get_option( 'woocommerce_gift_cards_pay_settings', array() );
+		$settings = get_option( Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
 
 		return (int) ( $settings['placeholder_id'] ?? 0 );
 	}

--- a/src/new-user-experience/onboarding/data/reducers.js
+++ b/src/new-user-experience/onboarding/data/reducers.js
@@ -55,6 +55,7 @@ export const GIFT_CARDS_DEFAULT_STATE = {
 	enabled: 'no',
 	title: __( 'Square Gift Cards', 'woocommerce-square' ),
 	is_default_placeholder: 'no',
+	placeholder_id: 0,
 	description: __(
 		'Allow customers to purchase and redeem gift cards during checkout.',
 		'woocommerce-square'

--- a/src/new-user-experience/onboarding/data/reducers.js
+++ b/src/new-user-experience/onboarding/data/reducers.js
@@ -54,6 +54,7 @@ const digitalWalletsReducer = (
 export const GIFT_CARDS_DEFAULT_STATE = {
 	enabled: 'no',
 	title: __( 'Square Gift Cards', 'woocommerce-square' ),
+	is_default_placeholder: 'no',
 	description: __(
 		'Allow customers to purchase and redeem gift cards during checkout.',
 		'woocommerce-square'

--- a/src/new-user-experience/onboarding/steps/gift-card/index.js
+++ b/src/new-user-experience/onboarding/steps/gift-card/index.js
@@ -24,11 +24,13 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 		setGiftCardData,
 	} = usePaymentGatewaySettings();
 
-	const { enabled } = giftCardsGatewaySettings;
+	const { enabled, is_default_placeholder } = giftCardsGatewaySettings;
 
 	if ( ! giftCardsGatewaySettingsLoaded ) {
 		return null;
 	}
+
+	const mediaId = 0;
 
 	return (
 		<>
@@ -74,27 +76,54 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 					) }
 
 					{ origin === 'settings' && (
-						<InputWrapper
-							label={ __(
-								'Enable / Disable',
-								'woocommerce-square'
-							) }
-						>
-							<SquareCheckboxControl
-								className="gift-card-gateway-toggle-field"
-								data-testid="gift-card-gateway-toggle-field"
+						<>
+							<InputWrapper
 								label={ __(
-									'Enable this payment method.',
+									'Enable / Disable',
 									'woocommerce-square'
 								) }
-								checked={ enabled === 'yes' }
-								onChange={ ( value ) =>
-									setGiftCardData( {
-										enabled: value ? 'yes' : 'no',
-									} )
-								}
-							/>
-						</InputWrapper>
+							>
+								<SquareCheckboxControl
+									className="gift-card-gateway-toggle-field"
+									data-testid="gift-card-gateway-toggle-field"
+									label={ __(
+										'Enable this payment method.',
+										'woocommerce-square'
+									) }
+									checked={ enabled === 'yes' }
+									onChange={ ( value ) =>
+										setGiftCardData( {
+											enabled: value ? 'yes' : 'no',
+										} )
+									}
+								/>
+							</InputWrapper>
+							<InputWrapper
+								label={ __(
+									'Gift card product placeholder image',
+									'woocommerce-square'
+								) }
+							>
+								<SquareCheckboxControl
+									className="gift-card-gateway-product-placeholder-toggle-field"
+									data-testid="gift-card-gateway-product-placeholder-toggle-field"
+									label={ __(
+										'Enable to use the following image as the default placeholder for gift card products.',
+										'woocommerce-square'
+									) }
+									checked={ is_default_placeholder === 'yes' }
+									onChange={ ( value ) =>
+										setGiftCardData( {
+											is_default_placeholder: value ? 'yes' : 'no',
+										} )
+									}
+								/>
+								<img
+									style={ { maxWidth: '350px' } }
+									src={ `${wcSquareSettings.homeUrl}/wp-content/plugins/woocommerce-square/src/images/gift-card-featured-image.png`}
+								/>
+							</InputWrapper>
+						</>
 					) }
 				</div>
 			</Section>

--- a/src/new-user-experience/onboarding/steps/gift-card/index.js
+++ b/src/new-user-experience/onboarding/steps/gift-card/index.js
@@ -2,7 +2,8 @@
  * External dependencies.
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { ToggleControl } from '@wordpress/components';
+import { ToggleControl, Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import parse from 'html-react-parser';
 
 /**
@@ -24,13 +25,33 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 		setGiftCardData,
 	} = usePaymentGatewaySettings();
 
+	const [ defaultPlaceholderUrl, setDefaultPlaceholderUrl ] = useState( wcSquareSettings.gcPlaceholderUrl );
+
 	const { enabled, is_default_placeholder } = giftCardsGatewaySettings;
 
 	if ( ! giftCardsGatewaySettingsLoaded ) {
 		return null;
 	}
 
-	const mediaId = 0;
+	function openMediaLibrary() {
+		const imageUploader = wp.media( {
+			title: __( 'Select or Upload an image to use as the Gift card placeholder:' ),
+			library : {
+				type : 'image'
+			},
+			button: {
+				text: 'Use this image'
+			},
+			multiple: false
+		} ).on( 'select', function() {
+			const attachment = imageUploader.state().get( 'selection' ).first().toJSON();
+
+			setGiftCardData( { placeholder_id: attachment.id } );
+			setDefaultPlaceholderUrl( attachment.url );
+		} );
+
+		imageUploader.open();
+	}
 
 	return (
 		<>
@@ -120,8 +141,15 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 								/>
 								<img
 									style={ { maxWidth: '350px' } }
-									src={ `${wcSquareSettings.homeUrl}/wp-content/plugins/woocommerce-square/src/images/gift-card-featured-image.png`}
+									src={ defaultPlaceholderUrl }
 								/>
+								<Button
+									variant='link'
+									onClick={ openMediaLibrary }
+									style={ { width: 'auto' } }
+								>
+									{ __( 'Replace image', 'woocommerce-square' ) }
+								</Button>
 							</InputWrapper>
 						</>
 					) }

--- a/src/new-user-experience/onboarding/steps/gift-card/index.js
+++ b/src/new-user-experience/onboarding/steps/gift-card/index.js
@@ -25,7 +25,9 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 		setGiftCardData,
 	} = usePaymentGatewaySettings();
 
-	const [ defaultPlaceholderUrl, setDefaultPlaceholderUrl ] = useState( wcSquareSettings.gcPlaceholderUrl );
+	const [ defaultPlaceholderUrl, setDefaultPlaceholderUrl ] = useState(
+		wcSquareSettings.gcPlaceholderUrl
+	);
 
 	const { enabled, is_default_placeholder } = giftCardsGatewaySettings;
 
@@ -34,21 +36,30 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 	}
 
 	function openMediaLibrary() {
-		const imageUploader = wp.media( {
-			title: __( 'Select or Upload an image to use as the Gift card placeholder:' ),
-			library : {
-				type : 'image'
-			},
-			button: {
-				text: 'Use this image'
-			},
-			multiple: false
-		} ).on( 'select', function() {
-			const attachment = imageUploader.state().get( 'selection' ).first().toJSON();
+		const imageUploader = wp
+			.media( {
+				title: __(
+					'Select or Upload an image to use as the Gift card placeholder:',
+					'woocommerce-square'
+				),
+				library: {
+					type: 'image',
+				},
+				button: {
+					text: 'Use this image',
+				},
+				multiple: false,
+			} )
+			.on( 'select', function () {
+				const attachment = imageUploader
+					.state()
+					.get( 'selection' )
+					.first()
+					.toJSON();
 
-			setGiftCardData( { placeholder_id: attachment.id } );
-			setDefaultPlaceholderUrl( attachment.url );
-		} );
+				setGiftCardData( { placeholder_id: attachment.id } );
+				setDefaultPlaceholderUrl( attachment.url );
+			} );
 
 		imageUploader.open();
 	}
@@ -135,20 +146,29 @@ export const GiftCardSetup = ( { origin = '' } ) => {
 									checked={ is_default_placeholder === 'yes' }
 									onChange={ ( value ) =>
 										setGiftCardData( {
-											is_default_placeholder: value ? 'yes' : 'no',
+											is_default_placeholder: value
+												? 'yes'
+												: 'no',
 										} )
 									}
 								/>
 								<img
 									style={ { maxWidth: '350px' } }
 									src={ defaultPlaceholderUrl }
+									alt={ __(
+										'Preview of the Gift card placeholder',
+										'woocommerce-square'
+									) }
 								/>
 								<Button
-									variant='link'
+									variant="link"
 									onClick={ openMediaLibrary }
 									style={ { width: 'auto' } }
 								>
-									{ __( 'Replace image', 'woocommerce-square' ) }
+									{ __(
+										'Replace image',
+										'woocommerce-square'
+									) }
 								</Button>
 							</InputWrapper>
 						</>

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -61,6 +61,7 @@ export const getGiftCardsSettingsData = async () => {
 	const giftCard = {
 		enabled: settings.enabled || GIFT_CARDS_DEFAULT_STATE.enabled,
 		is_default_placeholder: settings.is_default_placeholder || GIFT_CARDS_DEFAULT_STATE.is_default_placeholder,
+		placeholder_id: settings.placeholder_id || GIFT_CARDS_DEFAULT_STATE.placeholder_id,
 	};
 
 	return { giftCard };

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -60,6 +60,7 @@ export const getGiftCardsSettingsData = async () => {
 
 	const giftCard = {
 		enabled: settings.enabled || GIFT_CARDS_DEFAULT_STATE.enabled,
+		is_default_placeholder: settings.is_default_placeholder || GIFT_CARDS_DEFAULT_STATE.is_default_placeholder,
 	};
 
 	return { giftCard };

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -60,8 +60,11 @@ export const getGiftCardsSettingsData = async () => {
 
 	const giftCard = {
 		enabled: settings.enabled || GIFT_CARDS_DEFAULT_STATE.enabled,
-		is_default_placeholder: settings.is_default_placeholder || GIFT_CARDS_DEFAULT_STATE.is_default_placeholder,
-		placeholder_id: settings.placeholder_id || GIFT_CARDS_DEFAULT_STATE.placeholder_id,
+		is_default_placeholder:
+			settings.is_default_placeholder ||
+			GIFT_CARDS_DEFAULT_STATE.is_default_placeholder,
+		placeholder_id:
+			settings.placeholder_id || GIFT_CARDS_DEFAULT_STATE.placeholder_id,
 	};
 
 	return { giftCard };


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Earlier, we added the default git card placeholder image to the media library on `init` hook.
In this PR, we add to the media library when the **Gift card product placeholder image** setting is enabled and the settings are saved at `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=gift_cards_pay`.

This PR also adds a provision to replace the default placeholder for gift card via the following UI:

<img width="825" alt="Screenshot 2024-08-12 at 7 15 24 PM" src="https://github.com/user-attachments/assets/e41a64b9-9bf6-4d1f-95d7-f0434eb44e28">


Closes #30

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Delete the gift card placeholder (the purple one shown above) from the media library.
2. Create 2 gift card products. One with the product image set, and another without.
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=gift_cards_pay` and enable **Gift card product placeholder image** and save it.
4. Observe that the gift card placeholder gets added to the media library.
5. Observe that the gift card product created without the product image shows the purple image as the default placeholder.
6. Repeat (3) but this time replace the default placeholder.
7. Repeat (5) but this time observe the default placeholder is updated with whatever image you've set.
8. Delete the current active placeholder from the media library.
9. Observe that the setting **Gift card product placeholder image** automatically gets disabled.
10. Observe that the default placeholder for the gift card product is set to the image provided by Woo Core.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent Gift Card image from being forced upon a site.
