### PR TITLE
fix/i18n: Add missing `i18n` directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "@wordpress/env": "^10.0.0",
         "@wordpress/scripts": "^28.2.0",
         "copy-webpack-plugin": "^12.0.2",
-        "dotenv": "^16.4.5"
+        "dotenv": "^16.4.5",
+        "node-wp-i18n": "^1.2.7"
       },
       "engines": {
         "node": ">=20",
@@ -6828,6 +6829,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "node_modules/body-parser": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
@@ -8999,6 +9006,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -11011,6 +11027,31 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/gettext-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-3.1.1.tgz",
+      "integrity": "sha512-vNhWcqXEtZPs5Ft1ReA34g7ByWotpcOIeJvXVy2jF3/G2U9v6W0wG4Z4hXzcU8R//jArqkgHcVCGgGqa4vxVlQ==",
+      "dev": true,
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "readable-stream": "^3.2.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/gettext-parser/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/glob": {
@@ -15756,6 +15797,45 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
+    },
+    "node_modules/node-wp-i18n": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/node-wp-i18n/-/node-wp-i18n-1.2.7.tgz",
+      "integrity": "sha512-4X+890+Irj8sY+6WKkFx+4wk/GGu9mGLDY1PVPF9AWF1zTKWClLA83QikcQKX55rjjKpN1jSZEQoEANNVSSBYw==",
+      "dev": true,
+      "dependencies": {
+        "bluebird": "^3.4.1",
+        "gettext-parser": "^3.1.0",
+        "glob": "^7.0.5",
+        "lodash": "^4.14.2",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.4",
+        "tmp": "^0.2.1"
+      },
+      "bin": {
+        "wpi18n": "bin/wpi18n"
+      }
+    },
+    "node_modules/node-wp-i18n/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-wp-i18n/node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "version": "4.7.3",
   "homepage": "https://woocommerce.com/products/woocommerce-square/",
   "scripts": {
-    "build": "composer install --no-dev && npm run build:webpack && npm run archive",
+    "build": "composer install --no-dev && npm run build:webpack && npm run makepot && npm run archive",
     "build:dev": "composer install && npm run build:webpack",
     "build:webpack": "rimraf build/* && wp-scripts build",
     "build-watch:webpack": "rimraf build/* && wp-scripts start",
@@ -18,6 +18,7 @@
     "lint:js:fix": "wp-scripts lint-js src/ --ext js --fix",
     "phpcompat": "./vendor/bin/phpcs --standard=phpcs-compat.xml.dist -p .",
     "update-deps": "npm install -g rimraf && rimraf node_modules && rimraf npm-shrinkwrap.json && npm install && npm shrinkwrap --dev",
+    "makepot": "wpi18n makepot --domain-path i18n/languages --pot-file woocommerce-square.pot --type plugin --main-file woocommerce-square.php --exclude node_modules,tests,docs",
     "archive": "composer archive --file=$npm_package_name --format=zip",
     "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
     "woorelease": "npm run build",
@@ -37,7 +38,8 @@
     "@wordpress/env": "^10.0.0",
     "@wordpress/scripts": "^28.2.0",
     "copy-webpack-plugin": "^12.0.2",
-    "dotenv": "^16.4.5"
+    "dotenv": "^16.4.5",
+    "node-wp-i18n": "^1.2.7"
   },
   "engines": {
     "node": ">=20",


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In PR #166, the `i18n` directory wasn't included which was pointed out in https://github.com/woocommerce/woocommerce-square/issues/194#issuecomment-2286998100

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run `nvm use && npm ci && npm run build`
2. Extract the generated zip and verify that the `.pot` files exists.
