### PR TITLE
Update Business Location Button Text Based on Location Count

### DIFF
--- a/src/new-user-experience/onboarding/onboarding-app.js
+++ b/src/new-user-experience/onboarding/onboarding-app.js
@@ -169,9 +169,11 @@ export const OnboardingApp = () => {
 						<BusinessLocation />
 						{ settings.locations.length ? (
 							<SquareSettingsSaveButton
-								// eslint-disable-next-line
+								// eslint-disable-next-line @wordpress/i18n-no-variables
 								label={ __(
-									settings.locations.length === 1 ? 'Confirm' : 'Next',
+									settings.locations.length === 1
+										? 'Confirm'
+										: 'Next',
 									'woocommerce-square'
 								) }
 								afterSaveLabel={ __(

--- a/src/new-user-experience/onboarding/onboarding-app.js
+++ b/src/new-user-experience/onboarding/onboarding-app.js
@@ -170,6 +170,7 @@ export const OnboardingApp = () => {
 						{ settings.locations.length ? (
 							<SquareSettingsSaveButton
 								label={ __(
+									// eslint-disable-next-line
 									settings.locations.length === 1 ? 'Confirm' : 'Next',
 									'woocommerce-square'
 								) }

--- a/src/new-user-experience/onboarding/onboarding-app.js
+++ b/src/new-user-experience/onboarding/onboarding-app.js
@@ -169,8 +169,8 @@ export const OnboardingApp = () => {
 						<BusinessLocation />
 						{ settings.locations.length ? (
 							<SquareSettingsSaveButton
+								// eslint-disable-next-line
 								label={ __(
-									// eslint-disable-next-line
 									settings.locations.length === 1 ? 'Confirm' : 'Next',
 									'woocommerce-square'
 								) }

--- a/src/new-user-experience/onboarding/onboarding-app.js
+++ b/src/new-user-experience/onboarding/onboarding-app.js
@@ -169,6 +169,10 @@ export const OnboardingApp = () => {
 						<BusinessLocation />
 						{ settings.locations.length ? (
 							<SquareSettingsSaveButton
+								label={ __(
+									settings.locations.length === 1 ? 'Confirm' : 'Next',
+									'woocommerce-square'
+								) }
 								afterSaveLabel={ __(
 									'Changes Saved!',
 									'woocommerce-square'


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

As per the [internal discussion](https://fueled10up.slack.com/archives/C01UCQGPBDJ/p1723850630250799?thread_ts=1723037634.886629&cid=C01UCQGPBDJ), this PR updates the Business Location button text based on the number of locations in the dropdown. If only one location appears, the button will say "Confirm". If multiple locations appear, the button will say "Next". If no locations appear, the button will say "Create a Business Location".

### Steps to test the changes in this Pull Request:

Confirm the appropriate button text appears on the business location step.

### Changelog entry

> Update - Business Location button text changes as per the location count.
