### PR TITLE
Avoid Confirmation Popup on Save Square Settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,15 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@automattic/i18n-utils/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/@automattic/i18n-utils/node_modules/memize": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
@@ -6034,6 +6043,15 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/@woocommerce/components/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/@woocommerce/components/node_modules/path-to-regexp": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
@@ -6130,6 +6148,15 @@
       },
       "bin": {
         "pot-to-php": "tools/pot-to-php.js"
+      }
+    },
+    "node_modules/@woocommerce/currency/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@woocommerce/customer-effort-score": {
@@ -7095,6 +7122,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@woocommerce/experimental/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@woocommerce/experimental/node_modules/is-plain-obj": {
@@ -9668,6 +9704,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/i18n/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@wordpress/i18n/node_modules/memize": {
@@ -14797,7 +14842,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -16836,15 +16880,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gettext-parser": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
-      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "dependencies": {
-        "encoding": "^0.1.12",
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/gettext-parser": {

--- a/src/new-user-experience/settings/settings-app.js
+++ b/src/new-user-experience/settings/settings-app.js
@@ -223,7 +223,9 @@ export const SettingsApp = () => {
 			<SquareSettingsSaveButton
 				label={ __( 'Save changes', 'woocommerce-square' ) }
 				afterSaveLabel={ __( 'Changes Saved!', 'woocommerce-square' ) }
-				afterSaveCallback={ () => window.location.reload() }
+				afterSaveCallback={ () =>
+					document.querySelector( '.woocommerce-save-button' ).click()
+				}
 				disabled={ ! wcSquareSettings.depsCheck }
 			/>
 		</>


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

On the Square settings page, when the merchant changes the environment from the dropdown, it’s necessary to refresh the list of available locations based on the selected environment. Currently, this is achieved by reloading the page after saving, allowing the merchant to see and select the new location. However, based on an [internal discussion](https://fueled10up.slack.com/archives/C01UCQGPBDJ/p1724833450908149) about fixing the confirmation popup issue, it was decided to add a "Connect to Square Sandbox" button. This button will connect to the sandbox environment and populate the new locations, allowing users to select sandbox locations before clicking the main Sae button, thereby avoiding the need for a reload.

The original issue was that a confirmation popup appeared when the "Save Settings" button was selected, caused by the page reload request (see https://github.com/woocommerce/woocommerce-square/pull/105/commits/9d878b42afa5cb6d800e5b29d15049a291bde1ef). The core behavior, which uses the native save button, does not trigger this confirmation popup.

After further investigation, it was observed that even with the addition of the "Connect to Square Sandbox" button and the removal of the reload request on save, the confirmation popup still appears when attempting to navigate away from the page. This made the new button less effective.

This PR resolves the issue by triggering a click on the core save button (which is hidden) when the React-based save button is clicked, instead of reloading the page. This approach ultimately prevents the confirmation popup from appearing.

Closes #208.

### Steps to test the changes in this Pull Request:

1. Navigate to WooCommerce > Settings > Square.
2. Change the environment to Sandbox and save.
3. The page reloads.
4. Change the environment to Production (no need to connect) and save.
5. Notice the page saves and no confirmation popup appears.

### Changelog entry

> Fix - Confirmation popup appears when saving the Square settings.
