### PR TITLE
Fixed: URL linking to Square Developer dashboard in sandbox settings

### DIFF
--- a/src/new-user-experience/modules/sandbox-settings/index.js
+++ b/src/new-user-experience/modules/sandbox-settings/index.js
@@ -89,7 +89,7 @@ export const SandboxSettings = ( { indent = 0, showToggle = true } ) => {
 											'Application ID for the Sandbox Application, see the details in the %1$sMy Applications%2$s section.',
 											'woocommerce-square'
 										),
-										'<a target="_blank" href="https://squareupsandbox.com/dashboard/apps/my-applications">',
+										'<a target="_blank" href="https://developer.squareup.com/console/en/apps">',
 										'</a>'
 									)
 								) }


### PR DESCRIPTION
### All Submissions:
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [n/a] Have you written new tests for your changes, as applicable?
* [n/a] Have you successfully run tests with your changes locally?
* [no] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Change the URL for the **My Applications** link from `https://squareupsandbox.com/dashboard/apps/my-applications` to `https://developer.squareup.com/console/en/apps`.

Closes #209.

### Steps to test the changes in this Pull Request:
1. Go to **WooCommerce > Settings > Square > Settings**.
2. For **Environment Selection**, choose `Sandbox`.
3. Scroll down to **Sandbox Application ID**.
4. Look for the **My Applications** link. Click on it.
5. The link now correctly directs to the Square Developer dashboard (`https://developer.squareup.com/console/en/apps`).

### Changelog entry

> Fix - URL linking to Square Developer dashboard in sandbox settings.