### PR TITLE
Stop requesting to Reconnect to Square

### DIFF
--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -174,6 +174,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 
 		// Add the connection parameters to the response.
 		$filtered_settings['is_connected']           = wc_square()->get_gateway()->get_plugin()->get_settings_handler()->is_connected();
+		$filtered_settings['access_tokens']          = wc_square()->get_gateway()->get_plugin()->get_settings_handler()->get_access_tokens();
 		$filtered_settings['connection_url']         = wc_square()->get_gateway()->get_plugin()->get_connection_handler()->get_connect_url( false );
 		$filtered_settings['connection_url_wizard']  = wc_square()->get_gateway()->get_plugin()->get_connection_handler()->get_connect_url( false, array( 'from' => 'wizard' ) );
 		$filtered_settings['connection_url_sandbox'] = wc_square()->get_gateway()->get_plugin()->get_connection_handler()->get_connect_url( true, array( 'from' => 'wizard' ) );
@@ -196,6 +197,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 		$settings     = array();
 		$keys_to_skip = array(
 			'is_connected',
+			'access_tokens',
 			'locations',
 			'connection_url',
 			'connection_url_wizard',

--- a/src/new-user-experience/onboarding/data/reducers.js
+++ b/src/new-user-experience/onboarding/data/reducers.js
@@ -110,6 +110,7 @@ export const SQUARE_SETTINGS_DEFAULT_STATE = {
 	sync_interval: '0.25',
 	is_connected: false,
 	disconnection_url: '',
+	access_tokens: [],
 	connection_url: '',
 	connection_url_wizard: '',
 	connection_url_sandbox: '',

--- a/src/new-user-experience/settings/settings-app.js
+++ b/src/new-user-experience/settings/settings-app.js
@@ -30,7 +30,6 @@ export const SettingsApp = () => {
 
 	const [ initialState, setInitialState ] = useState( false );
 	const [ isFormDirty, setIsFormDirty ] = useState( false );
-	const [ envUpdated, setEnvUpdated ] = useState( false );
 
 	const {
 		enable_sandbox = 'no',
@@ -49,6 +48,13 @@ export const SettingsApp = () => {
 	useEffect( () => {
 		if ( ! squareSettingsLoaded ) {
 			return;
+		}
+
+		// Store the initially saved environment in local storage.
+		if ( enable_sandbox === 'yes' ) {
+			localStorage.setItem( 'wc_square_env', 'sandbox' );
+		} else {
+			localStorage.setItem( 'wc_square_env', 'production' );
 		}
 
 		setInitialState( settings );
@@ -102,7 +108,6 @@ export const SettingsApp = () => {
 					required
 					value={ enable_sandbox }
 					onChange={ ( value ) => {
-						setEnvUpdated( true );
 						setSquareSettingData( { enable_sandbox: value } );
 					} }
 					options={ [
@@ -140,14 +145,17 @@ export const SettingsApp = () => {
 						variant="button-primary"
 						className="button-primary"
 						href={
-							is_connected && ! envUpdated
+							is_connected &&
+							localStorage.getItem( 'wc_square_env' ) ===
+								'production'
 								? disconnection_url
 								: connection_url
 						}
 						isBusy={ isSquareSettingsSaving }
 						disabled={ ! wcSquareSettings.depsCheck }
 					>
-						{ is_connected && ! envUpdated
+						{ is_connected &&
+						localStorage.getItem( 'wc_square_env' ) === 'production'
 							? __(
 									'Disconnect from Square',
 									'woocommerce-square'

--- a/src/new-user-experience/settings/settings-app.js
+++ b/src/new-user-experience/settings/settings-app.js
@@ -38,6 +38,7 @@ export const SettingsApp = () => {
 		is_connected = false,
 		connection_url = '',
 		disconnection_url = '',
+		access_tokens = [],
 		locations = [],
 	} = settings;
 
@@ -48,13 +49,6 @@ export const SettingsApp = () => {
 	useEffect( () => {
 		if ( ! squareSettingsLoaded ) {
 			return;
-		}
-
-		// Store the initially saved environment in local storage.
-		if ( enable_sandbox === 'yes' ) {
-			localStorage.setItem( 'wc_square_env', 'sandbox' );
-		} else {
-			localStorage.setItem( 'wc_square_env', 'production' );
 		}
 
 		setInitialState( settings );
@@ -145,17 +139,14 @@ export const SettingsApp = () => {
 						variant="button-primary"
 						className="button-primary"
 						href={
-							is_connected &&
-							localStorage.getItem( 'wc_square_env' ) ===
-								'production'
+							access_tokens?.production
 								? disconnection_url
 								: connection_url
 						}
 						isBusy={ isSquareSettingsSaving }
 						disabled={ ! wcSquareSettings.depsCheck }
 					>
-						{ is_connected &&
-						localStorage.getItem( 'wc_square_env' ) === 'production'
+						{ access_tokens?.production
 							? __(
 									'Disconnect from Square',
 									'woocommerce-square'

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -165,6 +165,9 @@ export const getSquareSettings = async () => {
 		disconnection_url:
 			settings.disconnection_url ||
 			SQUARE_SETTINGS_DEFAULT_STATE.disconnection_url,
+		access_tokens:
+			settings.access_tokens ||
+			SQUARE_SETTINGS_DEFAULT_STATE.access_tokens,
 		connection_url:
 			settings.connection_url ||
 			SQUARE_SETTINGS_DEFAULT_STATE.connection_url,


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #205 & Closes #218.

### Steps to test the changes in this Pull Request:

1. Navigate to the Square settings under **WooCommerce > Settings > Square**.
2. Switch the environment to **Production** and save the changes (skip if already connected to Prod).
3. Next, change the environment to **Sandbox** but do not save, switch it back to **Production**.
4. In the `trunk` branch, you'll notice the button "Connect to Square," which is incorrect because we are already connected to the Production environment.
5. In this PR branch, you will see the correct button, "Disconnect from Square."
6. Confirm it also fixes #218.

### Changelog entry

> Fix - Connection settings now persist previous connection when toggling between Production and Sandbox.
