### PR TITLE
Fix CashApp Pay and Digital Wallet payments on Block Checkout for WooCommerce 9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -325,6 +325,15 @@
         "npm": ">=8.19.2"
       }
     },
+    "node_modules/@automattic/i18n-utils/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/@automattic/i18n-utils/node_modules/memize": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/memize/-/memize-2.1.0.tgz",
@@ -6034,6 +6043,15 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
+    "node_modules/@woocommerce/components/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
+      }
+    },
     "node_modules/@woocommerce/components/node_modules/path-to-regexp": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
@@ -6130,6 +6148,15 @@
       },
       "bin": {
         "pot-to-php": "tools/pot-to-php.js"
+      }
+    },
+    "node_modules/@woocommerce/currency/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@woocommerce/customer-effort-score": {
@@ -7095,6 +7122,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@woocommerce/experimental/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@woocommerce/experimental/node_modules/is-plain-obj": {
@@ -9668,6 +9704,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@wordpress/i18n/node_modules/gettext-parser": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+      "dependencies": {
+        "encoding": "^0.1.12",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@wordpress/i18n/node_modules/memize": {
@@ -14797,7 +14842,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -16836,15 +16880,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/gettext-parser": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
-      "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
-      "dependencies": {
-        "encoding": "^0.1.12",
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/gettext-parser": {

--- a/src/blocks/cash-app-pay/component-cash-app-pay.js
+++ b/src/blocks/cash-app-pay/component-cash-app-pay.js
@@ -121,8 +121,10 @@ export const ComponentCashAppPay = ( props ) => {
 						// Set the nonce.
 						setPaymentNonce( nonce );
 
-						// Place an Order.
-						onSubmit();
+						// Place an Order. Use setTimeout to ensure the nonce is set before submitting. (TODO: find a better way to do this).
+						setTimeout( () => {
+							onSubmit();
+						}, 0 );
 					} else {
 						// Declined. Reset the nonce and re-initialize the Square Cash App Pay Button.
 						setPaymentNonce( null );

--- a/src/blocks/digital-wallets/content.js
+++ b/src/blocks/digital-wallets/content.js
@@ -76,7 +76,10 @@ const Content = ( {
 				onClose();
 			} else {
 				setTokenResult( __tokenResult );
-				onSubmit();
+				// Use setTimeout to ensure the tokenResult is set before calling onSubmit. (TODO: find a better way handle this).
+				setTimeout( () => {
+					onSubmit();
+				}, 0 );
 			}
 		} )();
 	}


### PR DESCRIPTION
### All Submissions:
<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR fixes the CashApp Pay and Digital Wallet payments on Block Checkout for WooCommerce 9.3. The issue was occurring only with WooCommerce 9.3, and I suspect it's due to the React 18 upgrade in WC 9.3. The token updates in the state are not reflected in `onPaymentSetup` when `onSubmit` is called.

This PR fixes the issue by replacing `onSubmit();` with `setTimeout( onSubmit, 0 );`, breaking out of the current event loop to ensure state updates in `onPaymentSetup`. We are having an ongoing [discussion](https://woocommercecommunity.slack.com/archives/C03MCL9RTAR/p1725964836890459) with the Woo Team to figure out the proper fix. However, with WC 9.3 releasing tomorrow, proceeding with this fix for now is fine.

Closes #214 

### Steps to test the changes in this Pull Request:
1. Upgrade to WooCommerce 9.3(-rc-1)
1. Try placing an order using CashApp pay from block checkout and verify its works as expected.
1. Try placing an order using Digital wallets (GooglePay and ApplePay) from block checkout and verify it works as expected.

### Changelog entry
> Fix - CashApp Pay and Digital Wallet payments on Block Checkout for WooCommerce 9.3
