### PR TITLE
Fix Dynamic Properties Deprecations in Order Objects.

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -140,6 +140,36 @@ class Plugin extends Payment_Gateway_Plugin {
 		add_action( 'action_scheduler_init', array( $this, 'schedule_token_migration_job' ) );
 		add_action( 'wc_square_init_payment_token_migration_v2', array( $this, 'register_payment_tokens_migration_scheduler' ) );
 		add_action( 'wc_square_init_payment_token_migration', '__return_false' );
+
+		add_filter( 'woocommerce_order_class', array( $this, 'order_class' ), 20 );
+	}
+
+	/**
+	 * Replaces the default WooCommerce order class with the Square order class.
+	 *
+	 * This is to prevent deprecation notices from being thrown due to the use of
+	 * dynamic properties in the WooCommerce order class.
+	 *
+	 * The Square order classes include property definitions for the properties.
+	 *
+	 * Runs on the hook 'woocommerce_order_class, 20'.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $order_class_name The class name used for WooCommerce orders.
+	 * @return string The modified class name.
+	 */
+	public function order_class( $order_class_name ) {
+		// Remove leading slash from class name to normalize the namespace.
+		$order_class_name = ltrim( $order_class_name, '\\' );
+
+		if ( 'WC_Order' === $order_class_name ) {
+			return 'WooCommerce\\Square\\WC_Order_Square';
+		} elseif ( 'Automattic\\WooCommerce\\Admin\\Overrides\\Order' === $order_class_name ) {
+			return 'WooCommerce\\Square\\WC_Order_Admin_Override_Square';
+		}
+
+		return $order_class_name;
 	}
 
 	/**

--- a/includes/WC_Order_Admin_Override_Square.php
+++ b/includes/WC_Order_Admin_Override_Square.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This class solely exists to deal with the deprecated warnings on PHP 8.2+.
+ *
+ * In multiple places, the plugin dynamically adds properties on the instance
+ * of the \Automattic\WooCommerce\Admin\Overrides\Order class, which is no
+ * longer supported on PHP 8.2+
+ */
+
+namespace WooCommerce\Square;
+
+use Automattic\WooCommerce\Admin\Overrides\Order;
+
+/**
+ * Override of the \Automattic\WooCommerce\Admin\Overrides\Order class.
+ *
+ * This class is used to add additional properties to the order object.
+ *
+ * @since x.x.x
+ */
+class WC_Order_Admin_Override_Square extends Order {
+	/**
+	 * Holds the Square customer ID.
+	 *
+	 * @var string
+	 */
+	public $customer_id;
+
+	/**
+	 * Holds the Square customer ID. Same as $customer_id.
+	 *
+	 * @var string
+	 */
+	public $square_customer_id;
+
+	/**
+	 * Holds payment information on the order object.
+	 *
+	 * @var object
+	 */
+	public $payment;
+
+	/**
+	 * Holds order description.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Holds a combination of order number + retry count, should provide
+	 * a unique value for each transaction attempt.
+	 *
+	 * @var string
+	 */
+	public $unique_transaction_ref;
+
+	/**
+	 * Holds Square order ID.
+	 *
+	 * @var string
+	 */
+	public $square_order_id;
+
+	/**
+	 * Holds plugin version number.
+	 *
+	 * @var string
+	 */
+	public $square_version;
+
+	/**
+	 * Holds order payment total.
+	 *
+	 * @var float
+	 */
+	public $payment_total;
+
+	/**
+	 * Holds capture transaction type information.
+	 *
+	 * @var object
+	 */
+	public $capture;
+
+	/**
+	 * Holds refund order information.
+	 *
+	 * @var object
+	 */
+	public $refund;
+}

--- a/includes/WC_Order_Square.php
+++ b/includes/WC_Order_Square.php
@@ -87,7 +87,7 @@ class WC_Order_Square extends \WC_Order {
 	 *
 	 * @param mixed $the_order Post object or post ID of the order.
 	 *
-	 * @return bool|WC_Order|WC_Order_Refund|WC_Order_Square
+	 * @return bool|WC_Order|WC_Order_Refund|WC_Order_Square|WC_Order_Admin_Override_Square
 	 */
 	public static function wc_get_order( $the_order ) {
 		return \wc_get_order( $the_order );


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Fixes and issue in which deprecation notices are thrown in PHP 8.2+ due to the use of dynamic properties.

1. Introduces `WooCommerce\Square\WC_Order_Admin_Override_Square` to extend `Automattic\WooCommerce\Admin\Overrides\Order` to include the properties.
2. Introduces a filter to override `WC_Order` and `Automattic\WooCommerce\Admin\Overrides\Order`.

Closes #219 .

### Steps to test the changes in this Pull Request:

1. Create a simple product
2. Enable logging of deprecation notices
   ```
   define( 'WP_DEBUG', true );
   define( 'WP_DEBUG_LOG', '/path/to/debug.log' );
   define( 'WP_DEBUG_DISPLAY', true );
   ```
3. Ensure the store is configured to use blocks for the cart and checkout pages
4. Purchase the new product
5. Configure the store to use shortcodes for the cart and checkout pages.
6. Purchase the product
7. In the admin, process a refund using square for one of the orders.
8. Activate WooCommerce Subscriptions
9. Create a subscription product
10. Purchase the product
11. Go to my account
12. View the subscription product
13. Click renew now in the actions
14. Go to the subscription in the Dashboard (as a store admin)
15. Select Renew in the actions dropdown; submit the review.

Check the logs. Confirm there are no deprecation warnings for the creation of dynamic properties.

There may be some deprecation notices from Subscriptions relating to the use of `Automattic\WooCommerce\Admin\Features\Navigation` classes -- these are unrelated to this issue.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent deprecation notices creating orders in PHP 8.2 and later.
