### PR TITLE
Ensure Square sync works without issues when using cached API response

### DIFF
--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -106,7 +106,7 @@ class Helper {
 
 			if ( ! empty( $location_overrides ) ) {
 				$location_ids = array_map(
-					function( $location_override ) {
+					function ( $location_override ) {
 						return $location_override->getLocationId();
 					},
 					$location_overrides

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1657,7 +1657,7 @@ class Manual_Synchronization extends Stepped_Job {
 	 * @return int
 	 */
 	protected function get_max_objects_to_retrieve() {
-		$max = $this->get_attr( 'max_objects_to_retrieve', 100 );
+		$max = $this->get_attr( 'max_objects_to_retrieve', 50 );
 
 		/**
 		 * Filters the maximum number of objects to retrieve in a single sync job.

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1158,6 +1158,15 @@ class Manual_Synchronization extends Stepped_Job {
 
 			$response_data = $this->get_attr( 'catalog_objects_search_response_data', null );
 
+			if ( ! empty( $response_data ) ) {
+				$response_data = ApiHelper::getJsonHelper()->mapClass( json_decode( $response_data ), 'Square\\Models\\SearchCatalogObjectsResponse' );
+
+				// If the response data is invalid, reset it.
+				if ( ! $response_data instanceof SearchCatalogObjectsResponse ) {
+					$response_data = null;
+				}
+			}
+
 			if ( ! $response_data ) {
 
 				wc_square()->log( 'Generating a new catalog search request' );
@@ -1176,10 +1185,6 @@ class Manual_Synchronization extends Stepped_Job {
 				$response_data = $response->get_data();
 
 				$this->set_attr( 'catalog_objects_search_response_data', wp_json_encode( $response_data ) );
-
-			} else {
-
-				$response_data = ApiHelper::deserialize( $response_data, new SearchCatalogObjectsResponse() );
 			}
 
 			if ( ! $response_data instanceof SearchCatalogObjectsResponse ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -537,10 +537,12 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$products_map = Product::get_square_meta( $product_ids, 'square_item_id' );
 
+		$search_response = null;
 		if ( ! empty( $in_progress['unprocessed_search_response'] ) ) {
-			$search_response = ApiHelper::deserialize( $in_progress['unprocessed_search_response'], new SearchCatalogObjectsResponse() );
-		} else {
+			$search_response = ApiHelper::getJsonHelper()->mapClass( json_decode( $in_progress['unprocessed_search_response'] ), 'Square\\Models\\SearchCatalogObjectsResponse' );
+		}
 
+		if ( ! $search_response ) {
 			$response = wc_square()->get_api()->search_catalog_objects(
 				array(
 					'cursor'       => $this->get_attr( 'search_products_cursor' ),
@@ -1416,7 +1418,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 		// if a response was never cleared, we likely had a timeout
 		if ( null !== $in_progress['response_data'] ) {
-			$response_data = ApiHelper::deserialize( $in_progress['response_data'], new BatchRetrieveInventoryCountsResponse() );
+			$response_data = ApiHelper::getJsonHelper()->mapClass( json_decode( $in_progress['response_data'] ), 'Square\\Models\\BatchRetrieveInventoryCountsResponse' );
 		}
 
 		// if the saved response was somehow corrupted, start over

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -815,7 +815,7 @@ class Manual_Synchronization extends Stepped_Job {
 		}
 
 		$start           = microtime( true );
-		$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $batches ) ) . time() . '_upsert_products' );
+		$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $batches ) ) . time() . '_upsert_products' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		$response        = wc_square()->get_api()->batch_upsert_catalog_objects( $idempotency_key, $batches );
 		$upsert_response = $response->get_data();
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1002,11 +1002,8 @@ class Manual_Synchronization extends Stepped_Job {
 	 * @return CatalogObject
 	 */
 	protected function convert_to_catalog_object( $object_data ) {
-		$object_data_string = is_string( $object_data ) ? $object_data : wp_json_encode( $object_data );
-		$object_data_obj    = is_string( $object_data ) ? json_decode( $object_data ) : $object_data;
-
-		$catalog_object = new CatalogObject( $object_data_obj->type, $object_data_obj->id );
-		$object         = ApiHelper::deserialize( $object_data_string, $catalog_object );
+		$object_data_obj = is_string( $object_data ) ? json_decode( $object_data ) : $object_data;
+		$object          = ApiHelper::getJsonHelper()->mapClass( $object_data_obj, 'Square\\Models\\CatalogObject' );
 
 		return $object instanceof CatalogObject ? $object : null;
 	}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR makes improvements to syncing Square products. It includes the following changes:

- Fixed deserialization of cached API response data.
- Fixed a potential issue related to an infinite loop during inventory pull.
- Reduced the maximum object retrieval limit from 100 to 50 to better support sites with low-resource servers.

### Steps to test the changes in this Pull Request:
1. Set up a Square dashboard with a large number of products (around 1k-5k).
2. Set up the Square extension and import products, ensuring that they are imported without any issues.
3. Perform a manual sync with Woo as the SOR and Square as the SOR, and ensure it works as expected.

### Changelog entry
> Fix – Ensure Square sync works without issues when using cached API responses.
> Fix - Avoid a potential infinite loop during inventory pull.
> Tweak - Change the maximum object retrieval limit from 100 to 50 to avoid timeout issues.