### PR TITLE
Remove woocommerce_loop_add_to_cart_link filter

### DIFF
--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -133,7 +133,6 @@ class Products {
 			add_filter( 'woocommerce_get_item_data', array( $this, 'add_sent_to_email_to_cart_item' ), 10, 2 );
 			add_filter( 'woocommerce_add_to_cart_sold_individually_found_in_cart', array( $this, 'limit_gift_card_quantity_in_cart' ), 10, 2 );
 			add_filter( 'woocommerce_order_item_needs_processing', array( $this, 'filter_needs_processing' ), 10, 2 );
-			add_filter( 'woocommerce_loop_add_to_cart_link', array( $this, 'filter_shop_page_add_to_cart_button' ), 10, 3 );
 			add_filter( 'woocommerce_single_product_image_thumbnail_html', array( $this, 'filter_single_product_featured_image_placeholder' ) );
 			add_filter( 'woocommerce_product_get_image', array( $this, 'filter_gift_card_product_featured_image_placeholder' ), 10, 3 );
 
@@ -1218,33 +1217,6 @@ class Products {
 		}
 
 		return $item_data;
-	}
-
-	/**
-	 * Replaces the `Add to cart` button on the shop page
-	 * to `Buy Gift Card` for a gift card product.
-	 *
-	 * @param string      $html    Add to Cart button HTML.
-	 * @param \WC_Product $product WooCommerce product.
-	 * @param array       $args    Attributes for the button.
-	 */
-	public function filter_shop_page_add_to_cart_button( $html, $product, $args ) {
-		if ( ! is_shop() ) {
-			return $html;
-		}
-
-		/** @var \WC_Product $product */
-		if ( ! Product::is_gift_card( $product ) ) {
-			return $html;
-		}
-
-		return sprintf(
-			'<a href="%s" class="%s" %s>%s</a>',
-			esc_url( $product->get_permalink() ),
-			'button wp-element-button',
-			isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
-			esc_html__( 'Buy Gift Card', 'woocommerce-square' )
-		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR removes the `woocommerce_loop_add_to_cart_link` filter and its associated functionality. The goal is to ensure consistent styling between the "Add to Cart" and "Buy Gift Card" buttons for all themes.

I found that the button "Buy Gift Card" was being rendered by [this piece of code](https://github.com/woocommerce/woocommerce-square/blob/trunk/includes/Handlers/Products.php#L1231-L1248) called by `woocommerce_loop_add_to_cart_link` filter.  This function was added on 2023 Jul 25 by [this PR](https://github.com/woocommerce/woocommerce-square-private/pull/1031) and the main idea was:
- Replacing "Add to Cart" button with "Buy Gift Card".
- Changing the link of the button to the product page instead of adding it to the cart, so users could fill in gift card.

Upon inspecting the rendered content, the "Buy Gift Card" button lacked several styling classes present on the "Add to Cart" button. Additionally, the "Add to Cart" button contained a nested `<span>` for the text, while the "Buy Gift Card" button did not. This would explain the "Buy Gift Card" button not matching the "Add to Cart" button styling. The first idea here was using the `WP_HTML_Tag_Processor` class to only change button text and link, trying a less visually impactful approach as all the parameters would be kept, instead of recreating the button as it's being done. 

After researching the code, I found that when attending to [this issue](https://github.com/woocommerce/woocommerce-square/issues/120), on 2024 Jun 24 [this PR](https://github.com/woocommerce/woocommerce-square/pull/139) added support for the product blocks, changing specifically button "Add to Cart" text and URL, targeting to the product page. A very clean approach, changing only what is necessary in the button.

Then I removed the filter, tested the following features on Block/FSE Themes TT5, TT4 and TT3 and it worked as expected, added by
- The "Add to Cart" button is correctly replaced by "Buy Gift Card" for Square Gift Card products.
- The "Buy Gift Card" button redirects users to the product page instead of directly adding it to the cart, ensuring that necessary input fields are filled on the product page.

I also tested on the TT1 Classic Theme and, although it isn't visually appealing, I confirm that main functionality is also working.

Given that, I understand that the filter `woocommerce_loop_add_to_cart_link` can be removed, as the main functionality is being covered by the code added by [this PR](https://github.com/woocommerce/woocommerce-square/pull/139) .

Closes #140.

### Steps to test the changes in this Pull Request
1. Activate TT4 (Twenty Twenty-Four) theme.
3. Switch to this branch on your local environment
4. Create a Square Gift Card product.
![image](https://github.com/user-attachments/assets/e5980e2a-578b-4ad6-88c2-ea8055a273c7)
5. Visit the Shop page and confirm the following:
   - A "Buy Gift Card" is being displayed for such product instead of "Add to Cart" button.
   - The "Buy Gift Card" button visually matches the "Add to Cart" button.
   - Clicking "Buy Gift Card" redirects to the product page where users can complete necessary input fields for the gift card.

#### Additional tests
1. Activate TT5, TT3, or TT1 Classic theme and repeat steps to confirm that functionality remains intact across Block/FSE and Classic themes.

### Changelog entry
> Fix - Remove `woocommerce_loop_add_to_cart_link` filter to standardize "Buy Gift Card" and "Add to Cart" button styles across themes.
