### PR TITLE
fix/12: reposition error notice on classic checkout page

### DIFF
--- a/src/js/frontend/wc-square.js
+++ b/src/js/frontend/wc-square.js
@@ -813,4 +813,97 @@ jQuery( document ).ready( ( $ ) => {
 	}
 
 	window.WC_Square_Payment_Form_Handler = WC_Square_Payment_Form_Handler;
+
+	/**
+	 * Handles Classic Checkout error notice positioning and scrolling for
+	 * Square Credit Card payment method, improving the user experience by
+	 * ensuring payment gateway errors are always visible without requiring
+	 * the user to scroll.
+	 */
+	class WC_Square_Classic_Checkout_Error_Handler {
+		static SELECTORS = {
+			PAYMENT_METHOD_CHECKBOX: '#payment_method_square_credit_card',
+			PAYMENT_METHOD_FORM: '#payment',
+			ERROR_NOTICE: '.woocommerce-NoticeGroup-checkout',
+		};
+
+		/**
+		 * Bind it to WC `checkout_error` event.
+		 */
+		static init() {
+			$( document.body ).on( 'checkout_error', () => {
+				if ( this.isSquareCreditCardPaymentSelected() ) {
+					this.handleCheckoutError();
+				}
+			} );
+		}
+
+		/**
+		 * Reposition and scroll to notice if it is offscreen.
+		 */
+		static handleCheckoutError() {
+			this.repositionNotice();
+			this.cancelAllScrolling();
+			if ( this.isNoticeOffscreen() ) {
+				this.scrollToNotice();
+			}
+		}
+
+		/**
+		 * Checks if Square Credit Card payment method is selected.
+		 *
+		 * @return {boolean} True if Square payment is selected
+		 */
+		static isSquareCreditCardPaymentSelected() {
+			const $paymentMethod = $( this.SELECTORS.PAYMENT_METHOD_CHECKBOX );
+			return $paymentMethod.length > 0 && $paymentMethod.is( ':checked' );
+		}
+
+		/**
+		 * Moves checkout notice above payment method form.
+		 */
+		static repositionNotice() {
+			const $notice = $( this.SELECTORS.ERROR_NOTICE );
+			const $paymentForm = $( this.SELECTORS.PAYMENT_METHOD_FORM );
+
+			if ( $notice.length && $paymentForm.length ) {
+				$notice.insertBefore( $paymentForm );
+			}
+		}
+
+		/**
+		 * WooCommerce triggers a scroll to the top of the page after
+		 * `checkout_error` event is triggered. This cancels all scrolling in the page.
+		 */
+		static cancelAllScrolling() {
+			$( 'html, body' ).stop();
+		}
+
+		/**
+		 * Check if error notice is offscreen.
+		 *
+		 * @return {boolean} True if error notice is offscreen.
+		 */
+		static isNoticeOffscreen() {
+			const $notice = $( this.SELECTORS.ERROR_NOTICE );
+			return $notice.length &&
+				(
+					$notice[ 0 ].getBoundingClientRect().bottom <= 0 ||
+					$notice[ 0 ].getBoundingClientRect().top >= window.innerHeight
+				);
+		}
+
+		/**
+		 * Scrolls to error notice if it is not visible on the viewport.
+		 */
+		static scrollToNotice() {
+			const $notice = $( this.SELECTORS.ERROR_NOTICE );
+			$notice[ 0 ].scrollIntoView( {
+				behavior: 'smooth',
+				block: 'start',
+			} );
+		}
+	}
+
+	WC_Square_Classic_Checkout_Error_Handler.init();
 } );


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR addresses the issue where payment gateway specific error messages are displayed out of context on the checkout page, improving the user experience by making error handling more intuitive and context-specific.

Initially, the idea was to highlight invalid fields in red, but this approach was not feasible due to the fields being embedded within an `iframe` hosted by Square. Limitations such as cross-origin restrictions and security concerns made this approach impractical.

The proposed solution ensures that error messages are repositioned near the payment method form, rather than appearing at the top of the page. This fix is specifically designed to work with the Classic Checkout Page.

This solution also overrides WooCommerce's default behavior of scrolling to the top of the page upon encountering errors. Instead, it scrolls to show the alert box only if any part of it is not visible within the viewport.

Additionally, it ensures that the Square credit card payment method is selected before repositioning the alert.

Closes #12.

### Steps to test the changes in this Pull Request:

We aim to verify the repositioning of error notices on the Classic Checkout Page when using the Square Credit Card payment method.

#### Local environment setup
1. **WooCommerce version**: Use WooCommerce version 9.4.2
2. **Square extension**: Ensure the Square WooCommerce extension is installed, activated and connected in sandbox mode.
3. **Themes**: Test using a variety of themes, such as Storefront, TT5, TT4, TT3, etc.
4. **Regenerate static assets**: Run `npm run build:dev` before testing as this pull request changed JavaScript source code, affecting build artifacts.

#### Testing steps

1. **Activate Square credit card payment method**
   - Enable **Square Credit Card** as the payment method and configure it to use Square sandbox.

2. **Enable "Detailed Decline Messages"**
   - In the Square settings, activate the *Detailed Decline Messages* option to ensure specific error details are displayed for failed transactions.

3. **Create an order**
   - Add a product to your cart 

4. **Open the classic checkout page**
   - Navigate to the classic checkout page on the frontend of the store.

5. **Choose Square Credit Card as the payment method**
   - Select (Square) **Credit Card** from the list of available payment methods on the checkout page.

6. **Fill in credit card data to generate errors**
   - Use the following test card data to simulate 03 errors:
     - *Card Number*: 4111 1111 1111 1111
     - *Expiration*: 01/40
     - *CVV*: 911
     - *Postal Code*: 99999
   - If additional error scenarios are needed, refer to the [Square sandbox error documentation](https://developer.squareup.com/docs/devtools/sandbox/payments#generating-error-states) for more test card data combinations.

7. **Verify error message behavior**
   - Confirm that error notices are correctly aligned and displayed near the payment form.
   - Check that error messages are formatted properly and easily readable.

8. **Confirm scrolling behavior**
   - Ensure that *if no part of the error message is visible* within the viewport, the page scrolls automatically to the top of the error notice. If any part of the error message is visible, the scrolling won't be toggled.
   - Validate that the error message is in focus and no part of it is cut off from view when scrolled.

9. **Test with different themes**
   - Repeat the above steps using a variety of themes, such as Storefront, TT5, TT4, TT3, etc.
   - Validate that the error notices display correctly and scrolling behavior works consistently across all themes.

10. **Expected outcome**
    - Error notices should reposition appropriately, display correctly, and remain functional across all tested themes.
    - The page should automatically scroll to the error message if it is *completely* outside the visible viewport.

![image](https://github.com/user-attachments/assets/4ef7984c-d5e2-492c-b5c8-583932521e21)
<sub><sup>(Ensure the error notice is shown near the payment fields and the page scrolls to it when no part of it is visible when placing the order)</sup></sub>

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Reposition payment error messages close to Payment Method form on the Classic Checkout page.
