### PR TITLE
[E2E] Fix test c3.woo-sor.spec-with-inventory > OnePlus 8 pushed to Square with inventory

### DIFF
--- a/tests/e2e/specs/c3.woo-sor.spec-with-inventory.spec.js
+++ b/tests/e2e/specs/c3.woo-sor.spec-with-inventory.spec.js
@@ -85,7 +85,7 @@ test( 'OnePlus 8 pushed to Square with inventory', async ( { page } ) => {
 	const { name, variations } = extractCatalogInfo( catalogData.objects[0] );
 
 	expect( name ).toEqual( 'OnePlus 8' );
-	expect( variations[ 0 ].sku ).toEqual( 'oneplus-8' ); 
+	expect( variations[ 0 ].sku ).toEqual( 'oneplus-8' );
 	expect( variations[ 0 ].price ).toEqual( 29900 );
 
 	let inventory = await retrieveInventoryCount( variations[ 0 ].id );

--- a/tests/e2e/specs/c3.woo-sor.spec-with-inventory.spec.js
+++ b/tests/e2e/specs/c3.woo-sor.spec-with-inventory.spec.js
@@ -55,38 +55,57 @@ test( 'OnePlus 8 pushed to Square with inventory', async ( { page } ) => {
 
 	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=square&section=update' );
 
-	const result = await new Promise( ( resolve ) => {
-		let intervalId = setInterval( async () => {
-			await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=square&section=update' );
-			const __result = await listCatalog();
-			if ( __result.objects ) {
-				clearInterval( intervalId );
-				resolve( __result );
-			}
-		}, 3000 );
-	} );
+	const MAX_PROCESSING_TIME = 90000;
+	const POLLING_INTERVAL_BETWEEN_RETRIES = 3000;
 
-	const {
-		name,
-		variations,
-	} = extractCatalogInfo( result.objects[0] );
+	const getCatalogData = async () => {
+		const result = await listCatalog();
+		return result;
+	};
+
+	// Expose getCatalogData function to page context
+	await page.exposeFunction('getCatalogData', getCatalogData);
+
+	const startTime = Date.now();
+	let catalogData = null;
+
+	while ( Date.now() - startTime < MAX_PROCESSING_TIME ) {
+		const result = await getCatalogData();
+		if ( result?.objects?.length > 0 ) {
+			catalogData = result;
+			break;
+		}
+		await page.waitForTimeout( POLLING_INTERVAL_BETWEEN_RETRIES );
+	}
+
+	if ( ! catalogData ) {
+		throw new Error( `No catalog items found after ${MAX_PROCESSING_TIME}ms of polling` );
+	}
+
+	const { name, variations } = extractCatalogInfo( catalogData.objects[0] );
 
 	expect( name ).toEqual( 'OnePlus 8' );
-	expect( variations[ 0 ].sku ).toEqual( 'oneplus-8' );
+	expect( variations[ 0 ].sku ).toEqual( 'oneplus-8' ); 
 	expect( variations[ 0 ].price ).toEqual( 29900 );
 
 	let inventory = await retrieveInventoryCount( variations[ 0 ].id );
 
+	// Poll for inventory data if not immediately available
 	if ( ! inventory.counts ) {
-		await new Promise( ( resolve ) => {
-			const inventoryIntervalId = setInterval( async () => {
-				inventory = await retrieveInventoryCount( variations[ 0 ].id );
-				if ( inventory.counts ) {
-					clearInterval( inventoryIntervalId );
-					resolve();
-				}
-			}, 4000 );
-		} );
+		// Expose retrieveInventoryCount to page context
+		await page.exposeFunction('retrieveInventoryCountInPage', retrieveInventoryCount);
+		
+		inventory = await page.waitForFunction(
+			async ( variationId ) => {
+				const inventoryData = await window.retrieveInventoryCountInPage( variationId );
+				return inventoryData.counts ? inventoryData : null;
+			},
+			variations[ 0 ].id,
+			{
+				timeout: MAX_PROCESSING_TIME,
+				polling: POLLING_INTERVAL_BETWEEN_RETRIES
+			}
+		).then( result => result.jsonValue() );
 	}
 
 	expect( inventory ).toHaveProperty( 'counts' );


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR intends to fix the failing E2E test `c3.woo-sor.spec-with-inventory.spec.js:53:5 › OnePlus 8 pushed to Square with inventory`. 

The failure was due to an issue in the test setup or assertions, and the changes ensure the test now passes successfully.

### Steps to test the changes in this Pull Request:

#### Prerequisites:
1. Ensure you have the appropriate environment for E2E testing with Square.

#### Testing steps
1. **Checkout the branch** associated with this PR.
2. **Run the specific test** using the following command:
   ```bash
   npx playwright test tests/e2e/specs/c3.woo-sor.spec-with-inventory.spec.js --config=tests/e2e/config/playwright.config.js --grep "OnePlus 8 pushed to Square with inventory"
   ```
3. You can also try **running all the tests in the file** using the following command:
   ```bash
   npx playwright test tests/e2e/specs/c3.woo-sor.spec-with-inventory.spec.js --config=tests/e2e/config/playwright.config.js
   ```

#### Expected outcome
The specific E2E test `c3.woo-sor.spec-with-inventory.spec.js:53:5 › OnePlus 8 pushed to Square with inventory` should pass successfully, confirming that the issue has been resolved.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Resolved the failing E2E test for `c3.woo-sor.spec-with-inventory.spec.js:53:5 › OnePlus 8 pushed to Square with inventory`.
