### PR TITLE
Fix product duplication issue on the Square side when WooCommerce is SOR.

### DIFF
--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -789,7 +789,7 @@ class Settings extends \WC_Settings_API {
 
 		$section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : false;  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( ! ( $this->is_admin_settings_screen() || ( $this->is_admin_settings_screen() && 'update' !== $section ) || $force ) ) {
+		if ( ! ( $this->is_admin_settings_screen() && ( $this->is_admin_settings_screen() && 'update' !== $section ) || $force ) ) {
 			$this->locations = get_transient( $locations_transient_key );
 		}
 

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -789,7 +789,7 @@ class Settings extends \WC_Settings_API {
 
 		$section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : false;  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( ! ( $this->is_admin_settings_screen() && ( $this->is_admin_settings_screen() && 'update' !== $section ) || $force ) ) {
+		if ( ! ( ( $this->is_admin_settings_screen() && 'update' !== $section ) || $force ) ) {
 			$this->locations = get_transient( $locations_transient_key );
 		}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -675,6 +675,9 @@ class Manual_Synchronization extends Stepped_Job {
 			}
 
 			$this->set_attr( 'in_progress_search_matched_products', $in_progress );
+		} else {
+			// No products to update, clear the in progress data.
+			$this->set_attr( 'in_progress_search_matched_products', null );
 		}
 
 		if ( ! $catalog_processed && ! empty( $remaining_product_ids ) ) {
@@ -833,6 +836,7 @@ class Manual_Synchronization extends Stepped_Job {
 				throw new \Exception( 'API response data is missing' );
 			}
 	
+			$in_progress['staged_product_ids']            = $staged_product_ids;
 			$in_progress['unprocessed_upsert_response'] = wp_json_encode( $upsert_response, JSON_PRETTY_PRINT );
 			$this->set_attr( 'in_progress_upsert_catalog_objects', $in_progress );
 	


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #232, when uploading or syncing new products with Square, issues arise when there are a large number of products to sync. The product sync fails, and duplicate products are created on the Square side. This occurred because the upsert limit was too high (500) for new products. As a result, the sync process experiences `429 Too Many Requests` errors sometimes. Additionally, in cases of successful requests, time and memory limitations prevent the Square item data from being stored in the product meta, causing the same product to be sent again for upsert, which leads to duplicate products. (It’s worth noting that Square allows the creation of products with the same SKU, which is unusual.)

This PR fixes the upsert process here and reduces the upsert limit from `500` to `25`, which enables the plugin to complete the upsert requests and update product data based on the response.

Closes #232.
Closes #247.
Closes #108.

### Steps to test the changes in this Pull Request:
1. Configure the plugin and set WooCommerce as the Source of Record (SOR).  
2. Create a large number of dummy products (2,000–3,000) using [WooCommerce Smooth Generator](https://github.com/woocommerce/wc-smooth-generator) or any other dummy data generation tool or just import products using CSV.
3. Enable sync for all products. (This could be done by passing "yes" under the "Sync with Square" column in CSV import in step 2)
4. Start a manual sync from the Square settings.  
5. Verify that the products are properly synced with Square and that no duplicate products are created on the Square side.

**#108**
1. Try sending too many requests to Square by following the steps [here](https://github.com/woocommerce/woocommerce-square-private/pull/1081#issue-1800438239).
1. Sending too many requests will result in 429 errors in sync. 
1. Verify no duplicate products are created on the Square side.

**#247**
1. Enable debug logs from Square settings.
2. Checkout to `trunk` branch
3. Visit `WooCommerce > Settings > Square > Update` page.
4. Notice there are logs for the `listLocations` API call.
5. Checkout to this branch.
6. Visit `WooCommerce > Settings > Square > Update` page.
7. Verify there is no log for the `listLocations` API call.
 
### Changelog entry
> Fix - Resolved the product duplication issue on the Square side when WooCommerce is set as the SOR.