### PR TITLE
Fix inventory sync for variable products when sync is enabled through quick or bulk edit.

### DIFF
--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -553,6 +553,11 @@ class Products {
 		if ( is_string( $square_synced ) ) {
 			$errors = $this->check_product_sync_errors( $product );
 			if ( 'no' === $square_synced || empty( $errors ) ) {
+				if ( 'yes' === $square_synced && $product->is_type( 'variable' ) && wc_square()->get_settings_handler()->is_inventory_sync_enabled() ) {
+					// if syncing inventory with Square, parent variable products don't manage stock
+					$product->set_manage_stock( false );
+				}
+
 				Product::set_synced_with_square( $product, $square_synced );
 			} elseif ( ! empty( $errors ) ) {
 				foreach ( $errors as $error ) {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #262, when marking a variable product as synced with Square via quick or bulk edit, if the variable product has stock management enabled at the parent level and one of its variations does not have `manage stock` enabled at the child level, the inventory syncs incorrectly with Square. Upon investigation, I found this occurs because the `manage stock` setting is not updated to `false` during quick or bulk edits, unlike when [updating](https://github.com/woocommerce/woocommerce-square/blob/trunk/includes/Handlers/Products.php#L600-L603) a product from the product edit page. This PR ensures that `manage stock` is set to `false` for the parent variable product when it is marked as synced with Square via quick or bulk edit and inventory sync is enabled. This change ensures consistent behavior and fixes the inventory sync issue.

Closes #262 

### Steps to test the changes in this Pull Request:
1. Create a variable product with stock management enabled at the parent level.  
2. Create two variations: one with stock management enabled and one with stock management disabled.  
3. Publish the product and go to the products list table.  
4. Enable "Sync with Square?" for the created product using bulk or quick edit.  
5. Check the Square dashboard to confirm that tracking is enabled for one variation and disabled for the other.  

### Changelog entry
> Fix - Ensure inventory sync works correctly for variable products when Square sync is enabled through quick or bulk edit.
