### PR TITLE
fix/85: unblock UI and show generic error when buyer verification fails

### DIFF
--- a/src/js/frontend/wc-square.js
+++ b/src/js/frontend/wc-square.js
@@ -314,6 +314,9 @@ jQuery( document ).ready( ( $ ) => {
 										false,
 										verificationResult
 									);
+								})
+								.catch(error => {
+									this.handle_errors([ error ]);
 								});
 						});
 					} else {
@@ -421,7 +424,10 @@ jQuery( document ).ready( ( $ ) => {
 							false,
 							verificationResult
 						);
-				});
+					})
+					.catch(error => {
+						this.handle_errors([ error ]);
+					});;
 			});
 		}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR unblocks the UI and shows a generic error on the Checkout page when the buyer verification fails.

Closes #85 

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. On `trunk`, perform a Checkout with the card `4310 0000 0020 1019`.
2. Cancel the verification Challenge once it shows up.
3. Observe the Checkout page being blocked.
4. Switch to the fix branch and repeat.
5. Observe the Checkout page is unblocked and the page shows a generic error.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Unblock the Checkout page UI, and show a generic error when buyer verification fails.
