### PR TITLE
Move to `@woocommerce/e2e-utils-playwright`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@playwright/test": "^1.44.1",
         "@woocommerce/dependency-extraction-webpack-plugin": "^3.0.1",
+        "@woocommerce/e2e-utils-playwright": "^0.2.1",
         "@woocommerce/eslint-plugin": "^2.3.0",
         "@wordpress/env": "^10.0.0",
         "@wordpress/scripts": "^24.6.0",
@@ -6421,6 +6422,17 @@
       "engines": {
         "node": "^20.11.1",
         "pnpm": "^8.12.1"
+      }
+    },
+    "node_modules/@woocommerce/e2e-utils-playwright": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@woocommerce/e2e-utils-playwright/-/e2e-utils-playwright-0.2.1.tgz",
+      "integrity": "sha512-YdcUPOMXAF145J+3dm2mEaKlpzH3OByHtyAmiU2Qx2Tll+x06iTB8V4r3quHh+ErtLDU8K9Oh3Olf0wFZosf/A==",
+      "dev": true,
+      "license": "GPL-3.0+",
+      "engines": {
+        "node": "^20.11.1",
+        "pnpm": "9.1.3"
       }
     },
     "node_modules/@woocommerce/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@playwright/test": "^1.44.1",
     "@woocommerce/dependency-extraction-webpack-plugin": "^3.0.1",
+    "@woocommerce/e2e-utils-playwright": "^0.2.1",
     "@woocommerce/eslint-plugin": "^2.3.0",
     "@wordpress/env": "^10.0.0",
     "@wordpress/scripts": "^24.6.0",

--- a/tests/e2e/specs/a6.transaction-authorize.spec.js
+++ b/tests/e2e/specs/a6.transaction-authorize.spec.js
@@ -1,5 +1,6 @@
 import { chromium } from 'playwright';
 import { test, expect } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	createProduct,
 	doesProductExist,
@@ -60,8 +61,7 @@ for ( const isBlock of isBlockCheckout ) {
 	test( title + 'Payment Gateway > Transaction Type > Authorization @general', async ( {
 		page,
 	} ) => {
-		await page.goto( '/product/simple-product' );
-		await page.locator( '.single_add_to_cart_button' ).click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 
 		await visitCheckout( page, isBlock );
 		await fillAddressFields( page, isBlock );

--- a/tests/e2e/specs/a7.transaction-authorize-virtual-only.spec.js
+++ b/tests/e2e/specs/a7.transaction-authorize-virtual-only.spec.js
@@ -1,5 +1,6 @@
 import { chromium } from 'playwright';
 import { test, expect } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	createProduct,
 	doesProductExist,
@@ -53,8 +54,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 test( 'Payment Gateway > Transaction Type > Authorization + Virtual Only @general', async ( {
 	page,
 } ) => {
-	await page.goto( '/product/virtual-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'virtual-product' );
 
 	await visitCheckout( page, false );
 	await fillAddressFields( page, false );
@@ -93,8 +93,7 @@ test( 'Payment Gateway > Transaction Type > Authorization + Virtual Only but cha
 
 	await savePaymentGatewaySettings( page );
 
-	await page.goto( '/product/virtual-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'virtual-product' );
 
 	await visitCheckout( page, false );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/a8.transaction-authorize-paid-order.spec.js
+++ b/tests/e2e/specs/a8.transaction-authorize-paid-order.spec.js
@@ -1,5 +1,6 @@
 import { chromium } from 'playwright';
 import { test, expect } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	createProduct,
 	doesProductExist,
@@ -47,8 +48,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 test( 'Payment Gateway > Transaction Type > Authorization + Capture Paid Orders @general', async ( {
 	page,
 } ) => {
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 
 	await visitCheckout( page, false );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/a9.transaction-capture.spec.js
+++ b/tests/e2e/specs/a9.transaction-capture.spec.js
@@ -1,5 +1,6 @@
 import { chromium } from 'playwright';
 import { test, expect } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	fillAddressFields,
 	fillCreditCardFields,
@@ -31,8 +32,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 test( 'Payment Gateway > Transaction Type > Authorization @general', async ( {
 	page,
 } ) => {
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 
 	await visitCheckout( page, false );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/a91.card-logos.spec.js
+++ b/tests/e2e/specs/a91.card-logos.spec.js
@@ -1,11 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import { savePaymentGatewaySettings } from '../utils/helper';
 
 
 test( 'Payment Gateway - Accepted Card Logos @general', async ( { page } ) => {
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 	await page.goto( '/checkout-old' );
 
 	await expect(

--- a/tests/e2e/specs/a92.currency-support.spec.js
+++ b/tests/e2e/specs/a92.currency-support.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	visitCheckout,
@@ -26,8 +27,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 test( 'Square credit card should available only for the supported currencies @general', async ( { page } ) => {
 	// Update currency to INR
 	await runWpCliCommand('wp option update woocommerce_currency "INR"');
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 	// Confirm that the Credit card is not visible on checkout page.
 	await visitCheckout(page, false);
 	await expect(

--- a/tests/e2e/specs/a93.credit-card-form-fields.spec.js
+++ b/tests/e2e/specs/a93.credit-card-form-fields.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	visitCheckout,
@@ -23,8 +24,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 } );
 
 test( 'Verify square credit card form fields @general', async ( { page } ) => {
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 	// Confirm that the Credit card is not visible on checkout page.
 	await visitCheckout(page, true);
 	

--- a/tests/e2e/specs/b1.tokenization.spec.js
+++ b/tests/e2e/specs/b1.tokenization.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	fillAddressFields,
@@ -45,8 +46,7 @@ for ( const isBlock of isBlockCheckout ) {
 
 	test( title + 'Payment Gateway - Customer Profiles @general', async ( { page } ) => {
 		await deleteAllPaymentMethods( page );
-		await page.goto( '/product/simple-product' );
-		await page.locator( '.single_add_to_cart_button' ).click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout( page, isBlock );
 
 		await fillAddressFields( page, isBlock );
@@ -79,8 +79,7 @@ for ( const isBlock of isBlockCheckout ) {
 	} );
 
 	test( title + 'Checkout using saved card @general', async ( { page } ) => {
-		await page.goto( '/product/simple-product' );
-		await page.locator( '.single_add_to_cart_button' ).click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout( page, isBlock );
 
 		if ( isBlock ) {

--- a/tests/e2e/specs/b3.gift-card-full-payment.spec.js
+++ b/tests/e2e/specs/b3.gift-card-full-payment.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	createProduct,
@@ -40,8 +41,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 let orderId;
 
 test( 'Gift card - Full payment @giftcard', async ( { page } ) => {
-	await page.goto( '/product/dollar-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'dollar-product' );
 
 	await page.goto( '/checkout-old' );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/b4.gift-card-partial-payment.spec.js
+++ b/tests/e2e/specs/b4.gift-card-partial-payment.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	createProduct,
@@ -43,8 +44,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 let orderId = 0;
 
 test( 'Gift card - Partial payment @giftcard', async ( { page } ) => {
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 
 	await page.goto( '/checkout-old' );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/b5.gift-card-full-refund.spec.js
+++ b/tests/e2e/specs/b5.gift-card-full-refund.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	createProduct,
@@ -41,8 +42,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 
 test( 'Full Refund Gift card order @giftcard', async ( { page } ) => {
 	page.on('dialog', dialog => dialog.accept());
-	await page.goto( '/product/dollar-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'dollar-product' );
 
 	await page.goto( '/checkout-old' );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/b6.gift-card-partial-refund.spec.js
+++ b/tests/e2e/specs/b6.gift-card-partial-refund.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	createProduct,
@@ -41,8 +42,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 
 test( 'Partial Refund – Gift card order @giftcard', async ( { page } ) => {
 	page.on('dialog', dialog => dialog.accept());
-	await page.goto( '/product/dollar-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'dollar-product' );
 
 	await page.goto( '/checkout-old' );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/b7.gift-card-partial-payment-partial-refund.spec.js
+++ b/tests/e2e/specs/b7.gift-card-partial-payment-partial-refund.spec.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { chromium } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	createProduct,
@@ -42,8 +43,7 @@ test.beforeAll( 'Setup', async ( { baseURL } ) => {
 
 test( 'Gift card - Partial payment @giftcard', async ( { page } ) => {
 	page.on('dialog', dialog => dialog.accept());
-	await page.goto( '/product/simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 
 	await page.goto( '/checkout-old' );
 	await fillAddressFields( page, false );

--- a/tests/e2e/specs/d1.cash-app-pay.spec.js
+++ b/tests/e2e/specs/d1.cash-app-pay.spec.js
@@ -1,4 +1,5 @@
 import { test, expect, devices, chromium } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	clearCart,
 	createProduct,
@@ -54,8 +55,7 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 			enabled: false,
 		});
 
-		await page.goto('/product/simple-product');
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 
 		// Confirm that the Cash App Pay is not visible on checkout page.
 		await visitCheckout(page, false);
@@ -305,8 +305,7 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 					...iPhone,
 				});
 				const page = await context.newPage();
-				await page.goto('/product/simple-product');
-				await page.locator('.single_add_to_cart_button').click();
+				await addOneOrMoreProductToCart( page, 'simple-product' );
 				await visitCheckout(page, isBlock);
 				await fillAddressFields(page, isBlock);
 				await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
@@ -332,8 +331,7 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 				...iPhone,
 			});
 			const page = await context.newPage();
-			await page.goto('/product/simple-product');
-			await page.locator('.single_add_to_cart_button').click();
+			await addOneOrMoreProductToCart( page, 'simple-product' );
 			await expect(
 				page.getByRole('link', { name: 'View cart' }).first()
 			).toBeVisible();
@@ -366,9 +364,8 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 		});
 		const page = await context.newPage();
 		await clearCart( page );
-		await page.goto('/product/simple-product');
 		page.on('dialog', dialog => dialog.accept());
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
@@ -388,9 +385,8 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 			...iPhone,
 		});
 		const page = await context.newPage();
-		await page.goto('/product/simple-product');
 		page.on('dialog', dialog => dialog.accept());
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);

--- a/tests/e2e/specs/d2.cash-app-pay-inventory-sync.spec.js
+++ b/tests/e2e/specs/d2.cash-app-pay-inventory-sync.spec.js
@@ -94,9 +94,8 @@ test.describe('Cash App Pay Inventory Sync Tests', () => {
 			...iPhone,
 		});
 		const mobilePage = await context.newPage();
-		await mobilePage.goto('/product/sample-product-with-inventory/');
 		mobilePage.on('dialog', (dialog) => dialog.accept());
-		await mobilePage.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( mobilePage, 'sample-product-with-inventory' );
 		await visitCheckout(mobilePage, isBlock);
 		await fillAddressFields(mobilePage, isBlock);
 		await selectPaymentMethod(mobilePage, 'square_cash_app_pay', isBlock);

--- a/tests/e2e/specs/d3.cash-app-pay-trasaction-type.spec.js
+++ b/tests/e2e/specs/d3.cash-app-pay-trasaction-type.spec.js
@@ -1,4 +1,5 @@
 import { test, expect, devices, chromium } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	clearCart,
 	createProduct,
@@ -84,8 +85,7 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 					...iPhone,
 				});
 				const page = await context.newPage();
-				await page.goto('/product/simple-product');
-				await page.locator('.single_add_to_cart_button').click();
+				await addOneOrMoreProductToCart( page, 'simple-product' );
 				await visitCheckout(page, isBlock);
 				await fillAddressFields(page, isBlock);
 				await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
@@ -130,8 +130,7 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 			chargeVirtualOrders: true,
 		});
 
-		await page.goto('/product/virtual-product');
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'virtual-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);
@@ -163,8 +162,7 @@ test.describe('Cash App Pay Tests @cashapp', () => {
 			capturePaidOrders: true,
 		});
 
-		await page.goto('/product/simple-product');
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await selectPaymentMethod(page, 'square_cash_app_pay', isBlock);

--- a/tests/e2e/specs/d4.cash-app-pay-partial-gift-card.spec.js
+++ b/tests/e2e/specs/d4.cash-app-pay-partial-gift-card.spec.js
@@ -1,4 +1,5 @@
 import { test, expect, devices, chromium } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 import {
 	clearCart,
 	createProduct,
@@ -69,8 +70,7 @@ test.describe('Cash App Pay - Gift Card Tests @cashapp @giftcard', () => {
 			...iPhone,
 		});
 		const page = await context.newPage();
-		await page.goto('/product/simple-product');
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await fillGiftCardField( page );
@@ -107,8 +107,7 @@ test.describe('Cash App Pay - Gift Card Tests @cashapp @giftcard', () => {
 			...iPhone,
 		});
 		const page = await context.newPage();
-		await page.goto('/product/simple-product');
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await fillGiftCardField( page );
@@ -146,8 +145,7 @@ test.describe('Cash App Pay - Gift Card Tests @cashapp @giftcard', () => {
 			transactionType: 'authorization',
 		});
 
-		await page.goto('/product/simple-product');
-		await page.locator('.single_add_to_cart_button').click();
+		await addOneOrMoreProductToCart( page, 'simple-product' );
 		await visitCheckout(page, isBlock);
 		await fillAddressFields(page, isBlock);
 		await fillGiftCardField( page );

--- a/tests/e2e/specs/digital-wallets-cart.js
+++ b/tests/e2e/specs/digital-wallets-cart.js
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { firefox } from 'playwright';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 import {
 	doesProductExist,
@@ -31,8 +32,7 @@ test( 'Digital Wallet - Cart @general', async () => {
 	const browser = await firefox.launch();
 	const page = await browser.newPage();
 
-	await page.goto( 'simple-product' );
-	await page.locator( '.single_add_to_cart_button' ).click();
+	await addOneOrMoreProductToCart( page, 'simple-product' );
 
 	await page.goto( '/cart' );
 	await page.waitForSelector( '.gpay-card-info-container-fill', { state: 'visible' } );

--- a/tests/e2e/specs/e1.subscriptions.spec.js
+++ b/tests/e2e/specs/e1.subscriptions.spec.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const { test, expect, chromium } = require('@playwright/test');
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
 
 /**
  * Internal dependencies
@@ -57,8 +58,7 @@ test.describe('Subscriptions Tests @general', () => {
 					test.skip();
 				}
 
-				await page.goto('/product/simple-subscription-product');
-				await page.locator('.single_add_to_cart_button').click();
+				await addOneOrMoreProductToCart( page, 'simple-subscription-product' );
 				await expect(
 					page.getByRole('link', { name: 'View cart' }).first()
 				).toBeVisible();
@@ -100,8 +100,7 @@ test.describe('Subscriptions Tests @general', () => {
 			title +
 				'Customer can sign up to subscription using Saved CreditCard',
 			async ({ page }) => {
-				await page.goto('/product/simple-subscription-product');
-				await page.locator('.single_add_to_cart_button').click();
+				await addOneOrMoreProductToCart( page, 'simple-subscription-product' );
 				await expect(
 					page.getByRole('link', { name: 'View cart' }).first()
 				).toBeVisible();

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -1,6 +1,7 @@
 import fetch from 'node-fetch';
 import dummy from '../dummy-data';
 import { expect } from '@playwright/test';
+
 const { promisify } = require('util');
 const execAsync = promisify(require('child_process').exec);
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements the new `@woocommerce/e2e-utils-playwright` package.

We're not using all the utils from the E2E package, as Square requires "delays" to fill address fields on the Checkout page to prevent the card field from rendering multiple times.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

See if the E2E actions pass.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Use the `@woocommerce/e2e-utils-playwright` NPM package for E2E tests.
