### PR TITLE
Fix "Translation loading for the woocommerce-square domain was triggered too early" error on WP 6.7

### DIFF
--- a/includes/Admin/Privacy.php
+++ b/includes/Admin/Privacy.php
@@ -40,18 +40,27 @@ class Privacy extends \WC_Abstract_Privacy {
 	 */
 	public function __construct() {
 
-		parent::__construct( __( 'Square', 'woocommerce-square' ) );
+		parent::__construct();
+
+		// Initialize data exporters and erasers.
+		add_action( 'init', array( $this, 'register_erasers_exporters' ) );
+	}
+
+	/**
+	 * Initial registration of privacy erasers and exporters.
+	 */
+	public function register_erasers_exporters() {
+		$this->name = __( 'Square', 'woocommerce-square' );
 
 		$this->add_eraser( 'woocommerce-square-customer-data', __( 'WooCommerce Square Customer Data', 'woocommerce-square' ), array( $this, 'customer_data_eraser' ) );
 	}
-
 
 	/**
 	 * Gets the message to display.
 	 *
 	 * @since 2.0.0
 	 */
-	public function get_message() {
+	public function get_privacy_message() {
 
 		return wpautop(
 			sprintf(
@@ -98,7 +107,4 @@ class Privacy extends \WC_Abstract_Privacy {
 			'done'           => true,
 		);
 	}
-
-
 }
-

--- a/includes/Framework/PaymentGateway/Payment_Gateway_Privacy.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Privacy.php
@@ -46,19 +46,11 @@ class Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 
 		$this->plugin = $plugin;
 
-		parent::__construct( $plugin->get_plugin_name() );
+		parent::__construct();
 
 		// add the action & filter hooks
 		$this->add_hooks();
-
-		// add the token exporters & erasers
-		// translators: Placeholder %s - Plugin name
-		$this->add_exporter( "wc-{$plugin->get_id_dasherized()}-customer-tokens", sprintf( esc_html__( '%s Payment Tokens', 'woocommerce-square' ), $plugin->get_plugin_name() ), array( $this, 'customer_tokens_exporter' ) );
-
-		// translators: Placeholder %s - Plugin name
-		$this->add_eraser( "wc-{$plugin->get_id_dasherized()}-customer-tokens", sprintf( esc_html__( '%s Payment Tokens', 'woocommerce-square' ), $plugin->get_plugin_name() ), array( $this, 'customer_tokens_eraser' ) );
 	}
-
 
 	/**
 	 * Adds the action & filter hooks.
@@ -66,6 +58,8 @@ class Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 	 * @since 3.0.0
 	 */
 	protected function add_hooks() {
+		// Initialize data exporters and erasers.
+		add_action( 'init', array( $this, 'register_erasers_exporters' ) );
 
 		// add the gateway data to customer data exports
 		add_filter( 'woocommerce_privacy_export_customer_personal_data', array( $this, 'add_export_customer_data' ), 10, 2 );
@@ -78,6 +72,20 @@ class Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 
 		// removes the gateway data during an order data erasure
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this, 'remove_order_personal_data' ) );
+	}
+
+	/**
+	 * Initial registration of privacy erasers and exporters.
+	 */
+	public function register_erasers_exporters() {
+		$this->name = $this->plugin->get_plugin_name();
+
+		// add the token exporters & erasers
+		// translators: Placeholder %s - Plugin name
+		$this->add_exporter( "wc-{$this->plugin->get_id_dasherized()}-customer-tokens", sprintf( esc_html__( '%s Payment Tokens', 'woocommerce-square' ), $this->plugin->get_plugin_name() ), array( $this, 'customer_tokens_exporter' ) );
+
+		// translators: Placeholder %s - Plugin name
+		$this->add_eraser( "wc-{$this->plugin->get_id_dasherized()}-customer-tokens", sprintf( esc_html__( '%s Payment Tokens', 'woocommerce-square' ), $this->plugin->get_plugin_name() ), array( $this, 'customer_tokens_eraser' ) );
 	}
 
 

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -71,24 +71,32 @@ class Products {
 
 		$this->plugin = $plugin;
 
-		// add common errors
-		$this->product_errors = array(
-			/* translators: Placeholder: %s - product name */
-			'missing_sku'           => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
-			/* translators: Placeholder: %s - product name */
-			'missing_variation_sku' => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
-		);
-
 		// Get gift card features status.
 		$gift_card_settings      = get_option( Gift_Card::SQUARE_PAYMENT_SETTINGS_OPTION_NAME, array() );
 		$this->gift_card_enabled = $gift_card_settings['enabled'] ?? 'no';
 
+		add_action( 'init', array( $this, 'register_common_errors' ) );
 		add_action( 'current_screen', array( $this, 'add_tabs' ), 99 );
 
 		// add hooks
 		$this->add_products_edit_screen_hooks();
 		$this->add_product_edit_screen_hooks();
 		$this->add_product_sync_hooks();
+	}
+
+	/**
+	 * Loads register common errors.
+	 *
+	 * @since x.x.x
+	 */
+	public function register_common_errors() {
+		// Add common errors.
+		$this->product_errors = array(
+			/* translators: Placeholder: %s - product name */
+			'missing_sku'           => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			/* translators: Placeholder: %s - product name */
+			'missing_variation_sku' => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
In WordPress 6.7, they [changed the way translations are loaded](https://core.trac.wordpress.org/changeset/59127) which affects how and when translation strings should be triggered. With this change, any `__()` code called before the `after_setup_theme` is considered "too early" and will need to be updated to happen on a later hook. This PR updates code to fix these too-early translation notices.

Closes #258 

### Steps to test the changes in this Pull Request:
1. Ensure `define( 'WP_DEBUG', true );` is set in `wp-config.php`.  
2. Update to the latest version of WordPress 6.7.  
3. Navigate to your Edit User Profile page and update the language to something other than "English."  
4. Ensure there are no notices on the WordPress admin screen.

### Changelog entry
> Fix - Resolved "translation loading was triggered too early" issue in WordPress 6.7.