### PR TITLE
Ensure the correct UI is shown in the new WooCommerce payments settings.

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -4807,4 +4807,36 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 		}
 	}
 
+	/**
+	 * Check if the gateway has an account connected.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool true if the gateway has an account connected, false otherwise.
+	 */
+	public function is_account_connected() {
+		return $this->get_plugin()->get_settings_handler()->is_connected() && $this->get_plugin()->get_settings_handler()->get_location_id();;
+	}
+
+	/**
+	 * Returns true if the current gateway environment is configured to 'sandbox'
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool true if the current environment is test environment.
+	 */
+	public function is_in_test_mode() {
+		return $this->get_plugin()->get_settings_handler()->is_sandbox();
+	}
+
+	/**
+	 * Determine if the gateway still requires setup.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool tue if the gateway still requires setup, false otherwise.
+	 */
+	public function needs_setup() {
+		return ( ! $this->is_account_connected() );
+	}
 }

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -4815,7 +4815,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	 * @return bool true if the gateway has an account connected, false otherwise.
 	 */
 	public function is_account_connected() {
-		return $this->get_plugin()->get_settings_handler()->is_connected() && $this->get_plugin()->get_settings_handler()->get_location_id();;
+		return $this->get_plugin()->get_settings_handler()->is_connected() && $this->get_plugin()->get_settings_handler()->get_location_id();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
WooCommerce is modernizing the WooCommerce Payments experience with a new React-based interface for the core WooCommerce Payments settings page. This PR makes changes to ensure that payment methods added by this extension are shown correctly in the new UI.

> [!Note]
Since the Square account connection settings are located on the Square settings page rather than in individual payment gateway settings, the "Complete setup" button should redirect to the Square settings instead of the individual payment gateway settings page. However, on the current classic payment settings page, the "Finish setup" button also redirects to the individual settings page. We can ignore this for now, but I just want to add a note to consider it for future enhancements.

Closes #281 

### Steps to test the changes in this Pull Request:
Verify that the payment methods list displays the correct buttons and statuses for each payment method.  

- If the Square credentials are not set or the Square account is not connected, display the **"Complete setup"** button and the **"Action required"** status.  
![Screenshot 2025-02-07 at 7 22 35 PM](https://github.com/user-attachments/assets/29c17db7-f1b6-46c2-988c-a17083c8d0ec)

- If the Square account is configured but the method is not enabled, display the **"Enable"** and **"Manage"** buttons with an **Inactive** status.  
![image](https://github.com/user-attachments/assets/c1f71ec7-0288-4e34-8629-e07726a87988)

- If the payment method credentials are configured and the method is enabled, display the **"Manage"** button with an **"Active"** status for production and **"Test Mode"** for the sandbox environment.  
    - Sandbox
![image](https://github.com/user-attachments/assets/b14ca528-b410-4907-a3b9-37b225b1bb5b)

    - Production
![image](https://github.com/user-attachments/assets/5d1c5f5e-b420-4894-8202-4265ebc404aa)

### Changelog entry
> Fix - Ensure payment methods display the correct buttons and statuses in the new WooCommerce Payments settings.
