### PR TITLE
Ensure that Cash App Pay works as expected on mobile device.

### DIFF
--- a/src/blocks/cash-app-pay/utils.js
+++ b/src/blocks/cash-app-pay/utils.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getSetting } from '@woocommerce/settings';
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -166,15 +166,18 @@ export const log = ( data, type = 'notice' ) => {
  * Select the Cash App Pay payment method if the continuation session is set.
  */
 export const selectCashAppPaymentMethod = () => {
-	const payMethodInput =
-		document &&
-		document.getElementById(
-			'radio-control-wc-payment-method-options-square_cash_app_pay'
-		);
+	const availablePaymentMethods =
+		select( PAYMENT_STORE_KEY ).getAvailablePaymentMethods();
+	const availableMethodKeys = Object.keys( availablePaymentMethods || {} );
+
+	// Bail if the Cash App Pay payment method is not available.
+	if ( ! availableMethodKeys.includes( PAYMENT_METHOD_ID ) ) {
+		return;
+	}
+
 	if (
 		getSquareCashAppPayServerData().isContinuation &&
-		! window.wcSquareCashAppPaySelected &&
-		payMethodInput
+		! window.wcSquareCashAppPaySelected
 	) {
 		log( '[Square Cash App Pay] Selecting Cash App Pay payment method' );
 		dispatch( PAYMENT_STORE_KEY ).__internalSetActivePaymentMethod(


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As mentioned [here](https://github.com/woocommerce/woocommerce-square/pull/287#issuecomment-2668450606), Cash App Pay is not working after redirecting back to the store in WooCommerce 9.7 RC-1. This PR improves how the payment method is selected after the redirect from the Cash App and fixes the issue to ensure it works as expected.

### Steps to test the changes in this Pull Request:
1. Update to WooCommerce 9.7 RC-1
1. Set up Cash app Pay and verify that it works fine on mobile devices and desktop browsers.
1. Downgrate WooCommerce to the minimum supported version.
1. Verify that Cash app pay works fine on mobile devices and desktop browsers.

### Changelog entry
> Fix - Ensure that Cash App Pay works as expected on mobile devices.
