### PR TITLE
Ensure that no blank order is created via the "Add Payment Method" when HPOS is enabled.

### DIFF
--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -1116,8 +1116,8 @@ class Gateway extends Payment_Gateway_Direct {
 	 * Returns the $order object with a unique transaction ref member added
 	 *
 	 * @since 2.2.1
-	 * @param WC_Order $order the order object
-	 * @return WC_Order order object with member named unique_transaction_ref
+	 * @param \WC_Order $order the order object
+	 * @return \WC_Order order object with member named unique_transaction_ref
 	 */
 	protected function get_order_with_unique_transaction_ref( $order ) {
 		$order_id = $order->get_id();
@@ -1131,7 +1131,9 @@ class Gateway extends Payment_Gateway_Direct {
 		}
 
 		// keep track of the retry count
-		$this->update_order_meta( $order, 'retry_count', $retry_count );
+		if ( $order_id > 0 ) {
+			$this->update_order_meta( $order, 'retry_count', $retry_count );
+		}
 
 		$order->unique_transaction_ref = time() . '-' . $order_id . ( $retry_count >= 0 ? '-' . $retry_count : '' );
 		return $order;

--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -1131,7 +1131,7 @@ class Gateway extends Payment_Gateway_Direct {
 		}
 
 		// keep track of the retry count
-		if ( $order_id > 0 ) {
+		if ( $order_id > 0 ) { // TODO: look to remove this once fix is in Woo and is our minimum version. See https://github.com/woocommerce/woocommerce/issues/55728 for tracking.
 			$this->update_order_meta( $order, 'retry_count', $retry_count );
 		}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in https://github.com/woocommerce/woocommerce/issues/55728, when HPOS is enabled, adding a card via the "Add Payment Method" page under My Account creates blank orders. Initially, this issue was reported in this repository, but it was later moved to the WooCommerce core repository for potential improvements. While the core fix will ultimately resolve the issue here as well, it will be included in a future WooCommerce release. Since we support a minimum WooCommerce version of L-2, this PR has been raised to fix the issue until the fixed version becomes the minimum supported version.

Additionally, when using the "Add Payment Method" operation, meta data should not be updated. This PR addresses that as well.

### Steps to test the changes in this Pull Request:
1. Enable HPOS.  
2. Configure the Square Credit Card payment gateway with "Customer Profiles" enabled.  
3. Navigate to **My Account > Payment Methods > Add Payment Method**.  
4. Add a new credit card payment method.  
5. Go to **WooCommerce > Orders** and verify that no blank order is created.

### Changelog entry
> Fix - Ensure that no blank order is created via the "Add Payment Method" when HPOS is enabled.
