### PR TITLE
Fix deprecated PHP error in WooCommerce Square plugin

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -260,6 +260,12 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	/** @var string order note for the voided order. */
 	protected $voided_order_message;
 
+	/** @var string Gift card product default placeholder provided by the plugin. */
+	protected $is_default_placeholder;
+
+	/** @var integer ID of the placeholder media. */
+	protected $placeholder_id;
+
 	/**
 	 * Initialize the gateway
 	 *


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #270

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Enable the WooCommerce Square plugin.
1. Monitor the Query Monitor for PHP errors. 

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Deprecated PHP error for Gift Cards.
