### PR TITLE
Improve E2E test setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
         run: npm ci && npm run build
 
       - name: Install playwright
-        run: npx playwright install
+        run: npx playwright install --with-deps chromium
 
       # Use compiled versions to avoid need for npm and composer installation and build step.
       - name: Install required WP plugins

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,9 +49,8 @@ jobs:
       # Use compiled versions to avoid need for npm and composer installation and build step.
       - name: Install required WP plugins
         run: |
-          ls -l
-          gh release download --repo woocommerce/woocommerce-pre-orders --pattern  woocommerce-pre-orders.zip --dir ./wordpress/wp-content/plugins/
-          gh release download --repo woocommerce/woocommerce-subscriptions --pattern  woocommerce-subscriptions.zip --dir ./wordpress/wp-content/plugins/
+          gh release download --repo woocommerce/woocommerce-pre-orders --pattern  woocommerce-pre-orders.zip --dir ./test-plugins
+          gh release download --repo woocommerce/woocommerce-subscriptions --pattern  woocommerce-subscriptions.zip --dir ./test-plugins
           cd ./test-plugins
           unzip -o woocommerce-pre-orders.zip
           unzip -o woocommerce-subscriptions.zip

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,8 +49,9 @@ jobs:
       # Use compiled versions to avoid need for npm and composer installation and build step.
       - name: Install required WP plugins
         run: |
-          gh release download --repo woocommerce/woocommerce-pre-orders --pattern  woocommerce-pre-orders.zip --dir ./test-plugins
-          gh release download --repo woocommerce/woocommerce-subscriptions --pattern  woocommerce-subscriptions.zip --dir ./test-plugins
+          ls -l
+          gh release download --repo woocommerce/woocommerce-pre-orders --pattern  woocommerce-pre-orders.zip --dir ./wordpress/wp-content/plugins/
+          gh release download --repo woocommerce/woocommerce-subscriptions --pattern  woocommerce-subscriptions.zip --dir ./wordpress/wp-content/plugins/
           cd ./test-plugins
           unzip -o woocommerce-pre-orders.zip
           unzip -o woocommerce-subscriptions.zip

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -10,7 +10,14 @@
 		"tests": {
 			"mappings": {
 				"wp-cli.yml": "./tests/e2e/config/wp-cli.yml"
-			}
+			},
+			"plugins": [
+				"https://downloads.wordpress.org/plugin/woocommerce.zip",
+				"https://downloads.wordpress.org/plugin/email-log.zip",
+				".",
+				"./test-plugins/woocommerce-subscriptions",
+				"./test-plugins/woocommerce-pre-orders"
+			]
 		}
 	},
 	"config": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -3,9 +3,7 @@
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/woocommerce.zip",
 		"https://downloads.wordpress.org/plugin/email-log.zip",
-		".",
-		"./test-plugins/woocommerce-subscriptions",
-		"./test-plugins/woocommerce-pre-orders"
+		"."
 	],
 	"themes": [ "https://downloads.wordpress.org/theme/storefront.zip" ],
 	"env": {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR improves the E2E setup. Currently, when running `npm run env:start` to spin up the WP-ENV for the development version, `.wp-env.json` attempts to load the `woocommerce-subscriptions` and `woocommerce-pre-orders` plugins, which are required for E2E tests (introduced in PR #152). However, these plugins are not needed in the development environment. Since they are defined in `.wp-env.json`, the environment tries to load them, resulting in the following error:

```
Warning: The 'woocommerce-subscriptions' plugin could not be found.
Error: No plugins activated.
```

Although these plugins can be installed using `npm run env:install-plugins`, they are only necessary for testing and not for development. This PR ensures that these plugins are only added in the test container, preventing them from being loaded in the development environment and avoiding the error.

Additionally, Playwright installs unnecessary browsers by default and generates warnings during execution. See [[this GitHub Actions run](https://github.com/woocommerce/woocommerce-square/actions/runs/13811703417/job/38634576704#step:6:67)](https://github.com/woocommerce/woocommerce-square/actions/runs/13811703417/job/38634576704#step:6:67) for reference. This PR modifies the setup to install only the Chromium browser, making the process faster and eliminating the warnings.

```
Playwright Host validation warning: 
╔══════════════════════════════════════════════════════╗
║ Host system is missing dependencies to run browsers. ║
║ Please install them with the following command:      ║
║                                                      ║
║     sudo npx playwright install-deps                 ║
║                                                      ║
║ Alternatively, use apt:                              ║
║     sudo apt-get install libwoff1\                   ║
║         libevent-2.1-7t64\                           ║
║         libopus0\                                    ║
║         libgstreamer-plugins-base1.0-0\              ║
║         libgstreamer-gl1.0-0\                        ║
║         libgstreamer-plugins-bad1.0-0\               ║
║         libsecret-1-0\                               ║
║         libhyphen0\                                  ║
║         libmanette-0.2-0\                            ║
║         libflite1\                                   ║
║         libgles2\                                    ║
║         gstreamer1.0-libav                           ║
║                                                      ║
║ <3 Playwright Team                                   ║
╚══════════════════════════════════════════════════════╝
    at validateDependenciesLinux (/home/runner/work/woocommerce-square/woocommerce-square/node_modules/playwright-core/lib/server/registry/dependencies.js:216:9)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Registry._validateHostRequirements (/home/runner/work/woocommerce-square/woocommerce-square/node_modules/playwright-core/lib/server/registry/index.js:575:43)
    at async Registry._validateHostRequirementsForExecutableIfNeeded (/home/runner/work/woocommerce-square/woocommerce-square/node_modules/playwright-core/lib/server/registry/index.js:673:7)
    at async Registry.validateHostRequirementsForExecutablesIfNeeded (/home/runner/work/woocommerce-square/woocommerce-square/node_modules/playwright-core/lib/server/registry/index.js:662:43)
    at async t.<anonymous> (/home/runner/work/woocommerce-square/woocommerce-square/node_modules/playwright-core/lib/cli/program.js:119:7)
```

---

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Ensure that the E2E tests work as expected.
2. Verify that the Playwright installation step installs only the Chromium browser and does not generate any errors.


### Screenshots

**Development Environment:** http://localhost:8888/wp-admin/plugins.php

<img width="1546" alt="Screenshot 2025-03-13 at 9 31 46 AM" src="https://github.com/user-attachments/assets/9eb4c4bf-a11f-48c8-b577-891dccbca46c" />


**Test Environment:** http://localhost:8889/wp-admin/plugins.php

<img width="1551" alt="Screenshot 2025-03-13 at 9 32 40 AM" src="https://github.com/user-attachments/assets/35e9951f-004e-473a-809e-0d65397ab2c9" />

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Updates to E2E tests setup.