### PR TITLE
Fix jQuery error on Cart & Checkout pages when subscription product is added

### DIFF
--- a/src/blocks/digital-wallets/hooks.js
+++ b/src/blocks/digital-wallets/hooks.js
@@ -58,15 +58,15 @@ export function usePaymentRequest( payments, needsShipping ) {
 		const createPaymentRequest = async () => {
 			try {
 				const __paymentRequestJson = await getPaymentRequest();
-				const __paymentRequestObject = JSON.parse( __paymentRequestJson );
+				const __paymentRequestObject =
+					JSON.parse( __paymentRequestJson );
 				const __paymentRequest = payments.paymentRequest(
 					__paymentRequestObject
 				);
 
 				setPaymentRequest( __paymentRequest );
 			} catch {
-				// When payment request fails, return.
-				return;
+				// When payment request fails, no action require.
 			}
 		};
 

--- a/src/blocks/digital-wallets/hooks.js
+++ b/src/blocks/digital-wallets/hooks.js
@@ -56,13 +56,18 @@ export function usePaymentRequest( payments, needsShipping ) {
 		}
 
 		const createPaymentRequest = async () => {
-			const __paymentRequestJson = await getPaymentRequest();
-			const __paymentRequestObject = JSON.parse( __paymentRequestJson );
-			const __paymentRequest = payments.paymentRequest(
-				__paymentRequestObject
-			);
+			try {
+				const __paymentRequestJson = await getPaymentRequest();
+				const __paymentRequestObject = JSON.parse( __paymentRequestJson );
+				const __paymentRequest = payments.paymentRequest(
+					__paymentRequestObject
+				);
 
-			setPaymentRequest( __paymentRequest );
+				setPaymentRequest( __paymentRequest );
+			} catch {
+				// When payment request fails, return.
+				return;
+			}
 		};
 
 		createPaymentRequest();


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #303

### Steps to Reproduce:

1. Install and activate the **WooCommerce Square** and **WooCommerce Subscriptions** plugins.
2. Set up a payment method for Square with Digital Wallet.
3. Create a **Subscription product** in WooCommerce.
4. Go to the shop page and add the subscription product to the cart.
5. Navigate to the **Cart** page and then to the **Checkout** page.
6. Observe the console error.



### Screenshot:
Since Digital Wallets cannot be used for subscription products, this PR only handles the exception. However, the payment options block and the `--OR--` separator still appear on the cart page.  

If we want to remove them, we can open a follow-up issue to address this. However, IMO, we should leave it as is to avoid the need for deregistering and re-registering the express checkout block.

<img width="1722" alt="Screenshot 2025-03-14 at 10 57 01 AM" src="https://github.com/user-attachments/assets/91f1c87f-45db-45b7-b04b-1279b6db6f7c" />

### Changelog entry:
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - jQuery error on Cart & Checkout pages when a Subscription product is added to the cart, as Digital Wallets cannot be used for Subscription products.
