### PR TITLE
Mark Multiple Variations Support as (Beta)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,8 +5,6 @@ on:
       - smoke-testing
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - trunk
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -53,6 +53,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 			'enable_inventory_sync',
 			'override_product_images',
 			'hide_missing_products',
+			'enable_multivars_sync',
 			'sync_interval',
 			'is_connected',
 			'locations',
@@ -132,6 +133,11 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 					),
 					'hide_missing_products'            => array(
 						'description'       => __( 'Hide synced products when not found in Square.', 'woocommerce-square' ),
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'enable_multivars_sync' => array(
+						'description'       => __( 'Enable this beta feature to sync products with multiple variations to Square. (Beta)', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),

--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -136,7 +136,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),
-					'enable_multivars_sync' => array(
+					'enable_multivars_sync'            => array(
 						'description'       => __( 'Enable this beta feature to sync products with multiple variations to Square. (Beta)', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -89,76 +89,72 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			$product_variation_ids = $product->get_children();
 		}
 
-		$catalog_variations = $item_data->getVariations() ?: array();
+		$catalog_variations = $item_data->getVariations() ?: array(); // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 
 		// if dealing with a variable product, try and match the variations
 		if ( $product->is_type( 'variable' ) ) {
 
 			if ( ! $square_settings->is_multiple_variations_sync_enabled() ) {
 				$product_variation_ids = $product->get_children();
-			} else {
+			} elseif ( count( $attributes ) > 1 ) {
 				/**
 				 * If there are multiple variations, it must be a considered as Dynamic Options supported product.
 				 * Create/Update and Assign Dynamic Options only if a product
 				 * has multiple attributes OR options already exists in Square.
 				 */
-				if (
-					count( $attributes ) > 1
-				) {
-					$options_ids  = array();
-					$result       = wc_square()->get_api()->retrieve_options_data();
-					$options_data = $result[1] ?? array();
+				$options_ids  = array();
+				$result       = wc_square()->get_api()->retrieve_options_data();
+				$options_data = $result[1] ?? array();
 
-					// Set the product as a dynamic options product.
-					update_post_meta( $product->get_id(), '_dynamic_options', true );
+				// Set the product as a dynamic options product.
+				update_post_meta( $product->get_id(), '_dynamic_options', true );
 
-					// Loop through the attributes to create options and values at Square.
-					foreach ( $attributes as $attribute_id => $attribute ) {
+				// Loop through the attributes to create options and values at Square.
+				foreach ( $attributes as $attribute_id => $attribute ) {
 
-						$attribute_name = $attribute->get_name();
-						// Check if its a taxonomy-based attribute.
-						$attribute_option_values = array();
-						if ( taxonomy_exists( $attribute_id ) ) {
-							$terms                   = get_terms( $attribute_id );
-							$attribute_option_values = wp_list_pluck( $terms, 'name' );
-						} else {
-							$attribute_option_values = $attribute->get_options();
-						}
-
-						// Check if Square already has the option created with the same name.
-						// To do so, we can check if we already have the name in options/transient,
-						// if yes, use the relative Square ID.
-						$option_id = false;
-						foreach ( $options_data as $transient_option_id => $option_data_transient ) {
-							if ( $option_data_transient['name'] === $attribute_name ) {
-								$option_id = $transient_option_id;
-								break;
-							}
-						}
-
-						// If name does not exist, create a new option in Square.
-						// If name exists, check if all values are present in Square.
-						// If not, create the missing values.
-						$option        = wc_square()->get_api()->create_options_and_values( $option_id, $attribute_name, $attribute_option_values );
-						$options_ids[] = $option->getId();
+					$attribute_name = $attribute->get_name();
+					// Check if its a taxonomy-based attribute.
+					$attribute_option_values = array();
+					if ( taxonomy_exists( $attribute_id ) ) {
+						$terms                   = get_terms( $attribute_id );
+						$attribute_option_values = wp_list_pluck( $terms, 'name' );
+					} else {
+						$attribute_option_values = $attribute->get_options();
 					}
 
-					// Set the item_option_id for each option to the product.
-					$product_options = array();
-
-					foreach ( $options_ids as $option_id ) {
-						$item_option = new \Square\Models\CatalogItemOptionForItem();
-						$item_option->setItemOptionId( $option_id );
-						$product_options[] = $item_option;
+					// Check if Square already has the option created with the same name.
+					// To do so, we can check if we already have the name in options/transient,
+					// if yes, use the relative Square ID.
+					$option_id = false;
+					foreach ( $options_data as $transient_option_id => $option_data_transient ) {
+						if ( $option_data_transient['name'] === $attribute_name ) {
+							$option_id = $transient_option_id;
+							break;
+						}
 					}
 
-					$catalog_object->getItemData()->setItemOptions( $product_options );
-				} else {
-					// If the product has only one attribute, it's not a dynamic options product.
-					// So, remove the dynamic options meta.
-					delete_post_meta( $product->get_id(), '_dynamic_options' );
-					$catalog_object->getItemData()->setItemOptions( null );
+					// If name does not exist, create a new option in Square.
+					// If name exists, check if all values are present in Square.
+					// If not, create the missing values.
+					$option        = wc_square()->get_api()->create_options_and_values( $option_id, $attribute_name, $attribute_option_values );
+					$options_ids[] = $option->getId();
 				}
+
+				// Set the item_option_id for each option to the product.
+				$product_options = array();
+
+				foreach ( $options_ids as $option_id ) {
+					$item_option = new \Square\Models\CatalogItemOptionForItem();
+					$item_option->setItemOptionId( $option_id );
+					$product_options[] = $item_option;
+				}
+
+				$catalog_object->getItemData()->setItemOptions( $product_options );
+			} else {
+				// If the product has only one attribute, it's not a dynamic options product.
+				// So, remove the dynamic options meta.
+				delete_post_meta( $product->get_id(), '_dynamic_options' );
+				$catalog_object->getItemData()->setItemOptions( null );
 			}
 
 			if ( is_array( $catalog_variations ) ) {
@@ -304,7 +300,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
 				$variation_data->setName( $product->get_name() );
 			} else {
-				
+
 				$result                = wc_square()->get_api()->retrieve_options_data();
 				$options_data          = isset( $result[1] ) ? $result[1] : array();
 				$parent_product        = wc_get_product( $product->get_parent_id() );

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -84,8 +84,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		$square_settings = wc_square()->get_settings_handler();
 
 		if ( $square_settings->is_multiple_variations_sync_enabled() ) {
-			$attributes = $product->get_attributes();
-
+			$attributes            = $product->get_attributes();
 			$product_variation_ids = $product->get_children();
 		}
 

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -81,75 +81,84 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			$item_data->setReportingCategory( $square_category );
 		}
 
-		$attributes = $product->get_attributes();
+		$square_settings = wc_square()->get_settings_handler();
 
-		$product_variation_ids = $product->get_children();
-		$catalog_variations    = $item_data->getVariations() ?? array();
+		if ( $square_settings->is_multiple_variations_sync_enabled() ) {
+			$attributes = $product->get_attributes();
+
+			$product_variation_ids = $product->get_children();
+		}
+
+		$catalog_variations = $item_data->getVariations() ?: array();
 
 		// if dealing with a variable product, try and match the variations
 		if ( $product->is_type( 'variable' ) ) {
 
-			/**
-			 * If there are multiple variations, it must be a considered as Dynamic Options supported product.
-			 * Create/Update and Assign Dynamic Options only if a product
-			 * has multiple attributes OR options already exists in Square.
-			 */
-			if (
-				count( $attributes ) > 1
-			) {
-				$options_ids  = array();
-				$result       = wc_square()->get_api()->retrieve_options_data();
-				$options_data = $result[1] ?? array();
-
-				// Set the product as a dynamic options product.
-				update_post_meta( $product->get_id(), '_dynamic_options', true );
-
-				// Loop through the attributes to create options and values at Square.
-				foreach ( $attributes as $attribute_id => $attribute ) {
-
-					$attribute_name = $attribute->get_name();
-					// Check if its a taxonomy-based attribute.
-					$attribute_option_values = array();
-					if ( taxonomy_exists( $attribute_id ) ) {
-						$terms                   = get_terms( $attribute_id );
-						$attribute_option_values = wp_list_pluck( $terms, 'name' );
-					} else {
-						$attribute_option_values = $attribute->get_options();
-					}
-
-					// Check if Square already has the option created with the same name.
-					// To do so, we can check if we already have the name in options/transient,
-					// if yes, use the relative Square ID.
-					$option_id = false;
-					foreach ( $options_data as $transient_option_id => $option_data_transient ) {
-						if ( $option_data_transient['name'] === $attribute_name ) {
-							$option_id = $transient_option_id;
-							break;
-						}
-					}
-
-					// If name does not exist, create a new option in Square.
-					// If name exists, check if all values are present in Square.
-					// If not, create the missing values.
-					$option        = wc_square()->get_api()->create_options_and_values( $option_id, $attribute_name, $attribute_option_values );
-					$options_ids[] = $option->getId();
-				}
-
-				// Set the item_option_id for each option to the product.
-				$product_options = array();
-
-				foreach ( $options_ids as $option_id ) {
-					$item_option = new \Square\Models\CatalogItemOptionForItem();
-					$item_option->setItemOptionId( $option_id );
-					$product_options[] = $item_option;
-				}
-
-				$catalog_object->getItemData()->setItemOptions( $product_options );
+			if ( ! $square_settings->is_multiple_variations_sync_enabled() ) {
+				$product_variation_ids = $product->get_children();
 			} else {
-				// If the product has only one attribute, it's not a dynamic options product.
-				// So, remove the dynamic options meta.
-				delete_post_meta( $product->get_id(), '_dynamic_options' );
-				$catalog_object->getItemData()->setItemOptions( null );
+				/**
+				 * If there are multiple variations, it must be a considered as Dynamic Options supported product.
+				 * Create/Update and Assign Dynamic Options only if a product
+				 * has multiple attributes OR options already exists in Square.
+				 */
+				if (
+					count( $attributes ) > 1
+				) {
+					$options_ids  = array();
+					$result       = wc_square()->get_api()->retrieve_options_data();
+					$options_data = $result[1] ?? array();
+
+					// Set the product as a dynamic options product.
+					update_post_meta( $product->get_id(), '_dynamic_options', true );
+
+					// Loop through the attributes to create options and values at Square.
+					foreach ( $attributes as $attribute_id => $attribute ) {
+
+						$attribute_name = $attribute->get_name();
+						// Check if its a taxonomy-based attribute.
+						$attribute_option_values = array();
+						if ( taxonomy_exists( $attribute_id ) ) {
+							$terms                   = get_terms( $attribute_id );
+							$attribute_option_values = wp_list_pluck( $terms, 'name' );
+						} else {
+							$attribute_option_values = $attribute->get_options();
+						}
+
+						// Check if Square already has the option created with the same name.
+						// To do so, we can check if we already have the name in options/transient,
+						// if yes, use the relative Square ID.
+						$option_id = false;
+						foreach ( $options_data as $transient_option_id => $option_data_transient ) {
+							if ( $option_data_transient['name'] === $attribute_name ) {
+								$option_id = $transient_option_id;
+								break;
+							}
+						}
+
+						// If name does not exist, create a new option in Square.
+						// If name exists, check if all values are present in Square.
+						// If not, create the missing values.
+						$option        = wc_square()->get_api()->create_options_and_values( $option_id, $attribute_name, $attribute_option_values );
+						$options_ids[] = $option->getId();
+					}
+
+					// Set the item_option_id for each option to the product.
+					$product_options = array();
+
+					foreach ( $options_ids as $option_id ) {
+						$item_option = new \Square\Models\CatalogItemOptionForItem();
+						$item_option->setItemOptionId( $option_id );
+						$product_options[] = $item_option;
+					}
+
+					$catalog_object->getItemData()->setItemOptions( $product_options );
+				} else {
+					// If the product has only one attribute, it's not a dynamic options product.
+					// So, remove the dynamic options meta.
+					delete_post_meta( $product->get_id(), '_dynamic_options' );
+					$catalog_object->getItemData()->setItemOptions( null );
+				}
 			}
 
 			if ( is_array( $catalog_variations ) ) {
@@ -291,110 +300,116 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		 * @see https://github.com/woocommerce/woocommerce-square/issues/570
 		 */
 		if ( 'variation' === $product->get_type() ) {
-			$result                = wc_square()->get_api()->retrieve_options_data();
-			$options_data          = isset( $result[1] ) ? $result[1] : array();
-			$parent_product        = wc_get_product( $product->get_parent_id() );
-			$attributes            = $parent_product->get_attributes();
-			$variation_items       = $product->get_attributes();
-			$variation_item_values = array();
 
-			if ( 1 === count( $attributes ) ) {
-				// Set the name of the variation if it's a single variation.
-				$variation_data->setName( reset( $variation_items ) );
-				$variation_data->setItemOptionValues( null );
+			if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+				$variation_data->setName( $product->get_name() );
 			} else {
-				// If there are multiple attributes, the name of the variation is the combination of all attribute values.
-				$variation_name = array();
+				
+				$result                = wc_square()->get_api()->retrieve_options_data();
+				$options_data          = isset( $result[1] ) ? $result[1] : array();
+				$parent_product        = wc_get_product( $product->get_parent_id() );
+				$attributes            = $parent_product->get_attributes();
+				$variation_items       = $product->get_attributes();
+				$variation_item_values = array();
 
-				/**
-				 * Set the `item_option_values` for the variation.
-				 *
-				 * Retrieve the options data from the transient. At this point, the options data
-				 * should already be available, as we have already created the necessary options
-				 * and values in the parent product above.
-				 */
-				foreach ( $variation_items as $attribute_id => $attribute_value ) {
-					// If the attribute value is empty, set it to 'Any'.
-					$attribute_value = empty( $attribute_value ) ? WC_SQUARE_OPTION_ANY : $attribute_value;
+				if ( 1 === count( $attributes ) ) {
+					// Set the name of the variation if it's a single variation.
+					$variation_data->setName( reset( $variation_items ) );
+					$variation_data->setItemOptionValues( null );
+				} else {
+					// If there are multiple attributes, the name of the variation is the combination of all attribute values.
+					$variation_name = array();
 
-					// Check if it's a global attribute (taxonomy-based, e.g., "pa_color")
-					$taxonomy_exists = false;
-					if ( taxonomy_exists( $attribute_id ) ) {
-						// Use wc_attribute_label for global attributes
-						$attribute_name   = $attribute_id;
-						$variation_name[] = $attribute_value = WC_SQUARE_OPTION_ANY === $attribute_value ? WC_SQUARE_OPTION_ANY : get_term_by( 'slug', $attribute_value, $attribute_id )->name;
-						$taxonomy_exists  = true;
-					} else {
-						// For custom attributes, simply use the cleaned-up attribute ID
-						$attribute_name   = ucwords( str_replace( '-', ' ', $attribute_id ) );
-						$attribute_id     = $attribute_name;
-						$variation_name[] = $attribute_value;
-					}
+					/**
+					 * Set the `item_option_values` for the variation.
+					 *
+					 * Retrieve the options data from the transient. At this point, the options data
+					 * should already be available, as we have already created the necessary options
+					 * and values in the parent product above.
+					 */
+					foreach ( $variation_items as $attribute_id => $attribute_value ) {
+						// If the attribute value is empty, set it to 'Any'.
+						$attribute_value = empty( $attribute_value ) ? WC_SQUARE_OPTION_ANY : $attribute_value;
 
-					foreach ( $options_data as $option_id_transient => $option_data_transient ) {
-						$option_id       = '';
-						$option_value_id = '';
-
-						// Check for the Square ID of $attribute_name.
-						if ( $option_data_transient['name'] === $attribute_id ) { // @TODO: If merchant changes the name of the attribute, this will create a new item at Square. Think of a way to handle this.
-							$option_id = $option_id_transient;
-							// Check for the Square ID of $attribute_value.
-							foreach ( $option_data_transient['value_ids'] as $value_id => $value_name ) {
-								if ( $value_name === $attribute_value ) {
-									$option_value_id = $value_id;
-									break;
-								}
-							}
-							break;
-						}
-					}
-
-					if ( $option_id && $option_value_id ) {
-						$option_value_object = new \Square\Models\CatalogItemOptionValueForItemVariation();
-						$option_value_object->setItemOptionId( $option_id );
-						$option_value_object->setItemOptionValueId( $option_value_id );
-
-						$variation_item_values[] = $option_value_object;
-					} else {
-
-						if ( $taxonomy_exists ) {
-							// Get all attribute terms from Woo taxonomy.
-							$attribute_option_values = get_terms( $attribute_id );
-							$attribute_option_values = wp_list_pluck( $attribute_option_values, 'name' );
+						// Check if it's a global attribute (taxonomy-based, e.g., "pa_color")
+						$taxonomy_exists = false;
+						if ( taxonomy_exists( $attribute_id ) ) {
+							// Use wc_attribute_label for global attributes
+							$attribute_name   = $attribute_id;
+							$variation_name[] = $attribute_value = WC_SQUARE_OPTION_ANY === $attribute_value ? WC_SQUARE_OPTION_ANY : get_term_by( 'slug', $attribute_value, $attribute_id )->name;
+							$taxonomy_exists  = true;
 						} else {
-							// Get all attribute values from the parent product.
-							$attribute_option_values = $parent_product->get_attribute( $attribute_id );
-							$attribute_option_values = array_map( 'trim', explode( '|', $attribute_option_values ) );
+							// For custom attributes, simply use the cleaned-up attribute ID
+							$attribute_name   = ucwords( str_replace( '-', ' ', $attribute_id ) );
+							$attribute_id     = $attribute_name;
+							$variation_name[] = $attribute_value;
 						}
 
-						// If the attribute value is 'Any', add it to the attribute option values.
-						if ( WC_SQUARE_OPTION_ANY === $attribute_value && ! in_array( WC_SQUARE_OPTION_ANY, $attribute_option_values, true ) ) {
-							$attribute_option_values[] = WC_SQUARE_OPTION_ANY;
-						}
+						foreach ( $options_data as $option_id_transient => $option_data_transient ) {
+							$option_id       = '';
+							$option_value_id = '';
 
-						$option    = wc_square()->get_api()->create_options_and_values( $option_id, $attribute_name, $attribute_option_values );
-						$option_id = $option->getId();
-
-						// Get the Square ID of the attribute value.
-						$updated_option_values = $option->getItemOptionData()->getValues();
-						foreach ( $updated_option_values as $option_value ) {
-							if ( $option_value->getItemOptionValueData()->getName() === $attribute_value ) {
-								$option_value_id = $option_value->getId();
+							// Check for the Square ID of $attribute_name.
+							if ( $option_data_transient['name'] === $attribute_id ) { // @TODO: If merchant changes the name of the attribute, this will create a new item at Square. Think of a way to handle this.
+								$option_id = $option_id_transient;
+								// Check for the Square ID of $attribute_value.
+								foreach ( $option_data_transient['value_ids'] as $value_id => $value_name ) {
+									if ( $value_name === $attribute_value ) {
+										$option_value_id = $value_id;
+										break;
+									}
+								}
 								break;
 							}
 						}
 
-						$option_value_object = new \Square\Models\CatalogItemOptionValueForItemVariation();
-						$option_value_object->setItemOptionId( $option_id );
-						$option_value_object->setItemOptionValueId( $option_value_id );
+						if ( $option_id && $option_value_id ) {
+							$option_value_object = new \Square\Models\CatalogItemOptionValueForItemVariation();
+							$option_value_object->setItemOptionId( $option_id );
+							$option_value_object->setItemOptionValueId( $option_value_id );
 
-						$variation_item_values[] = $option_value_object;
+							$variation_item_values[] = $option_value_object;
+						} else {
+
+							if ( $taxonomy_exists ) {
+								// Get all attribute terms from Woo taxonomy.
+								$attribute_option_values = get_terms( $attribute_id );
+								$attribute_option_values = wp_list_pluck( $attribute_option_values, 'name' );
+							} else {
+								// Get all attribute values from the parent product.
+								$attribute_option_values = $parent_product->get_attribute( $attribute_id );
+								$attribute_option_values = array_map( 'trim', explode( '|', $attribute_option_values ) );
+							}
+
+							// If the attribute value is 'Any', add it to the attribute option values.
+							if ( WC_SQUARE_OPTION_ANY === $attribute_value && ! in_array( WC_SQUARE_OPTION_ANY, $attribute_option_values, true ) ) {
+								$attribute_option_values[] = WC_SQUARE_OPTION_ANY;
+							}
+
+							$option    = wc_square()->get_api()->create_options_and_values( $option_id, $attribute_name, $attribute_option_values );
+							$option_id = $option->getId();
+
+							// Get the Square ID of the attribute value.
+							$updated_option_values = $option->getItemOptionData()->getValues();
+							foreach ( $updated_option_values as $option_value ) {
+								if ( $option_value->getItemOptionValueData()->getName() === $attribute_value ) {
+									$option_value_id = $option_value->getId();
+									break;
+								}
+							}
+
+							$option_value_object = new \Square\Models\CatalogItemOptionValueForItemVariation();
+							$option_value_object->setItemOptionId( $option_id );
+							$option_value_object->setItemOptionValueId( $option_value_id );
+
+							$variation_item_values[] = $option_value_object;
+						}
 					}
-				}
 
-				// Set the name of the variation as the combination of all attribute values.
-				$variation_data->setName( implode( ', ', $variation_name ) );
-				$variation_data->setItemOptionValues( $variation_item_values );
+					// Set the name of the variation as the combination of all attribute values.
+					$variation_data->setName( implode( ', ', $variation_name ) );
+					$variation_data->setItemOptionValues( $variation_item_values );
+				}
 			}
 		}
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -296,13 +296,13 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 	}
 
 	/**
-	 * Upgrades to version 4.9.0.
+	 * Upgrades to version 4.7.0.
 	 *
-	 * @since 4.9.0
+	 * @since 4.7.0
 	 */
-	protected function upgrade_to_4_9_0() {
+	protected function upgrade_to_4_7_0() {
 		// Skip if already upgraded.
-		if ( get_option( 'wc_square_updated_to_4_9_0' ) ) {
+		if ( get_option( 'wc_square_updated_to_4_7_0' ) ) {
 			return;
 		}
 
@@ -326,6 +326,27 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 			false
 		);
 
+		// Mark upgrade complete.
+		update_option( 'wc_square_updated_to_4_7_0', true );
+
+		// Skip redirect existing users to the setup wizard on upgrade.
+		add_option( 'wc_square_show_wizard_on_activation', true, '', 'no' );
+
+		// Mark the onboarding wizard as visited for existing users.
+		add_option( 'wc_square_connected_page_visited', true, '', 'no' );
+	}
+
+	/**
+	 * Upgrades to version 4.9.0.
+	 *
+	 * @since 4.9.0
+	 */
+	protected function upgrade_to_4_9_0() {
+		// Skip if already upgraded.
+		if ( get_option( 'wc_square_updated_to_4_9_0' ) ) {
+			return;
+		}
+
 		// Show notice to inform users about the "beta" feature about the settings "enable multiple variations sync"
 		add_action(
 			'admin_notices',
@@ -342,12 +363,6 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 
 		// Mark upgrade complete.
 		update_option( 'wc_square_updated_to_4_9_0', true );
-
-		// Skip redirect existing users to the setup wizard on upgrade.
-		add_option( 'wc_square_show_wizard_on_activation', true, '', 'no' );
-
-		// Mark the onboarding wizard as visited for existing users.
-		add_option( 'wc_square_connected_page_visited', true, '', 'no' );
 	}
 
 	/**

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -327,15 +327,18 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 		);
 
 		// Show notice to inform users about the "beta" feature about the settings "enable multiple variations sync"
-		add_action( 'admin_notices', function() {
-			if ( current_user_can( 'manage_woocommerce' ) ) {
-				echo '<div class="notice notice-info is-dismissible">';
-				echo '<p><strong>New Feature:</strong> Support for Multiple Variations is now available as a beta feature in v4.9.0!</p>';
-				echo '<p>It is disabled by default but can be enabled via a new setting in <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square' ) ) . '">WooCommerce &rarr; Settings &rarr; Square</a> under "Enable Multiple Variations Support".</p>';
-				echo '<p>We plan to make this feature the default in v5.0.0 based on feedback from this release.</p>';
-				echo '</div>';
+		add_action(
+			'admin_notices',
+			function() {
+				if ( current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+					echo '<div class="notice notice-info is-dismissible">';
+					echo '<p><strong>New Feature:</strong> Support for Multiple Variations is now available as a beta feature in v4.9.0!</p>';
+					echo '<p>It is disabled by default but can be enabled via a new setting in <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square' ) ) . '">WooCommerce &rarr; Settings &rarr; Square</a> under "Enable Multiple Variations Support".</p>';
+					echo '<p>We plan to make this feature the default in v5.0.0 based on feedback from this release.</p>';
+					echo '</div>';
+				}
 			}
-		} );
+		);
 
 		// Mark upgrade complete.
 		update_option( 'wc_square_updated_to_4_9_0', true );

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -329,7 +329,7 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 		// Show notice to inform users about the "beta" feature about the settings "enable multiple variations sync"
 		add_action(
 			'admin_notices',
-			function() {
+			function () {
 				if ( current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
 					echo '<div class="notice notice-info is-dismissible">';
 					echo '<p><strong>New Feature:</strong> Support for Multiple Variations is now available as a beta feature in v4.9.0!</p>';

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -59,6 +59,7 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 			'3.7.1',
 			'3.8.3',
 			'4.7.0',
+			'4.9.0',
 		);
 	}
 
@@ -295,14 +296,13 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 	}
 
 	/**
-	 * Upgrades to version 4.7.0.
+	 * Upgrades to version 4.9.0.
 	 *
-	 * @since 4.7.0
+	 * @since 4.9.0
 	 */
-	protected function upgrade_to_4_7_0() {
-
+	protected function upgrade_to_4_9_0() {
 		// Skip if already upgraded.
-		if ( get_option( 'wc_square_updated_to_4_7_0' ) ) {
+		if ( get_option( 'wc_square_updated_to_4_9_0' ) ) {
 			return;
 		}
 
@@ -326,8 +326,19 @@ class Lifecycle extends \WooCommerce\Square\Framework\Lifecycle {
 			false
 		);
 
+		// Show notice to inform users about the "beta" feature about the settings "enable multiple variations sync"
+		add_action( 'admin_notices', function() {
+			if ( current_user_can( 'manage_woocommerce' ) ) {
+				echo '<div class="notice notice-info is-dismissible">';
+				echo '<p><strong>New Feature:</strong> Support for Multiple Variations is now available as a beta feature in v4.9.0!</p>';
+				echo '<p>It is disabled by default but can be enabled via a new setting in <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square' ) ) . '">WooCommerce &rarr; Settings &rarr; Square</a> under "Enable Multiple Variations Support".</p>';
+				echo '<p>We plan to make this feature the default in v5.0.0 based on feedback from this release.</p>';
+				echo '</div>';
+			}
+		} );
+
 		// Mark upgrade complete.
-		update_option( 'wc_square_updated_to_4_7_0', true );
+		update_option( 'wc_square_updated_to_4_9_0', true );
 
 		// Skip redirect existing users to the setup wizard on upgrade.
 		add_option( 'wc_square_show_wizard_on_activation', true, '', 'no' );

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -671,6 +671,18 @@ class Settings extends \WC_Settings_API {
 	}
 
 	/**
+	 * Determines whether the products with multiple variations should be synced.
+	 *
+	 * @since 4.9.0
+	 *
+	 * @return bool
+	 */
+	public function is_multiple_variations_sync_enabled() {
+
+		return 'yes' === $this->get_option( 'enable_multivars_sync' );
+	}
+
+	/**
 	 * Returns sync interval in seconds.
 	 * Returns 1 hr = 3600 seconds as default.
 	 *

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -211,7 +211,7 @@ class Interval_Polling extends Stepped_Job {
 							if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
 								$thumbnail_image_id = Product::get_catalog_item_thumbnail_id( $object );
 								Product::update_from_square( $product, $object->getItemData(), false );
-	
+
 								Product::update_image_from_square( $product, $thumbnail_image_id );
 							} else {
 								$data = $product_import->extract_product_data( $object, $product );

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -208,21 +208,28 @@ class Interval_Polling extends Stepped_Job {
 					} else {
 
 						try {
-							$data = $product_import->extract_product_data( $object, $product );
+							if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+								$thumbnail_image_id = Product::get_catalog_item_thumbnail_id( $object );
+								Product::update_from_square( $product, $object->getItemData(), false );
+	
+								Product::update_image_from_square( $product, $thumbnail_image_id );
+							} else {
+								$data = $product_import->extract_product_data( $object, $product );
 
-							/**
-							 * Filters the data that is used to create update a WooCommerce product during import.
-							 *
-							 * @since 2.0.0
-							 *
-							 * @param array $data product data
-							 * @param \Square\Models\CatalogObject $object the catalog object from the Square API
-							 * @param Interval_Polling $this current class instance
-							 */
-							$data = apply_filters( 'woocommerce_square_create_product_data', $data, $object, $this );
+								/**
+								 * Filters the data that is used to create update a WooCommerce product during import.
+								 *
+								 * @since 2.0.0
+								 *
+								 * @param array $data product data
+								 * @param \Square\Models\CatalogObject $object the catalog object from the Square API
+								 * @param Interval_Polling $this current class instance
+								 */
+								$data = apply_filters( 'woocommerce_square_create_product_data', $data, $object, $this );
 
-							// Update the product, this will update/create the variations as well.
-							$product_import->update_product( $product, $data );
+								// Update the product, this will update/create the variations as well.
+								$product_import->update_product( $product, $data );
+							}
 
 							$products_updated[] = $product->get_id();
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -66,7 +66,7 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
 			parent::run();
 			return;
-        }
+		}
 
 		// If the option is set to refresh the sync cycle, clear the next steps and completed steps.
 		// The refresh is requested when we do not have Square's Dynamic options data ready.
@@ -1439,11 +1439,10 @@ class Manual_Synchronization extends Stepped_Job {
 					 * @param Manual_Synchronization $this current class instance
 					 */
 					$data = apply_filters( 'woocommerce_square_create_product_data', $data, $square_object, $this );
-	
-					// Update the product, this will update/create the variations as well.
-					$product_import->update_product( $product, $data );	
-				}
 
+					// Update the product, this will update/create the variations as well.
+					$product_import->update_product( $product, $data );
+				}
 			} catch ( \Exception $exception ) {
 
 				Records::set_record(

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -62,6 +62,12 @@ class Manual_Synchronization extends Stepped_Job {
 	 * @return \stdClass the job object
 	 */
 	public function run() {
+		// Early return if the multiple variations sync is not enabled.
+		if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+			parent::run();
+			return;
+        }
+
 		// If the option is set to refresh the sync cycle, clear the next steps and completed steps.
 		// The refresh is requested when we do not have Square's Dynamic options data ready.
 		$refresh_sync_cycle = get_option( 'woocommerce_square_refresh_sync_cycle', false );
@@ -1415,21 +1421,28 @@ class Manual_Synchronization extends Stepped_Job {
 					$pull_inventory_variation_ids[] = $variation->getId();
 				}
 
-				$data = $product_import->extract_product_data( $square_object, $product );
+				if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+					Product::update_from_square( $product, $square_object->getItemData(), false );
 
-				/**
-				 * Filters the data that is used to create update a WooCommerce product during import.
-				 *
-				 * @since 2.0.0
-				 *
-				 * @param array $data product data
-				 * @param \Square\Models\CatalogObject $square_object the catalog object from the Square API
-				 * @param Manual_Synchronization $this current class instance
-				 */
-				$data = apply_filters( 'woocommerce_square_create_product_data', $data, $square_object, $this );
+					$image_id = Product::get_catalog_item_thumbnail_id( $square_object );
+					Product::update_image_from_square( $product, $image_id );
+				} else {
+					$data = $product_import->extract_product_data( $square_object, $product );
 
-				// Update the product, this will update/create the variations as well.
-				$product_import->update_product( $product, $data );
+					/**
+					 * Filters the data that is used to create update a WooCommerce product during import.
+					 *
+					 * @since 2.0.0
+					 *
+					 * @param array $data product data
+					 * @param \Square\Models\CatalogObject $square_object the catalog object from the Square API
+					 * @param Manual_Synchronization $this current class instance
+					 */
+					$data = apply_filters( 'woocommerce_square_create_product_data', $data, $square_object, $this );
+	
+					// Update the product, this will update/create the variations as well.
+					$product_import->update_product( $product, $data );	
+				}
 
 			} catch ( \Exception $exception ) {
 
@@ -1717,10 +1730,20 @@ class Manual_Synchronization extends Stepped_Job {
 					'refresh_category_mappings',
 					'query_unmapped_categories',
 					'upsert_categories',
-					'fetch_options_data',
-					'update_matched_products',
-					'search_matched_products',
-					'upsert_new_products',
+				);
+
+				// Add 'fetch_options_data' step when multiple variations sync is enabled.
+				if ( wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+					$next_steps[] = 'fetch_options_data';
+				}
+
+				$next_steps = array_merge(
+					$next_steps,
+					array(
+						'update_matched_products',
+						'search_matched_products',
+						'upsert_new_products',
+					)
 				);
 
 				// only handle product inventory if enabled

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -754,7 +754,7 @@ class Product_Import extends Stepped_Job {
 					'option'       => str_replace( '|', ' - ', $variation_data->getName() ),
 				),
 			);
-        } else {
+		} else {
 			$variation_options = $variation_data->getItemOptionValues();		
 
 			foreach ( $variation_options as $variation_option ) {
@@ -762,7 +762,7 @@ class Product_Import extends Stepped_Job {
 				$option_value_id = $variation_option->getItemOptionValueId();
 				$result          = wc_square()->get_api()->retrieve_options_data();
 				$options_data    = isset( $result[1] ) ? $result[1] : array();
-	
+
 				if ( isset( $options_data[ $option_id ] ) && isset( $options_data[ $option_id ]['value_ids'][ $option_value_id ] ) ) {
 					$option_name    = $options_data[ $option_id ]['name'];
 					$option_matched = $options_data[ $option_id ]['value_ids'][ $option_value_id ];
@@ -770,23 +770,23 @@ class Product_Import extends Stepped_Job {
 					// Fetch option data from Square.
 					$response    = wc_square()->get_api()->retrieve_catalog_object( $option_id );
 					$option_name = $response->get_data()->getObject()->getItemOptionData()->getDisplayName();
-	
+
 					$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
 					$option_matched       = '';
 					$option_values        = array();
 					$option_value_ids     = array();
-	
+
 					foreach ( $option_values_object as $option_value ) {
 						$option_value_name = $option_value->getItemOptionValueData()->getName();
 						$option_values[]   = $option_value_name;
-	
+
 						$option_value_ids[ $option_value->getId() ] = $option_value_name;
-	
+
 						if ( $option_value_id === $option_value->getId() ) {
 							$option_matched = $option_value_name;
 						}
 					}
-	
+
 					$options_data[ $option_id ] = array(
 						'name'      => $option_name,
 						'values'    => $option_values,
@@ -795,7 +795,7 @@ class Product_Import extends Stepped_Job {
 	
 					set_transient( 'wc_square_options_data', $options_data );
 				}
-	
+
 				$attributes[] = array(
 					'name'         => str_replace( 'pa_', '', $option_name ),
 					'slug'         => str_replace( 'pa_', '', sanitize_title( $option_name ) ),
@@ -804,7 +804,7 @@ class Product_Import extends Stepped_Job {
 					'pa_prefix'    => strpos( $option_name, 'pa_' ) !== false,
 				);
 			}
-	
+
 			if ( ! $variation_options ) {
 				$attribute_name = ! empty( reset( $this->woo_attributes ) ) ? reset( $this->woo_attributes )->get_name() : 'Attribute';
 				$attributes[]   = array(
@@ -815,7 +815,7 @@ class Product_Import extends Stepped_Job {
 					'pa_prefix'    => strpos( $attribute_name, 'pa_' ) !== false,
 				);
 			}
-        }
+		}
 
 		$data = array(
 			'name'           => $variation_data->getName(),

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -44,15 +44,23 @@ class Product_Import extends Stepped_Job {
 
 
 	protected function assign_next_steps() {
+		$next_steps = array();
 
-		$this->set_attr(
-			'next_steps',
+		// Add 'fetch_options_data' if Multiple Variations Sync is enabled.
+		if ( wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+			$next_steps[] = 'fetch_options_data';
+		}
+
+		// Add the remaining steps
+		$next_steps = array_merge(
+			$next_steps,
 			array(
-				'fetch_options_data',
 				'import_products',
 				'import_inventory',
 			)
 		);
+
+		$this->set_attr( 'next_steps', $next_steps );
 	}
 
 
@@ -658,14 +666,27 @@ class Product_Import extends Stepped_Job {
 				return null;
 			}
 
-			$options = $catalog_object->getItemData()->getItemOptions() ? $catalog_object->getItemData()->getItemOptions() : array();
-
-			if ( count( $options ) ) {
-				$data['attributes']                      = $this->extract_attributes_from_square_options( $options );
-				$data['custom_meta']['_dynamic_options'] = true;
+			if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+				$data['attributes'] = array(
+					array(
+						'name'      => 'Attribute',
+						'slug'      => 'attribute',
+						'position'  => 0,
+						'visible'   => true,
+						'variation' => true,
+						'options'   => str_replace( '|', ' - ', wp_list_pluck( $data['variations'], 'name' ) ),
+					),
+				);
 			} else {
-				$data['attributes']                      = $this->extract_attributes_from_square_variations( $data['variations'] );
-				$data['custom_meta']['_dynamic_options'] = false;
+				$options = $catalog_object->getItemData()->getItemOptions() ? $catalog_object->getItemData()->getItemOptions() : array();
+
+				if ( count( $options ) ) {
+					$data['attributes']                      = $this->extract_attributes_from_square_options( $options );
+					$data['custom_meta']['_dynamic_options'] = true;
+				} else {
+					$data['attributes']                      = $this->extract_attributes_from_square_variations( $data['variations'] );
+					$data['custom_meta']['_dynamic_options'] = false;
+				}
 			}
 		} else { // simple product
 			try {
@@ -723,68 +744,78 @@ class Product_Import extends Stepped_Job {
 			throw new \Exception( esc_html__( 'Variations with missing SKUs cannot be imported.', 'woocommerce-square' ) );
 		}
 
-		$variation_options = $variation_data->getItemOptionValues();
-
 		$attributes = array();
 
-		foreach ( $variation_options as $variation_option ) {
-			$option_id       = $variation_option->getItemOptionId();
-			$option_value_id = $variation_option->getItemOptionValueId();
-			$result          = wc_square()->get_api()->retrieve_options_data();
-			$options_data    = isset( $result[1] ) ? $result[1] : array();
+		if ( ! wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+			$attributes = array(
+				array(
+					'name'         => 'Attribute',
+					'is_variation' => true,
+					'option'       => str_replace( '|', ' - ', $variation_data->getName() ),
+				),
+			);
+        } else {
+			$variation_options = $variation_data->getItemOptionValues();		
 
-			if ( isset( $options_data[ $option_id ] ) && isset( $options_data[ $option_id ]['value_ids'][ $option_value_id ] ) ) {
-				$option_name    = $options_data[ $option_id ]['name'];
-				$option_matched = $options_data[ $option_id ]['value_ids'][ $option_value_id ];
-			} else {
-				// Fetch option data from Square.
-				$response    = wc_square()->get_api()->retrieve_catalog_object( $option_id );
-				$option_name = $response->get_data()->getObject()->getItemOptionData()->getDisplayName();
-
-				$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
-				$option_matched       = '';
-				$option_values        = array();
-				$option_value_ids     = array();
-
-				foreach ( $option_values_object as $option_value ) {
-					$option_value_name = $option_value->getItemOptionValueData()->getName();
-					$option_values[]   = $option_value_name;
-
-					$option_value_ids[ $option_value->getId() ] = $option_value_name;
-
-					if ( $option_value_id === $option_value->getId() ) {
-						$option_matched = $option_value_name;
+			foreach ( $variation_options as $variation_option ) {
+				$option_id       = $variation_option->getItemOptionId();
+				$option_value_id = $variation_option->getItemOptionValueId();
+				$result          = wc_square()->get_api()->retrieve_options_data();
+				$options_data    = isset( $result[1] ) ? $result[1] : array();
+	
+				if ( isset( $options_data[ $option_id ] ) && isset( $options_data[ $option_id ]['value_ids'][ $option_value_id ] ) ) {
+					$option_name    = $options_data[ $option_id ]['name'];
+					$option_matched = $options_data[ $option_id ]['value_ids'][ $option_value_id ];
+				} else {
+					// Fetch option data from Square.
+					$response    = wc_square()->get_api()->retrieve_catalog_object( $option_id );
+					$option_name = $response->get_data()->getObject()->getItemOptionData()->getDisplayName();
+	
+					$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
+					$option_matched       = '';
+					$option_values        = array();
+					$option_value_ids     = array();
+	
+					foreach ( $option_values_object as $option_value ) {
+						$option_value_name = $option_value->getItemOptionValueData()->getName();
+						$option_values[]   = $option_value_name;
+	
+						$option_value_ids[ $option_value->getId() ] = $option_value_name;
+	
+						if ( $option_value_id === $option_value->getId() ) {
+							$option_matched = $option_value_name;
+						}
 					}
+	
+					$options_data[ $option_id ] = array(
+						'name'      => $option_name,
+						'values'    => $option_values,
+						'value_ids' => $option_value_ids,
+					);
+	
+					set_transient( 'wc_square_options_data', $options_data );
 				}
-
-				$options_data[ $option_id ] = array(
-					'name'      => $option_name,
-					'values'    => $option_values,
-					'value_ids' => $option_value_ids,
+	
+				$attributes[] = array(
+					'name'         => str_replace( 'pa_', '', $option_name ),
+					'slug'         => str_replace( 'pa_', '', sanitize_title( $option_name ) ),
+					'is_variation' => true,
+					'option'       => $option_matched,
+					'pa_prefix'    => strpos( $option_name, 'pa_' ) !== false,
 				);
-
-				set_transient( 'wc_square_options_data', $options_data );
 			}
-
-			$attributes[] = array(
-				'name'         => str_replace( 'pa_', '', $option_name ),
-				'slug'         => str_replace( 'pa_', '', sanitize_title( $option_name ) ),
-				'is_variation' => true,
-				'option'       => $option_matched,
-				'pa_prefix'    => strpos( $option_name, 'pa_' ) !== false,
-			);
-		}
-
-		if ( ! $variation_options ) {
-			$attribute_name = ! empty( reset( $this->woo_attributes ) ) ? reset( $this->woo_attributes )->get_name() : 'Attribute';
-			$attributes[]   = array(
-				'name'         => str_replace( 'pa_', '', $attribute_name ),
-				'slug'         => str_replace( 'pa_', '', sanitize_title( $attribute_name ) ),
-				'is_variation' => true,
-				'option'       => $variation_data->getName(),
-				'pa_prefix'    => strpos( $attribute_name, 'pa_' ) !== false,
-			);
-		}
+	
+			if ( ! $variation_options ) {
+				$attribute_name = ! empty( reset( $this->woo_attributes ) ) ? reset( $this->woo_attributes )->get_name() : 'Attribute';
+				$attributes[]   = array(
+					'name'         => str_replace( 'pa_', '', $attribute_name ),
+					'slug'         => str_replace( 'pa_', '', sanitize_title( $attribute_name ) ),
+					'is_variation' => true,
+					'option'       => $variation_data->getName(),
+					'pa_prefix'    => strpos( $attribute_name, 'pa_' ) !== false,
+				);
+			}
+        }
 
 		$data = array(
 			'name'           => $variation_data->getName(),
@@ -1015,7 +1046,11 @@ class Product_Import extends Stepped_Job {
 				}
 
 				// Remove 'Any' from options.
-				if ( isset( $attribute['options'] ) && is_array( $attribute['options'] ) ) {
+				if (
+					wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled()
+					&& isset( $attribute['options'] )
+					&& is_array( $attribute['options'] )
+				) {
 					$attribute['options'] = array_diff( $attribute['options'], array( WC_SQUARE_OPTION_ANY ) );
 				}
 
@@ -1297,8 +1332,10 @@ class Product_Import extends Stepped_Job {
 				$updated_attribute_keys = array();
 
 				foreach ( $variation['attributes'] as $attribute_key => $attribute ) {
-					// Set empty if attribute is to 'Any' to prevent it from being saved.
-					$attribute['option'] = isset( $attribute['option'] ) && WC_SQUARE_OPTION_ANY !== $attribute['option'] ? $attribute['option'] : '';
+					if ( wc_square()->get_settings_handler()->is_multiple_variations_sync_enabled() ) {
+						// Set empty if attribute is to 'Any' to prevent it from being saved.
+						$attribute['option'] = isset( $attribute['option'] ) && WC_SQUARE_OPTION_ANY !== $attribute['option'] ? $attribute['option'] : '';
+					}
 
 					if ( ! isset( $attribute['name'] ) ) {
 						continue;

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -755,7 +755,7 @@ class Product_Import extends Stepped_Job {
 				),
 			);
 		} else {
-			$variation_options = $variation_data->getItemOptionValues();		
+			$variation_options = $variation_data->getItemOptionValues();
 
 			foreach ( $variation_options as $variation_option ) {
 				$option_id       = $variation_option->getItemOptionId();
@@ -792,7 +792,7 @@ class Product_Import extends Stepped_Job {
 						'values'    => $option_values,
 						'value_ids' => $option_value_ids,
 					);
-	
+
 					set_transient( 'wc_square_options_data', $options_data );
 				}
 

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -41,6 +41,7 @@ export const ConfigureSync = ( { indent = 0, isDirty = false } ) => {
 		enable_inventory_sync = 'no',
 		override_product_images = 'no',
 		hide_missing_products = 'no',
+		enable_multivars_sync = 'no',
 		sync_interval = '0.25',
 		is_connected = false,
 	} = settings;
@@ -312,6 +313,36 @@ export const ConfigureSync = ( { indent = 0, isDirty = false } ) => {
 						{ ( system_of_record === 'woocommerce' ||
 							system_of_record === 'square' ) && (
 							<>
+								<InputWrapper
+									label={ __(
+										'(Beta) Enable Multiple Variations Support',
+										'woocommerce-square'
+									) }
+									indent={ indent }
+									description={ __(
+										'Enable this beta feature to allow syncing of products with multiple variations in Square.',
+										'woocommerce-square'
+									) }
+								>
+									<SquareCheckboxControl
+										data-testid="pull-inventory-field"
+										checked={
+											enable_multivars_sync === 'yes'
+										}
+										onChange={ ( value ) =>
+											setSquareSettingData( {
+												enable_multivars_sync: value
+													? 'yes'
+													: 'no',
+											} )
+										}
+										label={ __(
+											'Enable syncing of products with multiple variations in Square',
+											'woocommerce-square'
+										) }
+									/>
+								</InputWrapper>
+
 								<InputWrapper
 									label={ __(
 										'Sync interval',

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -325,7 +325,7 @@ export const ConfigureSync = ( { indent = 0, isDirty = false } ) => {
 									) }
 								>
 									<SquareCheckboxControl
-										data-testid="pull-inventory-field"
+										data-testid="sync-multiple-variations"
 										checked={
 											enable_multivars_sync === 'yes'
 										}

--- a/src/new-user-experience/onboarding/data/reducers.js
+++ b/src/new-user-experience/onboarding/data/reducers.js
@@ -108,6 +108,7 @@ export const SQUARE_SETTINGS_DEFAULT_STATE = {
 	system_of_record: 'disabled',
 	enable_inventory_sync: 'no',
 	override_product_images: 'no',
+	enable_multivars_sync: 'no',
 	hide_missing_products: 'no',
 	sync_interval: '0.25',
 	is_connected: false,

--- a/src/new-user-experience/onboarding/onboarding-app.js
+++ b/src/new-user-experience/onboarding/onboarding-app.js
@@ -60,6 +60,7 @@ export const OnboardingApp = () => {
 		system_of_record,
 		enable_inventory_sync,
 		override_product_images,
+		enable_multivars_sync,
 		hide_missing_products,
 		sync_interval,
 		enable_customer_decline_messages,
@@ -272,6 +273,7 @@ export const OnboardingApp = () => {
 										system_of_record,
 										enable_inventory_sync,
 										override_product_images,
+										enable_multivars_sync,
 										hide_missing_products,
 										sync_interval,
 									};

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -159,7 +159,7 @@ export const getSquareSettings = async () => {
 		override_product_images:
 			settings.override_product_images ||
 			SQUARE_SETTINGS_DEFAULT_STATE.override_product_images,
-			enable_multivars_sync:
+		enable_multivars_sync:
 			settings.enable_multivars_sync ||
 			SQUARE_SETTINGS_DEFAULT_STATE.enable_multivars_sync,
 		hide_missing_products:

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -159,6 +159,9 @@ export const getSquareSettings = async () => {
 		override_product_images:
 			settings.override_product_images ||
 			SQUARE_SETTINGS_DEFAULT_STATE.override_product_images,
+			enable_multivars_sync:
+			settings.enable_multivars_sync ||
+			SQUARE_SETTINGS_DEFAULT_STATE.enable_multivars_sync,
 		hide_missing_products:
 			settings.hide_missing_products ||
 			SQUARE_SETTINGS_DEFAULT_STATE.hide_missing_products,

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -20,6 +20,11 @@ process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = '0';
  */
 module.exports = defineConfig({
   testDir: '../specs',
+  /* Specify patterns of test files to ignore */
+  testIgnore: [
+    'd8.square-sor-multiple-variations.spec.js',
+    'd7.woo-sor-multiple-variations.spec.js',
+  ],
   /* Maximum time one test can run for. */
   timeout: 60 * 1000,
   globalSetup: './global-setup',

--- a/tests/e2e/specs/b8.gift-card-product.spec.js
+++ b/tests/e2e/specs/b8.gift-card-product.spec.js
@@ -132,7 +132,7 @@ test( 'Gift card recipient email @giftcard', async ( { page } ) => {
 	await page
 		.locator('tr', { has: page.locator('td.column-subject:has-text("Gift Card!")') })
 		.locator('.view-content a')
-		.click();
+		.dispatchEvent( 'click' );
 
 	await expect( await page.locator( '#template_container' ).getByText( 'Gift Card received!' ) ).toBeVisible();
 	await expect( await page.locator( '#template_container' ).getByText( 'Hey Emily Doe, you just received a gift card!' ) ).toBeVisible();

--- a/tests/e2e/specs/b8.gift-card-product.spec.js
+++ b/tests/e2e/specs/b8.gift-card-product.spec.js
@@ -131,6 +131,7 @@ test( 'Gift card recipient email @giftcard', async ( { page } ) => {
 	// Locate and click the "View Content" link in the correct row.
 	await page
 		.locator('tr', { has: page.locator('td.column-subject:has-text("Gift Card!")') })
+		.first()
 		.locator('.view-content a')
 		.dispatchEvent( 'click' );
 

--- a/tests/e2e/specs/b8.gift-card-product.spec.js
+++ b/tests/e2e/specs/b8.gift-card-product.spec.js
@@ -127,8 +127,14 @@ test( 'Purchase Gift card product @giftcard', async ( { page } ) => {
 
 test( 'Gift card recipient email @giftcard', async ( { page } ) => {
 	await page.goto( '/wp-admin/admin.php?page=email-log' );
-	await page.locator( '.view-content a' ).first().dispatchEvent( 'click' );
-	await expect( await page.locator( '#template_container' ).getByText( 'woocommerce-square Gift Card received!' ) ).toBeVisible();
+
+	// Locate and click the "View Content" link in the correct row.
+	await page
+		.locator('tr', { has: page.locator('td.column-subject:has-text("Gift Card!")') })
+		.locator('.view-content a')
+		.click();
+
+	await expect( await page.locator( '#template_container' ).getByText( 'Gift Card received!' ) ).toBeVisible();
 	await expect( await page.locator( '#template_container' ).getByText( 'Hey Emily Doe, you just received a gift card!' ) ).toBeVisible();
 	await expect( await page.locator( '#wc-square-gift-card-email__card-balance' ) ).toContainText( '$25.00' )
 	await expect( await page.locator( '#wc-square-gift-card-email__card-number' ) ).toContainText( process.env.PURCHASED_GAN )


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR introduces a new **"(Beta) Enable Multiple Variations Support"** setting under **WooCommerce → Settings → Square**, allowing merchants to sync products with multiple variations. This feature is in **beta** and is **disabled by default**, giving merchants the option to enable it manually.  

![image](https://github.com/user-attachments/assets/ec63d10a-2a87-4cd9-81ff-6d53cfe41e67)

Additionally, an **admin notice** has been added to inform merchants about this new feature and guide them on how to enable it.  

![image](https://github.com/user-attachments/assets/74265f87-ea0c-4767-98b8-fbd3ce787466)

Currently, this PR is targeting the original `multiple-variations-support` branch and can be merged directly into the main PR before proceeding with the release.

Closes #302.  

### Steps to test the changes in this Pull Request:

1.	Go to WooCommerce → Settings → Square.
2.	Confirm that the ”(beta) Enable Multiple Variations Support” setting is present and disabled by default.
3.	Enable the setting and save changes.
4.	Verify that products with multiple variations sync correctly with Square.
5.	Disable the setting and save changes.
6.	Verify that products with multiple variations fail to sync, as expected.
7.	Check for the new admin notice about this beta feature after upgrading the plugin. Ensure the notice provides correct instructions for enabling the feature. (This may be challenging to test since upgrading the plugin locally while retaining custom changes isn’t straightforward.)

### Changelog entry

> Add - Introduced a new `(beta)` setting to enable/disable Multiple Variations Support feature.
