### PR TITLE
Fix E2E tests for remove label errors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -152,7 +152,7 @@ jobs:
         if: always()
         id: check_files
         run: |
-          ls -la tests/e2e/test-results/report
+          ls -la ./tests/e2e/test-results/report
 
           if [ -d "tests/e2e/test-results/report" ]; then
             echo "report_exists=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,20 +148,10 @@ jobs:
         if: ${{ github.event_name == 'push' && matrix.type == '@general' }}
         run: npm run test:e2e -- --grep-invert "@cashapp|@sync|@giftcard"
 
-      - name: Check if report exists
-        if: always()
-        id: check_files
-        run: |
-          if [ -d "./tests/e2e/test-results/report" ]; then
-            echo "report_exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "report_exists=false" >> $GITHUB_OUTPUT
-            echo "No report directory found at ./tests/e2e/test-results/report for ${{ matrix.type }}"
-          fi
-
       - uses: actions/upload-artifact@v4
-        if: always() && steps.check_files.outputs.report_exists == 'true'
+        if: always()
         with:
           name: playwright-report-${{ matrix.type }}
-          path: ./tests/e2e/test-results/report
+          path: tests/e2e/test-results/report
           retention-days: 2
+          if-no-files-found: ignore

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -152,18 +152,16 @@ jobs:
         if: always()
         id: check_files
         run: |
-          ls -la ./tests/e2e/test-results/report
-
-          if [ -d "tests/e2e/test-results/report" ]; then
+          if [ -d "./tests/e2e/test-results/report" ]; then
             echo "report_exists=true" >> $GITHUB_OUTPUT
           else
             echo "report_exists=false" >> $GITHUB_OUTPUT
-            echo "No report directory found at tests/e2e/test-results/report for ${{ matrix.type }}"
+            echo "No report directory found at ./tests/e2e/test-results/report for ${{ matrix.type }}"
           fi
 
       - uses: actions/upload-artifact@v4
         if: always() && steps.check_files.outputs.report_exists == 'true'
         with:
           name: playwright-report-${{ matrix.type }}
-          path: tests/e2e/test-results/report
+          path: ./tests/e2e/test-results/report
           retention-days: 2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -152,8 +152,7 @@ jobs:
         if: always()
         id: check_files
         run: |
-          ls -la playwright-report/
-          ls -la test-results/
+          ls -la tests/e2e/test-results/report
 
           if [ -d "tests/e2e/test-results/report" ]; then
             echo "report_exists=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -152,6 +152,9 @@ jobs:
         if: always()
         id: check_files
         run: |
+          ls -la playwright-report/
+          ls -la test-results/
+
           if [ -d "tests/e2e/test-results/report" ]; then
             echo "report_exists=true" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -79,19 +79,36 @@ jobs:
         continue-on-error: true
         with:
           script: |
-            github.rest.issues.removeLabel({
+            const labelsToRemove = ['status: e2e tests passing', 'status: e2e tests failing'];
+
+            const { data } = await github.rest.issues.listLabelsOnIssue({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: ['status: e2e tests passing']
             })
 
-            github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: ['status: e2e tests failing']
-            })
+            // Return early if there are no labels;
+            if ( data.length == 0 ) {
+              console.log ( 'Issue has no labels; not attempting to remove any labels' );
+              return;
+            }
+
+            // Remove each label if it exists.
+            for ( const labelName of labelsToRemove ) {
+              const labelExists = data.filter( label => label.name === labelName );
+
+              if ( labelExists.length > 0 ) {
+                console.log( `Removing label "${labelName}"...` );
+                await github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: labelName
+                })
+              } else {
+                console.log( `Label "${labelName}" not found on issue; skipping removal` );
+              }
+            }
 
       - name: Update Success Label
         if: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -148,8 +148,19 @@ jobs:
         if: ${{ github.event_name == 'push' && matrix.type == '@general' }}
         run: npm run test:e2e -- --grep-invert "@cashapp|@sync|@giftcard"
 
-      - uses: actions/upload-artifact@v4
+      - name: Check if report exists
         if: always()
+        id: check_files
+        run: |
+          if [ -d "tests/e2e/test-results/report" ]; then
+            echo "report_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "report_exists=false" >> $GITHUB_OUTPUT
+            echo "No report directory found at tests/e2e/test-results/report for ${{ matrix.type }}"
+          fi
+
+      - uses: actions/upload-artifact@v4
+        if: always() && steps.check_files.outputs.report_exists == 'true'
         with:
           name: playwright-report-${{ matrix.type }}
           path: tests/e2e/test-results/report

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
               repo: context.repo.repo,
             })
 
-            // Return early if there are no labels;
+            // Return early if there are no labels.
             if ( data.length == 0 ) {
               console.log ( 'Issue has no labels; not attempting to remove any labels' );
               return;


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #306.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Open the https://github.com/woocommerce/woocommerce-square/actions/runs/13812011592.
2. Observe that all E2E test steps have completed successfully.
3. Despite this, the summary page shows a failure due to the errors mentioned above.

### Screenshots

<img width="1721" alt="Image" src="https://github.com/user-attachments/assets/c5358a74-3077-4a90-af83-834196b5b538" />

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Fix E2E tests remove label errors.
