### PR TITLE
Remove Duplicate Onboarding Notice in WooCommerce Square

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -403,30 +403,6 @@ class Plugin extends Payment_Gateway_Plugin {
 					)
 				);
 			}
-		} else {
-
-			$instruction = '';
-
-			if ( wc_square()->get_dependency_handler()->meets_php_dependencies() ) {
-				if ( $this->is_plugin_settings() ) {
-					$instruction = __( 'To get started, connect with Square.', 'woocommerce-square' );
-				} else {
-					$instruction = sprintf(
-						/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
-						__( 'To get started, %1$sconnect with Square &raquo;%2$s', 'woocommerce-square' ),
-						'<a href="' . esc_url( $this->get_settings_url() ) . '">',
-						'</a>'
-					);
-				}
-			}
-
-			$message = sprintf(
-				/* translators: Placeholders: %1$s - plugin name */
-				__( 'Thanks for installing %1$s!', 'woocommerce-square' ),
-				esc_html( $this->get_plugin_name() )
-			);
-
-			$this->get_admin_notice_handler()->add_admin_notice( $message . ' ' . $instruction, 'connect' );
 		}
 
 		// add a notice for out-of-bounds base locations


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

It was reported that duplicate notices appear when installing Square:

![image](https://github.com/user-attachments/assets/a3b81ab9-1ac7-4ba2-b4f4-20e92a56023d)

As discussed internally ([Slack thread](https://fueled10up.slack.com/archives/C01UCQGPBDJ/p1742995569881699?thread_ts=1742919400.178219&cid=C01UCQGPBDJ)), both notices direct users to different pages:

- “Thanks for installing WooCommerce Square! To get started, connect with Square »” → WooCommerce > Settings > Square tab
- “Welcome to Square for WooCommerce! Get started by visiting the Onboarding Wizard.” → Onboarding Wizard

However, during first-time installation, the user should ideally be directed to the Onboarding Wizard for a smoother setup experience.

Solution
- Remove the “Thanks for installing WooCommerce Square! To get started, connect with Square »” notice, as it references an older onboarding flow.

### Steps to test the changes in this Pull Request:

1. Install WooCommerce Square on a fresh setup.
2. Verify that only one onboarding notice appears, leading to the Onboarding Wizard.

### Changelog entry

> Update - Remove Duplicate Onboarding Notice in WooCommerce Square.
