### PR TITLE
Add the onboarding URL to the "Complete setup" button on the new payment settings page.

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -4845,4 +4845,15 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	public function needs_setup() {
 		return ( ! $this->is_account_connected() );
 	}
+
+	/**
+	 * Returns the Onboarding URL for the gateway.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string the Onboarding URL.
+	 */
+	public function get_connection_url() {
+		return admin_url( 'admin.php?page=woocommerce-square-onboarding' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As suggested in #338, this PR adds a `get_connection_url` method to the gateway class to set the onboarding URL for the "Complete setup" button on the new payment settings page.

![image](https://github.com/user-attachments/assets/3311cf4b-eeff-42b7-9b16-e3b9c693377e)


Closes #338

### Steps to test the changes in this Pull Request:
1. Enable the new payment settings page by adding the feature flag (more info [here](https://developer.woocommerce.com/2024/12/16/modernizing-the-woocommerce-payments-experience-technical-changes-ahead/)).
2. Install and activate the Square plugin.
3. Go to **WooCommerce > Settings > Payments**.
4. Click the "Complete setup" button in the Square payment gateway and verify that it redirects to the onboarding page instead of the settings page.

### Changelog entry
> Add - Set the onboarding URL for the "Complete setup" button on the new payment settings page.
