### PR TITLE
Ensure that debug logs for payment gateways are being generated as expected.

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -350,12 +350,6 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 		// default icon filter  @see WC_Payment_Gateway::$icon
 		$this->icon = apply_filters( 'wc_' . $this->get_id() . '_icon', '' );
 
-		$square_settings = get_option( 'wc_square_settings', array() );
-
-		$this->debug_mode = $square_settings['debug_mode'] ?? 'off';
-
-		$this->enable_customer_decline_messages = $square_settings['enable_customer_decline_messages'] ?? 'no';
-
 		// Load the form fields
 		$this->init_form_fields();
 
@@ -363,6 +357,12 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 		$this->init_settings();
 
 		$this->load_settings();
+
+		$square_settings = get_option( 'wc_square_settings', array() );
+
+		$this->debug_mode = $square_settings['debug_mode'] ?? 'off';
+
+		$this->enable_customer_decline_messages = $square_settings['enable_customer_decline_messages'] ?? 'no';
 
 		$this->init_payment_tokens_handler();
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #285, If debug mode was set to "OFF" in the Square credit card settings before upgrading to 4.7.0, it remains "OFF" even after enabling logs in the Square settings (WooCommerce > Settings > Square). This occurs because the `debug_mode` value in the payment method settings overrides the debug mode setting from the Square general settings.  The plugin [sets](https://github.com/woocommerce/woocommerce-square/blob/33b5e1d15de79734a1442e411ef82fc779ae3e04/includes/Framework/PaymentGateway/Payment_Gateway.php#L355) the `debug_mode` based on the Square general settings. However, the `load_settings` function is called [afterward](https://github.com/woocommerce/woocommerce-square/blob/33b5e1d15de79734a1442e411ef82fc779ae3e04/includes/Framework/PaymentGateway/Payment_Gateway.php#L365), which overwrites the value from the Square settings.

This PR move the code for set `debug_mode` after load_settings function to fix this issue.

Closes #285 

### Steps to test the changes in this Pull Request:
1. Install and configure Square 4.6.x.  
2. Set debug mode to "OFF" in the Square credit card settings.  
3. Switch to this PR branch.  
4. Go to **Square General Settings** (WooCommerce > Settings > Square).  
5. Set debug mode to "Save to Log."  
6. Place an order using the Square credit card payment gateway.  
7. Navigate to **WooCommerce > Status > Logs** and note that debug logs are proprely generated for `square_credit_card`.  

### Changelog entry
> Fix - Ensure that debug logs for payment gateways are being generated as expected.
