### PR TITLE
Fix errors between the Block Checkout and the Shortcode Checkout

### DIFF
--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -268,6 +268,26 @@ class Gateway extends Payment_Gateway_Direct {
 		$this->get_payment_form_instance()->render_js();
 	}
 
+	/**
+	 * Retrieves the validation exception for the gateway.
+	 *
+	 * This function is used to fetch the exception that occurs during
+	 * the validation of fields in the payment gateway. It can be utilized
+	 * in the `validation_fields` method to handle and process validation errors.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return Exception|null The validation exception if one exists, or null if no exception occurred.
+	 */
+	public function get_validation_exception() {
+		if ( '' === Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-buyer-verification-token' ) ) {
+			throw new \Exception( '3D Secure Verification Token is missing' );
+		}
+
+		if ( ! Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-nonce' ) ) {
+			throw new \Exception( 'Payment nonce is missing' );
+		}
+	}
 
 	/**
 	 * Validates the entered payment fields.
@@ -277,7 +297,6 @@ class Gateway extends Payment_Gateway_Direct {
 	 * @return bool
 	 */
 	public function validate_fields() {
-
 		$is_valid = true;
 
 		if ( $this->is_gift_card_applied() ) {
@@ -285,17 +304,9 @@ class Gateway extends Payment_Gateway_Direct {
 		}
 
 		try {
-
-			if ( '' === Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-buyer-verification-token' ) ) {
-				throw new \Exception( '3D Secure Verification Token is missing' );
-			}
-
+			$this->get_validation_exception();
 			if ( Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
 				return $is_valid;
-			}
-
-			if ( ! Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-nonce' ) ) {
-				throw new \Exception( 'Payment nonce is missing' );
 			}
 		} catch ( \Exception $exception ) {
 
@@ -1103,6 +1114,20 @@ class Gateway extends Payment_Gateway_Direct {
 	 */
 	public function wc_ajax_square_checkout_validate( $data, $errors = null ) {
 		$error_messages = null;
+
+		// Check Square payment validation.
+		if ( ! $this->validate_fields() ) {
+			try {
+				$this->get_validation_exception();
+			} catch ( \Exception $exception ) {
+				if ( $this->debug_checkout() || $this->is_detailed_customer_decline_messages_enabled() ) {
+					$errors->add( 'validation',  $exception->getMessage() );
+				} else {
+					$errors->add( 'validation', __( 'An error occurred, please try again or try an alternate form of payment.', 'woocommerce-square' ) );
+				}
+			}
+		}
+
 		if ( ! is_null( $errors ) ) {
 			$error_messages = $errors->get_error_messages();
 		}

--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -304,9 +304,16 @@ class Gateway extends Payment_Gateway_Direct {
 		}
 
 		try {
-			$this->get_validation_exception();
+			if ( '' === Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-buyer-verification-token' ) ) {
+				throw new \Exception( '3D Secure Verification Token is missing' );
+			}
+
 			if ( Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
 				return $is_valid;
+			}
+
+			if ( ! Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-nonce' ) ) {
+				throw new \Exception( 'Payment nonce is missing' );
 			}
 		} catch ( \Exception $exception ) {
 

--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -1121,7 +1121,7 @@ class Gateway extends Payment_Gateway_Direct {
 				$this->get_validation_exception();
 			} catch ( \Exception $exception ) {
 				if ( $this->debug_checkout() || $this->is_detailed_customer_decline_messages_enabled() ) {
-					$errors->add( 'validation',  $exception->getMessage() );
+					$errors->add( 'validation', $exception->getMessage() );
 				} else {
 					$errors->add( 'validation', __( 'An error occurred, please try again or try an alternate form of payment.', 'woocommerce-square' ) );
 				}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #341 .

The issue is related to #240 so i use the base branch `fix/240`. Once it merged it automatically change base branch to trunk.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Activate the Square extension.
2. Navigate to WooCommerce > Settings.
3. Go to the Square tab.
4. Access the Advanced Settings section.
5. Set the Debug Mode field to Show on Checkout Page or Both.
6. Now go to shop page and add product in cart.
7. Go to Block Checkout and the Shortcode Checkout.
8. On checkout > Payment options > Select "Credit Card" option
9. Do not fill any details in CC and click on `Place Order` button
10. Check the error in both checkout pages.

### Screenshots

#### Shortcode checkout with Detailed error message
<img width="639" alt="Screenshot 2025-04-25 at 9 09 39 AM" src="https://github.com/user-attachments/assets/7a83ad5e-de94-4dce-af8d-0e897c5979a1" />

#### Block checkout with Detailed error message
<img width="631" alt="Screenshot 2025-04-25 at 9 10 04 AM" src="https://github.com/user-attachments/assets/6120d510-58e4-49bf-b6c1-9139fb9033cd" />

#### Shortcode checkout without Detailed error message
<img width="614" alt="Screenshot 2025-04-25 at 9 10 55 AM" src="https://github.com/user-attachments/assets/f892d3e4-921c-41ff-82d6-be96acdc092c" />

#### Block checkout without Detailed error message
<img width="636" alt="Screenshot 2025-04-25 at 9 10 34 AM" src="https://github.com/user-attachments/assets/e096f082-677c-4d38-962f-997a0ec95c89" />


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Error message between the Block Checkout and the Shortcode Checkout.
