### PR TITLE
Add Pre-Sync Validations for Product Variations

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -158,6 +158,7 @@ class Admin {
 						'fetch_stock_with_square'     => __( 'Fetch stock from Square', 'woocommerce-square' ),
 						'sync_inventory'              => __( 'Sync inventory', 'woocommerce-square' ),
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
+						'attribute_name_too_long'     => __( 'Attribute name is too long', 'woocommerce-square' ),
 					),
 				)
 			);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -158,7 +158,8 @@ class Admin {
 						'fetch_stock_with_square'     => __( 'Fetch stock from Square', 'woocommerce-square' ),
 						'sync_inventory'              => __( 'Sync inventory', 'woocommerce-square' ),
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
-						'attribute_name_too_long'     => __( 'Attribute name is too long', 'woocommerce-square' ),
+						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters.', 'woocommerce-square' ),
+						'too_many_attributes'         => __( 'Too many attributes, maximum allowed are 6.', 'woocommerce-square' ),
 					),
 				)
 			);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -158,8 +158,9 @@ class Admin {
 						'fetch_stock_with_square'     => __( 'Fetch stock from Square', 'woocommerce-square' ),
 						'sync_inventory'              => __( 'Sync inventory', 'woocommerce-square' ),
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
-						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters.', 'woocommerce-square' ),
+						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters', 'woocommerce-square' ),
 						'too_many_attributes'         => __( 'Too many attributes, maximum allowed are 6.', 'woocommerce-square' ),
+						'too_many_attribute_values'   => __( 'Too many attribute values, maximum allowed are 1', 'woocommerce-square' ),
 					),
 				)
 			);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -160,7 +160,8 @@ class Admin {
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
 						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters', 'woocommerce-square' ),
 						'too_many_attributes'         => __( 'Too many attributes, maximum allowed are 6.', 'woocommerce-square' ),
-						'too_many_attribute_values'   => __( 'Too many attribute values, maximum allowed are 1', 'woocommerce-square' ),
+						'too_many_attribute_values'   => __( 'Too many attribute values, maximum allowed are 250', 'woocommerce-square' ),
+						'too_many_variations'         => __( 'Too many variations, maximum allowed are 250.', 'woocommerce-square' ),
 					),
 				)
 			);

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -129,6 +129,13 @@ class Admin {
 				true
 			);
 
+			wp_enqueue_style(
+				'wc-square-admin-products',
+				$this->get_plugin()->get_plugin_url() . '/build/assets/admin/wc-square-admin-products-styles.css',
+				array(),
+				Plugin::VERSION
+			);
+
 			wp_localize_script(
 				'wc-square-admin-products',
 				'wc_square_admin_products',

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -620,7 +620,7 @@ class Products {
 		}
 
 		$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
-		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] );
+		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore
 		$was_synced = Product::is_synced_with_square( $product );
 
 		// condition has unchanged
@@ -915,19 +915,19 @@ class Products {
 	 */
 	private function format_product_error( string $error, \WC_Product $product, array $additional_params = array() ) {
 		$product_link = Product::get_product_edit_link( $product );
-		
+
 		// Define additional parameters for specific error types
 		$params = array(
 			'too_many_variations'     => array( $product_link, 250 ),
 			'too_many_options'        => array( $product_link, 6 ),
 			'too_many_option_values'  => array( $product_link, 250 ),
 			'attribute_name_too_long' => array( $product_link, $additional_params['attribute_name'] ?? '', 65 ),
-			'default'                 => array( $product_link )
+			'default'                 => array( $product_link ),
 		);
 
-		$message_params = isset( $params[$error] ) ? $params[$error] : $params['default'];
-		
-		return vsprintf( $this->product_errors[$error], $message_params );
+		$message_params = isset( $params[ $error ] ) ? $params[ $error ] : $params['default'];
+
+		return vsprintf( $this->product_errors[ $error ], $message_params );
 	}
 
 
@@ -1748,7 +1748,7 @@ class Products {
 
 		// 2. Variable Product Validation.
 		if ( $product->is_type( 'variable' ) ) {
-			$variations = $product->get_children();
+			$variations     = $product->get_children();
 			$variation_skus = array();
 
 			// Check number of variations.

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -104,17 +104,17 @@ class Products {
 			/* translators: Placeholder: %s - product name */
 			'parent_sku_conflict'      => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'gift_card'               => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'gift_card'                => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_price'           => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'missing_price'            => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
-			'too_many_variations'     => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
+			'too_many_variations'      => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of options allowed */
-			'too_many_options'        => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
+			'too_many_options'         => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of option values allowed */
-			'too_many_option_values'  => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
+			'too_many_option_values'   => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$s - attribute name, %3$d - maximum length allowed */
-			'attribute_name_too_long' => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
+			'attribute_name_too_long'  => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
 		);
 	}
 
@@ -1761,5 +1761,71 @@ class Products {
 				array( 'back_link' => true )
 			);
 		}
+	}
+
+	/**
+	 * Process product data.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function process_product_data( $post_id ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $post_id ) ) {
+			return;
+		}
+
+		$product = wc_get_product( $post_id );
+
+		if ( ! $product ) {
+			return;
+		}
+
+		// Only process if product is syncable
+		if ( ! $this->is_product_syncable( $product ) ) {
+			return;
+		}
+
+		$sync_with_square = isset( $_POST['_sync_with_square'] ) ? 'yes' : 'no';
+		$stock_managed    = isset( $_POST['_manage_stock'] ) ? 'yes' : 'no';
+		$backorders       = isset( $_POST['_backorders'] ) ? wc_clean( wp_unslash( $_POST['_backorders'] ) ) : 'no';
+
+		// If syncing with Square is enabled and stock is managed, ensure backorders are disabled
+		if ( 'yes' === $sync_with_square && 'yes' === $stock_managed ) {
+			$backorders = 'no';
+		}
+
+		$product->update_meta_data( '_sync_with_square', $sync_with_square );
+		$product->update_meta_data( '_backorders', $backorders );
+
+		if ( 'yes' === $sync_with_square ) {
+			$this->process_sync_with_square( $product );
+		}
+
+		$product->save();
+	}
+
+	/**
+	 * Validates and processes the product data.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param WC_Product $product Product object.
+	 * @param array      $data    Product data.
+	 * @return array
+	 */
+	public function validate_product_data( $product, $data ) {
+		$errors = array();
+
+		if ( ! $this->is_product_syncable( $product ) ) {
+			return $errors;
+		}
+
+		$this->process_sync_with_square(
+			$product,
+			isset( $data['_sync_with_square'] ) ? 'yes' : 'no'
+		);
+
+		return $errors;
 	}
 }

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -104,8 +104,6 @@ class Products {
 			/* translators: Placeholder: %s - product name */
 			'parent_sku_conflict'   => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'gift_card'            => __( '%s is a gift card product and cannot be synced with Square.', 'woocommerce-square' ),
-			/* translators: Placeholder: %s - product name */
 			'missing_price'        => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
 			'too_many_variations'  => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -96,25 +96,9 @@ class Products {
 		// Add common errors.
 		$this->product_errors = array(
 			/* translators: Placeholder: %s - product name */
-			'missing_sku'             => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_sku'            => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_variation_sku'   => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
-			/* translators: Placeholder: %s - product name */
-			'duplicate_skus'          => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
-			/* translators: Placeholder: %s - product name */
-			'parent_sku_conflict'     => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
-			/* translators: Placeholder: %s - product name */
-			'gift_card'               => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
-			/* translators: Placeholder: %s - product name */
-			'missing_price'           => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
-			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
-			'too_many_variations'     => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
-			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of options allowed */
-			'too_many_options'        => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
-			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of option values allowed */
-			'too_many_option_values'  => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
-			/* translators: Placeholder: %1$s - product name, %2$s - attribute name, %3$d - maximum length allowed */
-			'attribute_name_too_long' => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
+			'missing_variation_sku' => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
 		);
 	}
 
@@ -184,7 +168,6 @@ class Products {
 		// handle individual products input fields for setting sync status
 		add_action( 'woocommerce_product_options_general_product_data', array( $this, 'add_product_data_fields' ) );
 		add_action( 'woocommerce_admin_process_product_object', array( $this, 'process_product_data' ), 20 );
-		add_action( 'woocommerce_admin_process_product_object', array( $this, 'process_product_data_on_save' ), 20 );
 		add_action( 'woocommerce_before_product_object_save', array( $this, 'maybe_adjust_square_stock' ) );
 
 		add_action( 'admin_notices', array( $this, 'add_notice_product_hidden_from_catalog' ) );
@@ -639,110 +622,6 @@ class Products {
 		}
 	}
 
-	/**
-	 * Process product data on save.
-	 *
-	 * @since 4.9.0
-	 * @param int $post_id Post ID.
-	 */
-	public function process_product_data_on_save( $post_id ) {
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $post_id ) ) {
-			return;
-		}
-
-		$product = wc_get_product( $post_id );
-
-		if ( ! $product || ! $this->is_product_syncable( $product ) ) {
-			return;
-		}
-
-		$sync_with_square = isset( $_POST['_sync_with_square'] ) ? 'yes' : 'no';
-		$stock_managed    = isset( $_POST['_manage_stock'] ) ? 'yes' : 'no';
-		$backorders       = isset( $_POST['_backorders'] ) ? wc_clean( wp_unslash( $_POST['_backorders'] ) ) : 'no';
-
-		// If syncing with Square is enabled and stock is managed, ensure backorders are disabled
-		if ( 'yes' === $sync_with_square && 'yes' === $stock_managed ) {
-			$backorders = 'no';
-		}
-
-		$product->update_meta_data( '_sync_with_square', $sync_with_square );
-		$product->update_meta_data( '_backorders', $backorders );
-
-		if ( 'yes' === $sync_with_square ) {
-			$this->process_sync_with_square( $product );
-		}
-
-		$product->save();
-	}
-
-	/**
-	 * Validates and processes the product data.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param WC_Product $product Product object.
-	 * @param array      $data    Product data.
-	 * @return array
-	 */
-	public function validate_product_data( $product, $data ) {
-		$errors = array();
-
-		if ( ! $this->is_product_syncable( $product ) ) {
-			return $errors;
-		}
-
-		$this->process_sync_with_square( $product, isset( $data['_sync_with_square'] ) ? 'yes' : 'no' );
-
-		return $errors;
-	}
-
-	/**
-	 * Checks if a product can be synced with Square.
-	 *
-	 * @since 4.9.0
-	 * @param \WC_Product $product The product to check.
-	 * @return bool Whether the product can be synced.
-	 */
-	private function is_product_syncable( \WC_Product $product ) {
-		// Check if product sync is enabled
-		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
-			return false;
-		}
-
-		// Check if product is valid
-		if ( ! $product || ! $product instanceof \WC_Product ) {
-			return false;
-		}
-
-		// Check if product type is supported
-		$supported_types = array( 'simple', 'variable' );
-		if ( ! in_array( $product->get_type(), $supported_types, true ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Process sync with Square for a product.
-	 *
-	 * @since 4.9.0
-	 * @param \WC_Product $product The product to sync.
-	 * @param string      $sync_status Optional. The sync status to set. Default 'yes'.
-	 */
-	private function process_sync_with_square( \WC_Product $product, $sync_status = 'yes' ) {
-		if ( ! $this->is_product_syncable( $product ) ) {
-			return;
-		}
-
-		// Update sync status
-		Product::set_synced_with_square( $product, $sync_status );
-
-		// If syncing is enabled, stage for sync
-		if ( 'yes' === $sync_status ) {
-			$this->maybe_stage_product_for_sync( $product );
-		}
-	}
 
 	/**
 	 * Adjusts a product's Square stock.
@@ -910,24 +789,13 @@ class Products {
 	 *
 	 * @param string $error error identifier (e.g. 'missing_variation_sku' or 'missing_sku')
 	 * @param \WC_Product $product product object
-	 * @param array $additional_params Additional parameters for the error message
 	 * @return string formatted error message
 	 */
 	private function format_product_error( string $error, \WC_Product $product, array $additional_params = array() ) {
-		$product_link = Product::get_product_edit_link( $product );
-
-		// Define additional parameters for specific error types
-		$params = array(
-			'too_many_variations'     => array( $product_link, 250 ),
-			'too_many_options'        => array( $product_link, 6 ),
-			'too_many_option_values'  => array( $product_link, 250 ),
-			'attribute_name_too_long' => array( $product_link, $additional_params['attribute_name'] ?? '', 65 ),
-			'default'                 => array( $product_link ),
+		return sprintf(
+			$this->product_errors[ $error ],
+			Product::get_product_edit_link( $product )
 		);
-
-		$message_params = isset( $params[ $error ] ) ? $params[ $error ] : $params['default'];
-
-		return vsprintf( $this->product_errors[ $error ], $message_params );
 	}
 
 
@@ -1722,155 +1590,5 @@ class Products {
 		}
 
 		return wp_get_attachment_url( $attachment->ID );
-	}
-
-	/**
-	 * Validates a product before it can be synced with Square.
-	 * This runs on the product edit screen to catch issues early.
-	 *
-	 * @since 4.9.0
-	 * @param \WC_Product $product The product to validate.
-	 * @return array Array of validation errors, empty if valid.
-	 */
-	private function validate_product_for_square_sync( \WC_Product $product ) {
-		$errors = array();
-
-		// Define Square constraints.
-		$max_variations            = 250;
-		$max_options               = 6;
-		$max_option_values         = 250;
-		$max_attribute_name_length = 65;
-
-		// 1. SKU Validation.
-		if ( ! Product::has_sku( $product ) ) {
-			$errors['missing_sku'] = $this->format_product_error( 'missing_sku', $product );
-		}
-
-		// 2. Variable Product Validation.
-		if ( $product->is_type( 'variable' ) ) {
-			$variations     = $product->get_children();
-			$variation_skus = array();
-
-			// Check number of variations.
-			if ( count( $variations ) > $max_variations ) {
-				$errors['too_many_variations'] = $this->format_product_error( 'too_many_variations', $product );
-			}
-
-			// Check variations SKUs.
-			foreach ( $variations as $variation_id ) {
-				$variation = wc_get_product( $variation_id );
-				if ( ! $variation || ! $variation->get_sku() ) {
-					$errors['missing_variation_sku'] = $this->format_product_error( 'missing_variation_sku', $product );
-					break;
-				}
-				$variation_skus[] = $variation->get_sku();
-			}
-
-			// Check for duplicate SKUs.
-			if ( count( $variation_skus ) !== count( array_unique( $variation_skus ) ) ) {
-				$errors['duplicate_skus'] = $this->format_product_error( 'duplicate_skus', $product );
-			}
-
-			// Check if parent SKU conflicts with variation SKUs.
-			if ( $product->get_sku() && in_array( $product->get_sku(), $variation_skus, true ) ) {
-				$errors['parent_sku_conflict'] = $this->format_product_error( 'parent_sku_conflict', $product );
-			}
-
-			// 3. Attribute/Options Validation.
-			$attributes = $product->get_attributes();
-
-			// Check number of options/attributes.
-			if ( count( $attributes ) > $max_options ) {
-				$errors['too_many_options'] = $this->format_product_error( 'too_many_options', $product );
-			}
-
-			// Check each attribute.
-			foreach ( $attributes as $attribute ) {
-				// Check attribute name length.
-				if ( strlen( $attribute->get_name() ) > $max_attribute_name_length ) {
-					$errors['attribute_name_too_long'] = $this->format_product_error(
-						'attribute_name_too_long',
-						$product,
-						array( 'attribute_name' => $attribute->get_name() )
-					);
-				}
-
-				// Check number of values per option.
-				if ( $attribute->is_taxonomy() ) {
-					$terms = get_terms(
-						array(
-							'taxonomy'   => $attribute->get_name(),
-							'hide_empty' => false,
-						)
-					);
-					if ( count( $terms ) > $max_option_values ) {
-						$errors['too_many_option_values'] = $this->format_product_error( 'too_many_option_values', $product );
-					}
-				} else {
-					$values = $attribute->get_options();
-					if ( count( $values ) > $max_option_values ) {
-						$errors['too_many_option_values'] = $this->format_product_error( 'too_many_option_values', $product );
-					}
-				}
-			}
-		}
-
-		// 4. Gift Card Validation.
-		if ( $product->get_meta( '_gift_card' ) === 'yes' ) {
-			$errors['gift_card'] = $this->format_product_error( 'gift_card', $product );
-		}
-
-		// 5. Price Validation.
-		if ( ! $product->get_regular_price() && ! $product->get_sale_price() ) {
-			$errors['missing_price'] = $this->format_product_error( 'missing_price', $product );
-		}
-
-		/**
-		 * Filter the validation errors for a product before syncing with Square.
-		 *
-		 * @since 2.0.0
-		 * @param array $errors Array of validation errors.
-		 * @param \WC_Product $product The product being validated.
-		 */
-		return apply_filters( 'wc_square_product_sync_validation_errors', $errors, $product );
-	}
-
-	/**
-	 * Maybe prevent product save if validation fails
-	 *
-	 * @since 2.0.0
-	 * @param \WC_Product $product the product to validate
-	 */
-	public function maybe_prevent_product_save( $product ) {
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $product->get_id() ) ) {
-			return;
-		}
-
-		try {
-			// Check if product sync is enabled.
-			if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
-				return;
-			}
-
-			$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
-			$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] );
-			$was_synced = Product::is_synced_with_square( $product );
-
-			// Validate if product is being set to sync or is already synced.
-			if ( $set_synced || $was_synced ) {
-				$validation_errors = $this->validate_product_for_square_sync( $product );
-				if ( ! empty( $validation_errors ) ) {
-					foreach ( $validation_errors as $error ) {
-						wc_square()->get_message_handler()->add_warning( $error );
-					}
-				}
-			}
-		} catch ( \Exception $e ) {
-			wp_die(
-				esc_html( $e->getMessage() ),
-				esc_html__( 'Square Sync Validation Error', 'woocommerce-square' ),
-				array( 'back_link' => true )
-			);
-		}
 	}
 }

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -96,13 +96,13 @@ class Products {
 		// Add common errors.
 		$this->product_errors = array(
 			/* translators: Placeholder: %s - product name */
-			'missing_sku'              => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_sku'             => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_variation_sku'    => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_variation_sku'   => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'duplicate_skus'           => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
+			'duplicate_skus'          => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'parent_sku_conflict'      => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
+			'parent_sku_conflict'     => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
 			'gift_card'               => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
@@ -1736,9 +1736,9 @@ class Products {
 		$errors = array();
 
 		// Define Square constraints.
-		$max_variations = 250;
-		$max_options = 6;
-		$max_option_values = 250;
+		$max_variations            = 250;
+		$max_options               = 6;
+		$max_option_values         = 250;
 		$max_attribute_name_length = 65;
 
 		// 1. SKU Validation.
@@ -1750,7 +1750,7 @@ class Products {
 		if ( $product->is_type( 'variable' ) ) {
 			$variations = $product->get_children();
 			$variation_skus = array();
-			
+
 			// Check number of variations.
 			if ( count( $variations ) > $max_variations ) {
 				$errors['too_many_variations'] = $this->format_product_error( 'too_many_variations', $product );
@@ -1778,7 +1778,7 @@ class Products {
 
 			// 3. Attribute/Options Validation.
 			$attributes = $product->get_attributes();
-			
+
 			// Check number of options/attributes.
 			if ( count( $attributes ) > $max_options ) {
 				$errors['too_many_options'] = $this->format_product_error( 'too_many_options', $product );
@@ -1797,10 +1797,12 @@ class Products {
 
 				// Check number of values per option.
 				if ( $attribute->is_taxonomy() ) {
-					$terms = get_terms( array(
-						'taxonomy'   => $attribute->get_name(),
-						'hide_empty' => false,
-					) );
+					$terms = get_terms(
+						array(
+							'taxonomy'   => $attribute->get_name(),
+							'hide_empty' => false,
+						)
+					);
 					if ( count( $terms ) > $max_option_values ) {
 						$errors['too_many_option_values'] = $this->format_product_error( 'too_many_option_values', $product );
 					}
@@ -1840,6 +1842,10 @@ class Products {
 	 * @param \WC_Product $product the product to validate
 	 */
 	public function maybe_prevent_product_save( $product ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $product->get_id() ) ) {
+			return;
+		}
+
 		try {
 			// Check if product sync is enabled.
 			if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -82,6 +82,9 @@ class Products {
 		$this->add_products_edit_screen_hooks();
 		$this->add_product_edit_screen_hooks();
 		$this->add_product_sync_hooks();
+
+		// Add hook to prevent product save on validation failure
+		add_action( 'woocommerce_before_product_object_save', array( $this, 'maybe_prevent_product_save' ), 10, 1 );
 	}
 
 	/**
@@ -96,6 +99,22 @@ class Products {
 			'missing_sku'           => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
 			'missing_variation_sku' => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
+			/* translators: Placeholder: %s - product name */
+			'duplicate_skus'        => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
+			/* translators: Placeholder: %s - product name */
+			'parent_sku_conflict'   => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
+			/* translators: Placeholder: %s - product name */
+			'gift_card'            => __( '%s is a gift card product and cannot be synced with Square.', 'woocommerce-square' ),
+			/* translators: Placeholder: %s - product name */
+			'missing_price'        => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
+			'too_many_variations'  => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
+			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of options allowed */
+			'too_many_options'     => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
+			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of option values allowed */
+			'too_many_option_values' => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
+			/* translators: Placeholder: %1$s - product name, %2$s - attribute name, %3$d - maximum length allowed */
+			'attribute_name_too_long' => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
 		);
 	}
 
@@ -588,7 +607,6 @@ class Products {
 	 * @param \WC_Product $product product object
 	 */
 	public function process_product_data( $product ) {
-
 		// don't process fields if product sync is disabled
 		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
 			return;
@@ -599,7 +617,6 @@ class Products {
 			return;
 		}
 
-		$errors     = array();
 		$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
 		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore
 		$was_synced = Product::is_synced_with_square( $product );
@@ -787,13 +804,24 @@ class Products {
 	 *
 	 * @param string $error error identifier (e.g. 'missing_variation_sku' or 'missing_sku')
 	 * @param \WC_Product $product product object
+	 * @param array $additional_params Additional parameters for the error message
 	 * @return string formatted error message
 	 */
-	private function format_product_error( string $error, \WC_Product $product ) {
-		return sprintf(
-			$this->product_errors[ $error ],
-			Product::get_product_edit_link( $product )
+	private function format_product_error( string $error, \WC_Product $product, array $additional_params = array() ) {
+		$product_link = Product::get_product_edit_link( $product );
+		
+		// Define additional parameters for specific error types
+		$params = array(
+			'too_many_variations'     => array( $product_link, 250 ),
+			'too_many_options'        => array( $product_link, 6 ),
+			'too_many_option_values'  => array( $product_link, 250 ),
+			'attribute_name_too_long' => array( $product_link, $additional_params['attribute_name'] ?? '', 65 ),
+			'default'                 => array( $product_link )
 		);
+
+		$message_params = isset( $params[$error] ) ? $params[$error] : $params['default'];
+		
+		return vsprintf( $this->product_errors[$error], $message_params );
 	}
 
 
@@ -1588,5 +1616,146 @@ class Products {
 		}
 
 		return wp_get_attachment_url( $attachment->ID );
+	}
+
+	/**
+	 * Validates a product before it can be synced with Square.
+	 * This runs on the product edit screen to catch issues early.
+	 *
+	 * @since 2.0.0
+	 * @param \WC_Product $product the product to validate
+	 * @return array Array of validation errors, empty if valid
+	 */
+	private function validate_product_for_square_sync( \WC_Product $product ) {
+		$errors = array();
+
+		// Define Square constraints
+		$max_variations = 250;
+		$max_options = 6;
+		$max_option_values = 250;
+		$max_attribute_name_length = 65;
+
+		// 1. SKU Validation
+		if (!Product::has_sku($product)) {
+			$errors['missing_sku'] = $this->format_product_error('missing_sku', $product);
+		}
+
+		// 2. Variable Product Validation
+		if ($product->is_type('variable')) {
+			$variations = $product->get_children();
+			$variation_skus = array();
+			
+			// Check number of variations
+			if (count($variations) > $max_variations) {
+				$errors['too_many_variations'] = $this->format_product_error('too_many_variations', $product);
+			}
+
+			// Check variations SKUs
+			foreach ($variations as $variation_id) {
+				$variation = wc_get_product($variation_id);
+				if (!$variation || !$variation->get_sku()) {
+					$errors['missing_variation_sku'] = $this->format_product_error('missing_variation_sku', $product);
+					break;
+				}
+				$variation_skus[] = $variation->get_sku();
+			}
+
+			// Check for duplicate SKUs
+			if (count($variation_skus) !== count(array_unique($variation_skus))) {
+				$errors['duplicate_skus'] = $this->format_product_error('duplicate_skus', $product);
+			}
+
+			// Check if parent SKU conflicts with variation SKUs
+			if ($product->get_sku() && in_array($product->get_sku(), $variation_skus)) {
+				$errors['parent_sku_conflict'] = $this->format_product_error('parent_sku_conflict', $product);
+			}
+
+			// 3. Attribute/Options Validation
+			$attributes = $product->get_attributes();
+			
+			// Check number of options/attributes
+			if (count($attributes) > $max_options) {
+				$errors['too_many_options'] = $this->format_product_error('too_many_options', $product);
+			}
+
+			// Check each attribute
+			foreach ($attributes as $attribute) {
+				// Check attribute name length
+				if (strlen($attribute->get_name()) > $max_attribute_name_length) {
+					$errors['attribute_name_too_long'] = $this->format_product_error(
+						'attribute_name_too_long',
+						$product,
+						array('attribute_name' => $attribute->get_name())
+					);
+				}
+
+				// Check number of values per option
+				if ($attribute->is_taxonomy()) {
+					$terms = get_terms([
+						'taxonomy' => $attribute->get_name(),
+						'hide_empty' => false,
+					]);
+					if (count($terms) > $max_option_values) {
+						$errors['too_many_option_values'] = $this->format_product_error('too_many_option_values', $product);
+					}
+				} else {
+					$values = $attribute->get_options();
+					if (count($values) > $max_option_values) {
+						$errors['too_many_option_values'] = $this->format_product_error('too_many_option_values', $product);
+					}
+				}
+			}
+		}
+
+		// 4. Gift Card Validation
+		if ($product->get_meta('_gift_card') === 'yes') {
+			$errors['gift_card'] = $this->format_product_error('gift_card', $product);
+		}
+
+		// 5. Price Validation
+		if (!$product->get_regular_price() && !$product->get_sale_price()) {
+			$errors['missing_price'] = $this->format_product_error('missing_price', $product);
+		}
+
+		/**
+		 * Filter the validation errors for a product before syncing with Square.
+		 *
+		 * @since 2.0.0
+		 * @param array $errors Array of validation errors
+		 * @param \WC_Product $product The product being validated
+		 */
+		return apply_filters('wc_square_product_sync_validation_errors', $errors, $product);
+	}
+
+	/**
+	 * Maybe prevent product save if validation fails
+	 *
+	 * @since 2.0.0
+	 * @param \WC_Product $product the product to validate
+	 */
+	public function maybe_prevent_product_save( $product ) {
+		try {
+			// Check if product sync is enabled
+			if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
+				return;
+			}
+
+			$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
+			$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore
+			$was_synced = Product::is_synced_with_square( $product );
+
+			// Validate if product is being set to sync or is already synced
+			if ( $set_synced || $was_synced ) {
+				$validation_errors = $this->validate_product_for_square_sync( $product );
+				if ( ! empty( $validation_errors ) ) {
+					foreach ( $validation_errors as $error ) {
+						wc_square()->get_message_handler()->add_warning( $error );
+					}
+					// throw new \Exception( __( 'This product cannot be synced with Square due to validation errors. Please fix the errors and try again.', 'woocommerce-square' ) );
+				}
+			}
+		} catch ( \Exception $e ) {
+			wp_die( esc_html( $e->getMessage() ), esc_html__( 'Square Sync Validation Error', 'woocommerce-square' ), array( 'back_link' => true ) );
+		}
 	}
 }

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -96,21 +96,23 @@ class Products {
 		// Add common errors.
 		$this->product_errors = array(
 			/* translators: Placeholder: %s - product name */
-			'missing_sku'           => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_sku'              => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_variation_sku' => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_variation_sku'    => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'duplicate_skus'        => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
+			'duplicate_skus'           => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'parent_sku_conflict'   => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
+			'parent_sku_conflict'      => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_price'        => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'gift_card'               => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			/* translators: Placeholder: %s - product name */
+			'missing_price'           => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
-			'too_many_variations'  => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
+			'too_many_variations'     => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of options allowed */
-			'too_many_options'     => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
+			'too_many_options'        => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of option values allowed */
-			'too_many_option_values' => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
+			'too_many_option_values'  => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$s - attribute name, %3$d - maximum length allowed */
 			'attribute_name_too_long' => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
 		);
@@ -1621,108 +1623,108 @@ class Products {
 	 * This runs on the product edit screen to catch issues early.
 	 *
 	 * @since 4.9.0
-	 * @param \WC_Product $product the product to validate
-	 * @return array Array of validation errors, empty if valid
+	 * @param \WC_Product $product The product to validate.
+	 * @return array Array of validation errors, empty if valid.
 	 */
 	private function validate_product_for_square_sync( \WC_Product $product ) {
 		$errors = array();
 
-		// Define Square constraints
+		// Define Square constraints.
 		$max_variations = 250;
 		$max_options = 6;
 		$max_option_values = 250;
 		$max_attribute_name_length = 65;
 
-		// 1. SKU Validation
-		if (!Product::has_sku($product)) {
-			$errors['missing_sku'] = $this->format_product_error('missing_sku', $product);
+		// 1. SKU Validation.
+		if ( ! Product::has_sku( $product ) ) {
+			$errors['missing_sku'] = $this->format_product_error( 'missing_sku', $product );
 		}
 
-		// 2. Variable Product Validation
-		if ($product->is_type('variable')) {
+		// 2. Variable Product Validation.
+		if ( $product->is_type( 'variable' ) ) {
 			$variations = $product->get_children();
 			$variation_skus = array();
 			
-			// Check number of variations
-			if (count($variations) > $max_variations) {
-				$errors['too_many_variations'] = $this->format_product_error('too_many_variations', $product);
+			// Check number of variations.
+			if ( count( $variations ) > $max_variations ) {
+				$errors['too_many_variations'] = $this->format_product_error( 'too_many_variations', $product );
 			}
 
-			// Check variations SKUs
-			foreach ($variations as $variation_id) {
-				$variation = wc_get_product($variation_id);
-				if (!$variation || !$variation->get_sku()) {
-					$errors['missing_variation_sku'] = $this->format_product_error('missing_variation_sku', $product);
+			// Check variations SKUs.
+			foreach ( $variations as $variation_id ) {
+				$variation = wc_get_product( $variation_id );
+				if ( ! $variation || ! $variation->get_sku() ) {
+					$errors['missing_variation_sku'] = $this->format_product_error( 'missing_variation_sku', $product );
 					break;
 				}
 				$variation_skus[] = $variation->get_sku();
 			}
 
-			// Check for duplicate SKUs
-			if (count($variation_skus) !== count(array_unique($variation_skus))) {
-				$errors['duplicate_skus'] = $this->format_product_error('duplicate_skus', $product);
+			// Check for duplicate SKUs.
+			if ( count( $variation_skus ) !== count( array_unique( $variation_skus ) ) ) {
+				$errors['duplicate_skus'] = $this->format_product_error( 'duplicate_skus', $product );
 			}
 
-			// Check if parent SKU conflicts with variation SKUs
-			if ($product->get_sku() && in_array($product->get_sku(), $variation_skus)) {
-				$errors['parent_sku_conflict'] = $this->format_product_error('parent_sku_conflict', $product);
+			// Check if parent SKU conflicts with variation SKUs.
+			if ( $product->get_sku() && in_array( $product->get_sku(), $variation_skus, true ) ) {
+				$errors['parent_sku_conflict'] = $this->format_product_error( 'parent_sku_conflict', $product );
 			}
 
-			// 3. Attribute/Options Validation
+			// 3. Attribute/Options Validation.
 			$attributes = $product->get_attributes();
 			
-			// Check number of options/attributes
-			if (count($attributes) > $max_options) {
-				$errors['too_many_options'] = $this->format_product_error('too_many_options', $product);
+			// Check number of options/attributes.
+			if ( count( $attributes ) > $max_options ) {
+				$errors['too_many_options'] = $this->format_product_error( 'too_many_options', $product );
 			}
 
-			// Check each attribute
-			foreach ($attributes as $attribute) {
-				// Check attribute name length
-				if (strlen($attribute->get_name()) > $max_attribute_name_length) {
+			// Check each attribute.
+			foreach ( $attributes as $attribute ) {
+				// Check attribute name length.
+				if ( strlen( $attribute->get_name() ) > $max_attribute_name_length ) {
 					$errors['attribute_name_too_long'] = $this->format_product_error(
 						'attribute_name_too_long',
 						$product,
-						array('attribute_name' => $attribute->get_name())
+						array( 'attribute_name' => $attribute->get_name() )
 					);
 				}
 
-				// Check number of values per option
-				if ($attribute->is_taxonomy()) {
-					$terms = get_terms([
-						'taxonomy' => $attribute->get_name(),
+				// Check number of values per option.
+				if ( $attribute->is_taxonomy() ) {
+					$terms = get_terms( array(
+						'taxonomy'   => $attribute->get_name(),
 						'hide_empty' => false,
-					]);
-					if (count($terms) > $max_option_values) {
-						$errors['too_many_option_values'] = $this->format_product_error('too_many_option_values', $product);
+					) );
+					if ( count( $terms ) > $max_option_values ) {
+						$errors['too_many_option_values'] = $this->format_product_error( 'too_many_option_values', $product );
 					}
 				} else {
 					$values = $attribute->get_options();
-					if (count($values) > $max_option_values) {
-						$errors['too_many_option_values'] = $this->format_product_error('too_many_option_values', $product);
+					if ( count( $values ) > $max_option_values ) {
+						$errors['too_many_option_values'] = $this->format_product_error( 'too_many_option_values', $product );
 					}
 				}
 			}
 		}
 
-		// 4. Gift Card Validation
-		if ($product->get_meta('_gift_card') === 'yes') {
-			$errors['gift_card'] = $this->format_product_error('gift_card', $product);
+		// 4. Gift Card Validation.
+		if ( $product->get_meta( '_gift_card' ) === 'yes' ) {
+			$errors['gift_card'] = $this->format_product_error( 'gift_card', $product );
 		}
 
-		// 5. Price Validation
-		if (!$product->get_regular_price() && !$product->get_sale_price()) {
-			$errors['missing_price'] = $this->format_product_error('missing_price', $product);
+		// 5. Price Validation.
+		if ( ! $product->get_regular_price() && ! $product->get_sale_price() ) {
+			$errors['missing_price'] = $this->format_product_error( 'missing_price', $product );
 		}
 
 		/**
 		 * Filter the validation errors for a product before syncing with Square.
 		 *
 		 * @since 2.0.0
-		 * @param array $errors Array of validation errors
-		 * @param \WC_Product $product The product being validated
+		 * @param array $errors Array of validation errors.
+		 * @param \WC_Product $product The product being validated.
 		 */
-		return apply_filters('wc_square_product_sync_validation_errors', $errors, $product);
+		return apply_filters( 'wc_square_product_sync_validation_errors', $errors, $product );
 	}
 
 	/**
@@ -1733,16 +1735,16 @@ class Products {
 	 */
 	public function maybe_prevent_product_save( $product ) {
 		try {
-			// Check if product sync is enabled
+			// Check if product sync is enabled.
 			if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
 				return;
 			}
 
 			$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
-			$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore
+			$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$was_synced = Product::is_synced_with_square( $product );
 
-			// Validate if product is being set to sync or is already synced
+			// Validate if product is being set to sync or is already synced.
 			if ( $set_synced || $was_synced ) {
 				$validation_errors = $this->validate_product_for_square_sync( $product );
 				if ( ! empty( $validation_errors ) ) {
@@ -1753,7 +1755,11 @@ class Products {
 				}
 			}
 		} catch ( \Exception $e ) {
-			wp_die( esc_html( $e->getMessage() ), esc_html__( 'Square Sync Validation Error', 'woocommerce-square' ), array( 'back_link' => true ) );
+			wp_die( 
+				esc_html( $e->getMessage() ),
+				esc_html__( 'Square Sync Validation Error', 'woocommerce-square' ),
+				array( 'back_link' => true )
+			);
 		}
 	}
 }

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -1620,7 +1620,7 @@ class Products {
 	 * Validates a product before it can be synced with Square.
 	 * This runs on the product edit screen to catch issues early.
 	 *
-	 * @since 2.0.0
+	 * @since 4.9.0
 	 * @param \WC_Product $product the product to validate
 	 * @return array Array of validation errors, empty if valid
 	 */

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -82,9 +82,6 @@ class Products {
 		$this->add_products_edit_screen_hooks();
 		$this->add_product_edit_screen_hooks();
 		$this->add_product_sync_hooks();
-
-		// Add hook to prevent product save on validation failure
-		add_action( 'woocommerce_before_product_object_save', array( $this, 'maybe_prevent_product_save' ), 10, 1 );
 	}
 
 	/**
@@ -96,7 +93,7 @@ class Products {
 		// Add common errors.
 		$this->product_errors = array(
 			/* translators: Placeholder: %s - product name */
-			'missing_sku'            => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_sku'           => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
 			'missing_variation_sku' => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
 		);
@@ -602,6 +599,7 @@ class Products {
 			return;
 		}
 
+		$errors     = array();
 		$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
 		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore
 		$was_synced = Product::is_synced_with_square( $product );
@@ -791,7 +789,7 @@ class Products {
 	 * @param \WC_Product $product product object
 	 * @return string formatted error message
 	 */
-	private function format_product_error( string $error, \WC_Product $product, array $additional_params = array() ) {
+	private function format_product_error( string $error, \WC_Product $product ) {
 		return sprintf(
 			$this->product_errors[ $error ],
 			Product::get_product_edit_link( $product )

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -96,23 +96,23 @@ class Products {
 		// Add common errors.
 		$this->product_errors = array(
 			/* translators: Placeholder: %s - product name */
-			'missing_sku'             => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_sku'              => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_variation_sku'   => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_variation_sku'    => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'duplicate_skus'          => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
+			'duplicate_skus'           => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'parent_sku_conflict'     => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
+			'parent_sku_conflict'      => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'gift_card'              => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'gift_card'               => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_price'          => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'missing_price'           => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
-			'too_many_variations'    => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
+			'too_many_variations'     => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of options allowed */
-			'too_many_options'       => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
+			'too_many_options'        => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of option values allowed */
-			'too_many_option_values' => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
+			'too_many_option_values'  => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$s - attribute name, %3$d - maximum length allowed */
 			'attribute_name_too_long' => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
 		);
@@ -184,6 +184,7 @@ class Products {
 		// handle individual products input fields for setting sync status
 		add_action( 'woocommerce_product_options_general_product_data', array( $this, 'add_product_data_fields' ) );
 		add_action( 'woocommerce_admin_process_product_object', array( $this, 'process_product_data' ), 20 );
+		add_action( 'woocommerce_admin_process_product_object', array( $this, 'process_product_data_on_save' ), 20 );
 		add_action( 'woocommerce_before_product_object_save', array( $this, 'maybe_adjust_square_stock' ) );
 
 		add_action( 'admin_notices', array( $this, 'add_notice_product_hidden_from_catalog' ) );
@@ -606,7 +607,8 @@ class Products {
 	 *
 	 * @param \WC_Product $product product object
 	 */
-	public function update_product_sync_status( $product ) {
+	public function process_product_data( $product ) {
+
 		// don't process fields if product sync is disabled
 		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
 			return;
@@ -618,7 +620,7 @@ class Products {
 		}
 
 		$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
-		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] );
 		$was_synced = Product::is_synced_with_square( $product );
 
 		// condition has unchanged
@@ -643,7 +645,7 @@ class Products {
 	 * @since 4.9.0
 	 * @param int $post_id Post ID.
 	 */
-	public function process_product_data( $post_id ) {
+	public function process_product_data_on_save( $post_id ) {
 		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $post_id ) ) {
 			return;
 		}
@@ -689,10 +691,7 @@ class Products {
 			return $errors;
 		}
 
-		$this->process_sync_with_square(
-			$product,
-			isset( $data['_sync_with_square'] ) ? 'yes' : 'no'
-		);
+		$this->process_sync_with_square( $product, isset( $data['_sync_with_square'] ) ? 'yes' : 'no' );
 
 		return $errors;
 	}
@@ -1848,7 +1847,7 @@ class Products {
 			}
 
 			$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
-			$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] );
 			$was_synced = Product::is_synced_with_square( $product );
 
 			// Validate if product is being set to sync or is already synced.
@@ -1858,11 +1857,10 @@ class Products {
 					foreach ( $validation_errors as $error ) {
 						wc_square()->get_message_handler()->add_warning( $error );
 					}
-					// throw new \Exception( __( 'This product cannot be synced with Square due to validation errors. Please fix the errors and try again.', 'woocommerce-square' ) );
 				}
 			}
 		} catch ( \Exception $e ) {
-			wp_die( 
+			wp_die(
 				esc_html( $e->getMessage() ),
 				esc_html__( 'Square Sync Validation Error', 'woocommerce-square' ),
 				array( 'back_link' => true )

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -96,25 +96,25 @@ class Products {
 		// Add common errors.
 		$this->product_errors = array(
 			/* translators: Placeholder: %s - product name */
-			'missing_sku'              => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_sku'             => __( "Please add an SKU to sync %s with Square. The SKU must match the item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_variation_sku'    => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
+			'missing_variation_sku'   => __( "Please add an SKU to every variation of %s for syncing with Square. Each SKU must be unique and match the corresponding item's SKU in your Square account.", 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'duplicate_skus'           => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
+			'duplicate_skus'          => __( 'Variations of %s have duplicate SKUs. Each variation must have a unique SKU.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'parent_sku_conflict'      => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
+			'parent_sku_conflict'     => __( 'The SKU of %s conflicts with one of its variations. Parent and variation SKUs must be unique.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'gift_card'                => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'gift_card'              => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %s - product name */
-			'missing_price'            => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
+			'missing_price'          => __( '%s must have a price set to sync with Square.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of variations allowed */
-			'too_many_variations'      => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
+			'too_many_variations'    => __( '%1$s has too many variations. Square allows a maximum of %2$d variations per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of options allowed */
-			'too_many_options'         => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
+			'too_many_options'       => __( '%1$s has too many options. Square allows a maximum of %2$d options per product.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$d - maximum number of option values allowed */
-			'too_many_option_values'   => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
+			'too_many_option_values' => __( '%1$s has an option with too many values. Square allows a maximum of %2$d values per option.', 'woocommerce-square' ),
 			/* translators: Placeholder: %1$s - product name, %2$s - attribute name, %3$d - maximum length allowed */
-			'attribute_name_too_long'  => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
+			'attribute_name_too_long' => __( '%1$s has an attribute name "%2$s" that exceeds Square\'s limit of %3$d characters.', 'woocommerce-square' ),
 		);
 	}
 
@@ -606,7 +606,7 @@ class Products {
 	 *
 	 * @param \WC_Product $product product object
 	 */
-	public function process_product_data( $product ) {
+	public function update_product_sync_status( $product ) {
 		// don't process fields if product sync is disabled
 		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
 			return;
@@ -618,7 +618,7 @@ class Products {
 		}
 
 		$posted_key = '_' . Product::SYNCED_WITH_SQUARE_TAXONOMY;
-		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore
+		$set_synced = isset( $_POST[ $posted_key ] ) && 'yes' === sanitize_key( $_POST[ $posted_key ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$was_synced = Product::is_synced_with_square( $product );
 
 		// condition has unchanged
@@ -637,6 +637,113 @@ class Products {
 		}
 	}
 
+	/**
+	 * Process product data on save.
+	 *
+	 * @since 4.9.0
+	 * @param int $post_id Post ID.
+	 */
+	public function process_product_data( $post_id ) {
+		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $post_id ) ) {
+			return;
+		}
+
+		$product = wc_get_product( $post_id );
+
+		if ( ! $product || ! $this->is_product_syncable( $product ) ) {
+			return;
+		}
+
+		$sync_with_square = isset( $_POST['_sync_with_square'] ) ? 'yes' : 'no';
+		$stock_managed    = isset( $_POST['_manage_stock'] ) ? 'yes' : 'no';
+		$backorders       = isset( $_POST['_backorders'] ) ? wc_clean( wp_unslash( $_POST['_backorders'] ) ) : 'no';
+
+		// If syncing with Square is enabled and stock is managed, ensure backorders are disabled
+		if ( 'yes' === $sync_with_square && 'yes' === $stock_managed ) {
+			$backorders = 'no';
+		}
+
+		$product->update_meta_data( '_sync_with_square', $sync_with_square );
+		$product->update_meta_data( '_backorders', $backorders );
+
+		if ( 'yes' === $sync_with_square ) {
+			$this->process_sync_with_square( $product );
+		}
+
+		$product->save();
+	}
+
+	/**
+	 * Validates and processes the product data.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param WC_Product $product Product object.
+	 * @param array      $data    Product data.
+	 * @return array
+	 */
+	public function validate_product_data( $product, $data ) {
+		$errors = array();
+
+		if ( ! $this->is_product_syncable( $product ) ) {
+			return $errors;
+		}
+
+		$this->process_sync_with_square(
+			$product,
+			isset( $data['_sync_with_square'] ) ? 'yes' : 'no'
+		);
+
+		return $errors;
+	}
+
+	/**
+	 * Checks if a product can be synced with Square.
+	 *
+	 * @since 4.9.0
+	 * @param \WC_Product $product The product to check.
+	 * @return bool Whether the product can be synced.
+	 */
+	private function is_product_syncable( \WC_Product $product ) {
+		// Check if product sync is enabled
+		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
+			return false;
+		}
+
+		// Check if product is valid
+		if ( ! $product || ! $product instanceof \WC_Product ) {
+			return false;
+		}
+
+		// Check if product type is supported
+		$supported_types = array( 'simple', 'variable' );
+		if ( ! in_array( $product->get_type(), $supported_types, true ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Process sync with Square for a product.
+	 *
+	 * @since 4.9.0
+	 * @param \WC_Product $product The product to sync.
+	 * @param string      $sync_status Optional. The sync status to set. Default 'yes'.
+	 */
+	private function process_sync_with_square( \WC_Product $product, $sync_status = 'yes' ) {
+		if ( ! $this->is_product_syncable( $product ) ) {
+			return;
+		}
+
+		// Update sync status
+		Product::set_synced_with_square( $product, $sync_status );
+
+		// If syncing is enabled, stage for sync
+		if ( 'yes' === $sync_status ) {
+			$this->maybe_stage_product_for_sync( $product );
+		}
+	}
 
 	/**
 	 * Adjusts a product's Square stock.
@@ -1761,71 +1868,5 @@ class Products {
 				array( 'back_link' => true )
 			);
 		}
-	}
-
-	/**
-	 * Process product data.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param int $post_id Post ID.
-	 */
-	public function process_product_data( $post_id ) {
-		if ( ! isset( $_POST['_wpnonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['_wpnonce'] ), 'update-post_' . $post_id ) ) {
-			return;
-		}
-
-		$product = wc_get_product( $post_id );
-
-		if ( ! $product ) {
-			return;
-		}
-
-		// Only process if product is syncable
-		if ( ! $this->is_product_syncable( $product ) ) {
-			return;
-		}
-
-		$sync_with_square = isset( $_POST['_sync_with_square'] ) ? 'yes' : 'no';
-		$stock_managed    = isset( $_POST['_manage_stock'] ) ? 'yes' : 'no';
-		$backorders       = isset( $_POST['_backorders'] ) ? wc_clean( wp_unslash( $_POST['_backorders'] ) ) : 'no';
-
-		// If syncing with Square is enabled and stock is managed, ensure backorders are disabled
-		if ( 'yes' === $sync_with_square && 'yes' === $stock_managed ) {
-			$backorders = 'no';
-		}
-
-		$product->update_meta_data( '_sync_with_square', $sync_with_square );
-		$product->update_meta_data( '_backorders', $backorders );
-
-		if ( 'yes' === $sync_with_square ) {
-			$this->process_sync_with_square( $product );
-		}
-
-		$product->save();
-	}
-
-	/**
-	 * Validates and processes the product data.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param WC_Product $product Product object.
-	 * @param array      $data    Product data.
-	 * @return array
-	 */
-	public function validate_product_data( $product, $data ) {
-		$errors = array();
-
-		if ( ! $this->is_product_syncable( $product ) ) {
-			return $errors;
-		}
-
-		$this->process_sync_with_square(
-			$product,
-			isset( $data['_sync_with_square'] ) ? 'yes' : 'no'
-		);
-
-		return $errors;
 	}
 }

--- a/src/css/admin/wc-square-admin-products.scss
+++ b/src/css/admin/wc-square-admin-products.scss
@@ -1,0 +1,21 @@
+.wc-square-validation-errors {
+    border-left: 4px solid #d63638;
+    background: #fff;
+    box-shadow: 0 1px 1px 0 rgba(0,0,0,.1);
+    padding: 1px 12px 10px;
+}
+
+.wc-square-validation-errors ul {
+    margin: 0.5em 0;
+    padding-left: 1.5em;
+    list-style: disc;
+}
+
+.wc-square-validation-errors li {
+    margin: 0.5em 0;
+    color: #d63638;
+}
+
+.wc-square-field-error-highlight {
+    border-color: #d63638 !important;
+}

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -809,7 +809,7 @@ jQuery( document ).ready( ( $ ) => {
 
 		// Validate the maximum allowed attribute values 255.
 		const validateMaxAttributeValues = ( $field ) => {
-			const maxValues = 1; // Maximum values allowed by Square.
+			const maxValues = 250; // Maximum values allowed by Square.
 			let currentValues = $field.val().split('|').length;
 			
 			// Add ID if not present.
@@ -834,7 +834,7 @@ jQuery( document ).ready( ( $ ) => {
 
 		// Validate the maximum allowed variations 255.
 		const validateMaxVariations = () => {
-			const maxVariations = 1; // Maximum variations allowed by Square.
+			const maxVariations = 250; // Maximum variations allowed by Square.
 			const currentVariations = $('#woocommerce-product-data').find('.woocommerce_variation').length;
 			
 			const $field = $('.variations_tab');

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -736,11 +736,6 @@ jQuery( document ).ready( ( $ ) => {
 		const showFieldError = (selector, message) => {
 			const $field = $(selector);
 
-			// Add ID if not present.
-			if (!$field.attr('id')) {
-				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
-			}
-
 			// Add error class to highlight the field
 			$field.addClass('wc-square-field-error-highlight');
 			
@@ -760,8 +755,15 @@ jQuery( document ).ready( ( $ ) => {
 		};
 
 		// Add attribute name length validation.
-		const validateAttributeName = (name, $field) => {
+		const validateAttributeName = ($field) => {
 			const maxLength = 65; // Maximum length allowed by Square.
+			const name = $field.val();
+
+			// Add ID if not present.
+			if (!$field.attr('id')) {
+				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
+			}
+
 			if (name.length > maxLength) {
 				const truncatedName = name.substring(0, maxLength) + '...';
 				showFieldError($field, wc_square_admin_products.i18n.attribute_name_too_long + ': ' + truncatedName);
@@ -780,10 +782,15 @@ jQuery( document ).ready( ( $ ) => {
 
 		// Validate maximum number of attributes.
 		const validateMaxAttributes = () => {
-			const maxAttributes = 1; // Maximum attributes allowed by Square.
+			const maxAttributes = 6; // Maximum attributes allowed by Square.
 			const currentAttributes = $('#product_attributes .woocommerce_attribute').length;
 			
 			const $addButton = $('.attribute_tab');
+			// Add ID if not present.
+			if (!$addButton.attr('id')) {
+				$addButton.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
+			}
+
 			if (currentAttributes > maxAttributes) {
 				// Show error on the "Add new attribute" button's parent.
 				showFieldError($addButton, wc_square_admin_products.i18n.too_many_attributes);
@@ -800,19 +807,51 @@ jQuery( document ).ready( ( $ ) => {
 			return true;
 		};
 
+		// Validate the maximum allowed attribute values 255.
+		const validateMaxAttributeValues = ( $field ) => {
+			const maxValues = 1; // Maximum values allowed by Square.
+			let currentValues = $field.val().split('|').length;
+			
+			// Add ID if not present.
+			if (!$field.attr('id')) {
+				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
+			}
+
+			if (currentValues > maxValues) {
+				showFieldError($field, wc_square_admin_products.i18n.too_many_attribute_values + ': ' + $field.val());
+				return false;
+			}
+
+			// Clear validation errors when attribute values are changed.
+			$field.removeClass('wc-square-field-error-highlight');
+			$('#square-error-' + $field.attr('id')).remove();
+			if (!$('#wc-square-validation-errors ul li').length) {
+				$('#wc-square-validation-errors').remove();
+			}
+
+			return true;
+		};
+
+		// Validate the maximum allowed attribute values 255.
+		$('#product_attributes').on('change', '[name*="attribute_values"]', function() {
+			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
+				validateMaxAttributeValues( $(this) );
+			}
+		});
+
 		// Validate attribute name and max attributes when editing existing attribute.
 		$('#product_attributes').on('change', 'input.attribute_name', function() {
 			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
-				const $field = $(this);
-				const name = $field.val();
-				validateAttributeName(name, $field);
+				validateAttributeName( $(this) );
 				validateMaxAttributes();
 			}
 		});
 
 		// Validate max attributes when deleting attribute.
 		$('#product_attributes').on('click', '.product_attributes .delete', function() {
-			validateMaxAttributes();
+			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
+				validateMaxAttributes();
+			}
 		});
 
 		// Run validation when the page loads or when sync checkbox changes.
@@ -826,9 +865,14 @@ jQuery( document ).ready( ( $ ) => {
 					
 					// Validate all attribute names
 					$('#product_attributes').find('input.attribute_name').each(function() {
-						const $field = $(this);
-						const name = $field.val();
-						validateAttributeName(name, $field);
+						validateAttributeName( $(this) );
+					});
+
+					// Validate all attribute values.
+					$('#product_attributes').find('[name*="attribute_values"]').each(function() {
+						if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
+							validateMaxAttributeValues( $(this) );
+						}
 					});
 				}
 			};

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -827,6 +827,12 @@ jQuery( document ).ready( ( $ ) => {
 
 		// Event handlers.
 		const setupValidationHandlers = () => {
+
+			// Early return if product type is not variable.
+			if (!isVariable()) {
+				return;
+			}
+
 			const $syncCheckbox = $('#_' + wc_square_admin_products.synced_with_square_taxonomy);
 			const $productAttributes = $('#product_attributes');
 			const $productData = $('#woocommerce-product-data');

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -818,7 +818,7 @@ jQuery( document ).ready( ( $ ) => {
 			}
 
 			if (currentValues > maxValues) {
-				showFieldError($field, wc_square_admin_products.i18n.too_many_attribute_values + ': ' + $field.val());
+				showFieldError($field, wc_square_admin_products.i18n.too_many_attribute_values + ': ' + $field.val().substring(0, 50) + '...');
 				return false;
 			}
 
@@ -831,6 +831,37 @@ jQuery( document ).ready( ( $ ) => {
 
 			return true;
 		};
+
+		// Validate the maximum allowed variations 255.
+		const validateMaxVariations = () => {
+			const maxVariations = 1; // Maximum variations allowed by Square.
+			const currentVariations = $('#woocommerce-product-data').find('.woocommerce_variation').length;
+			
+			const $field = $('.variations_tab');
+			// Add ID if not present.
+			if (!$field.attr('id')) {
+				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
+			}
+
+			if (currentVariations > maxVariations) {
+				showFieldError($field, wc_square_admin_products.i18n.too_many_variations);
+				return false;
+			}
+
+			// Clear validation errors when variations are changed.
+			$field.removeClass('wc-square-field-error-highlight');
+			$('#square-error-' + $field.attr('id')).remove();
+			if (!$('#wc-square-validation-errors ul li').length) {
+				$('#wc-square-validation-errors').remove();
+			}
+
+			return true;
+		};
+
+		// Validate when .save-variation-changes button is clicked., count .woocommerce_variation
+		$('#woocommerce-product-data').on('click', '.save-variation-changes, #variable_product_options button', function() {
+			validateMaxVariations();
+		});
 
 		// Validate the maximum allowed attribute values 255.
 		$('#product_attributes').on('change', '[name*="attribute_values"]', function() {
@@ -860,10 +891,13 @@ jQuery( document ).ready( ( $ ) => {
 			
 			const validateAll = () => {
 				if ($syncCheckbox.prop('checked')) {
-					// Validate max attributes
+					// Validate max attributes.
 					validateMaxAttributes();
+
+					// Validate max variations.
+					validateMaxVariations();
 					
-					// Validate all attribute names
+					// Validate all attribute names.
 					$('#product_attributes').find('input.attribute_name').each(function() {
 						validateAttributeName( $(this) );
 					});
@@ -877,14 +911,14 @@ jQuery( document ).ready( ( $ ) => {
 				}
 			};
 
-			// Run validation on page load
+			// Run validation on page load.
 			validateAll();
 
-			// Run validation when sync checkbox changes
+			// Run validation when sync checkbox changes.
 			$syncCheckbox.on('change', validateAll);
 
-			// Run validation when variations are loaded
-			$('#woocommerce-product-data').on('woocommerce_variations_loaded', validateAll);
+			// Run validation when variations are loaded.
+			$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded woocommerce_variations_added woocommerce_variations_removed', validateAll );
 		});
 	}
 } );

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -813,11 +813,18 @@ jQuery( document ).ready( ( $ ) => {
 		};
 
 		const validateMaxAttributeValues = ($field) => {
+			let attrValues = $field.val();
+
+			// if attrValues is array (when taxonomy attribute), convert to string and combine values by '|'.
+			if (Array.isArray(attrValues)) {
+				attrValues = attrValues.join('|');
+			}
+
 			return validateLimit(
-				$field.val().split('|').length,
+				attrValues.length,
 				250,
 				$field,
-				wc_square_admin_products.i18n.too_many_attribute_values + ': ' + $field.val().substring(0, 50) + '...'
+				wc_square_admin_products.i18n.too_many_attribute_values + ': ' + attrValues.substring(0, 50) + '...'
 			);
 		};
 

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -778,23 +778,69 @@ jQuery( document ).ready( ( $ ) => {
 			return true;
 		};
 
-		// Validate attribute name when editing existing attribute.
-		$('#product_attributes').on('change', 'input.attribute_name', function() {
-			const $field = $(this);
-			const name = $field.val();
-			validateAttributeName(name, $field);
-		});
+		// Validate maximum number of attributes.
+		const validateMaxAttributes = () => {
+			const maxAttributes = 1; // Maximum attributes allowed by Square.
+			const currentAttributes = $('#product_attributes .woocommerce_attribute').length;
+			
+			const $addButton = $('.attribute_tab');
+			if (currentAttributes > maxAttributes) {
+				// Show error on the "Add new attribute" button's parent.
+				showFieldError($addButton, wc_square_admin_products.i18n.too_many_attributes);
+				return false;
+			}
 
-		// Run validation when the page loads.
-		$(document).ready(function() {
-			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).val() === 'yes') {
-				// loop through all attributes and validate the attribute name.
-				$('#product_attributes').find('input.attribute_name').each(function() {
+			// Clear any existing max attributes error.
+			$addButton.removeClass('wc-square-field-error-highlight');
+			$('#square-error-' + $addButton.attr('id')).remove();
+			if (!$('#wc-square-validation-errors ul li').length) {
+				$('#wc-square-validation-errors').remove();
+			}
+
+			return true;
+		};
+
+		// Validate attribute name and max attributes when editing existing attribute.
+		$('#product_attributes').on('change', 'input.attribute_name', function() {
+			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
 				const $field = $(this);
 				const name = $field.val();
-					validateAttributeName(name, $field);
-				});
+				validateAttributeName(name, $field);
+				validateMaxAttributes();
 			}
+		});
+
+		// Validate max attributes when deleting attribute.
+		$('#product_attributes').on('click', '.product_attributes .delete', function() {
+			validateMaxAttributes();
+		});
+
+		// Run validation when the page loads or when sync checkbox changes.
+		$(document).ready(function() {
+			const $syncCheckbox = $('#_' + wc_square_admin_products.synced_with_square_taxonomy);
+			
+			const validateAll = () => {
+				if ($syncCheckbox.prop('checked')) {
+					// Validate max attributes
+					validateMaxAttributes();
+					
+					// Validate all attribute names
+					$('#product_attributes').find('input.attribute_name').each(function() {
+						const $field = $(this);
+						const name = $field.val();
+						validateAttributeName(name, $field);
+					});
+				}
+			};
+
+			// Run validation on page load
+			validateAll();
+
+			// Run validation when sync checkbox changes
+			$syncCheckbox.on('change', validateAll);
+
+			// Run validation when variations are loaded
+			$('#woocommerce-product-data').on('woocommerce_variations_loaded', validateAll);
 		});
 	}
 } );

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -785,7 +785,7 @@ jQuery( document ).ready( ( $ ) => {
 			validateAttributeName(name, $field);
 		});
 
-		// 
+		// Run validation when the page loads.
 		$(document).ready(function() {
 			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).val() === 'yes') {
 				// loop through all attributes and validate the attribute name.

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -736,10 +736,15 @@ jQuery( document ).ready( ( $ ) => {
 		const showFieldError = (selector, message) => {
 			const $field = $(selector);
 
-			// Add error class to highlight the field
+			// Prevent duplicate errors.
+			if ($field.hasClass('wc-square-field-error-highlight')) {
+				return;
+			}
+
+			// Add error class to highlight the field.
 			$field.addClass('wc-square-field-error-highlight');
 			
-			// Create or get the error container
+			// Create or get the error container.
 			let $errorContainer = $('#wc-square-validation-errors');
 			if (!$errorContainer.length) {
 				$errorContainer = $('<div id="wc-square-validation-errors" class="wc-square-validation-errors"><h4>' + __('Square Sync Validation Errors', 'woocommerce-square') + '</h4><ul></ul></div>');

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -736,11 +736,6 @@ jQuery( document ).ready( ( $ ) => {
 		const showFieldError = (selector, message) => {
 			const $field = $(selector);
 
-			// Prevent duplicate errors.
-			if ($field.hasClass('wc-square-field-error-highlight')) {
-				return;
-			}
-
 			// Add error class to highlight the field.
 			$field.addClass('wc-square-field-error-highlight');
 			
@@ -756,174 +751,138 @@ jQuery( document ).ready( ( $ ) => {
 			const errorId = 'square-error-' + $field.attr('id');
 			if (!$('#' + errorId).length) {
 				$errorList.append('<li id="' + errorId + '">' + message + '</li>');
+			} else {
+				// Just update the message if it already exists.
+				$('#' + errorId).text(message);
 			}
 		};
 
-		// Add attribute name length validation.
+		// Generic validation helper functions.
+		const ensureFieldId = ($field) => {
+			if (!$field.attr('id')) {
+				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
+			}
+			return $field;
+		};
+
+		const clearValidationError = ($field) => {
+			$field.removeClass('wc-square-field-error-highlight');
+			$('#square-error-' + $field.attr('id')).remove();
+			if (!$('#wc-square-validation-errors ul li').length) {
+				$('#wc-square-validation-errors').remove();
+			}
+		};
+
+		const validateLimit = (current, max, $field, errorMessage) => {
+			$field = ensureFieldId($field);
+			
+			if (current > max) {
+				showFieldError($field, errorMessage);
+				return false;
+			}
+
+			clearValidationError($field);
+			return true;
+		};
+
+		// Specific validation functions.
 		const validateAttributeName = ($field) => {
-			const maxLength = 65; // Maximum length allowed by Square.
+			const maxLength = 65;
 			const name = $field.val();
-
-			// Add ID if not present.
-			if (!$field.attr('id')) {
-				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
-			}
-
-			if (name.length > maxLength) {
-				const truncatedName = name.substring(0, maxLength) + '...';
-				showFieldError($field, wc_square_admin_products.i18n.attribute_name_too_long + ': ' + truncatedName);
-				return false;
-			}
 			
-			// Clear validation errors when attribute name is changed.
-			$field.removeClass('wc-square-field-error-highlight');
-			$('#square-error-' + $field.attr('id')).remove();
-			if (!$('#wc-square-validation-errors ul li').length) {
-				$('#wc-square-validation-errors').remove();
-			}
-
-			return true;
+			return validateLimit(
+				name.length, 
+				maxLength, 
+				$field, 
+				wc_square_admin_products.i18n.attribute_name_too_long + ': ' + name.substring(0, maxLength) + '...'
+			);
 		};
 
-		// Validate maximum number of attributes.
 		const validateMaxAttributes = () => {
-			const maxAttributes = 6; // Maximum attributes allowed by Square.
-			const currentAttributes = $('#product_attributes .woocommerce_attribute').length;
-			
-			const $addButton = $('.attribute_tab');
-			// Add ID if not present.
-			if (!$addButton.attr('id')) {
-				$addButton.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
-			}
-
-			if (currentAttributes > maxAttributes) {
-				// Show error on the "Add new attribute" button's parent.
-				showFieldError($addButton, wc_square_admin_products.i18n.too_many_attributes);
-				return false;
-			}
-
-			// Clear any existing max attributes error.
-			$addButton.removeClass('wc-square-field-error-highlight');
-			$('#square-error-' + $addButton.attr('id')).remove();
-			if (!$('#wc-square-validation-errors ul li').length) {
-				$('#wc-square-validation-errors').remove();
-			}
-
-			return true;
+			return validateLimit(
+				$('#product_attributes .woocommerce_attribute').length,
+				6,
+				$('.attribute_tab'),
+				wc_square_admin_products.i18n.too_many_attributes
+			);
 		};
 
-		// Validate the maximum allowed attribute values 255.
-		const validateMaxAttributeValues = ( $field ) => {
-			const maxValues = 250; // Maximum values allowed by Square.
-			let currentValues = $field.val().split('|').length;
-			
-			// Add ID if not present.
-			if (!$field.attr('id')) {
-				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
-			}
-
-			if (currentValues > maxValues) {
-				showFieldError($field, wc_square_admin_products.i18n.too_many_attribute_values + ': ' + $field.val().substring(0, 50) + '...');
-				return false;
-			}
-
-			// Clear validation errors when attribute values are changed.
-			$field.removeClass('wc-square-field-error-highlight');
-			$('#square-error-' + $field.attr('id')).remove();
-			if (!$('#wc-square-validation-errors ul li').length) {
-				$('#wc-square-validation-errors').remove();
-			}
-
-			return true;
+		const validateMaxAttributeValues = ($field) => {
+			return validateLimit(
+				$field.val().split('|').length,
+				250,
+				$field,
+				wc_square_admin_products.i18n.too_many_attribute_values + ': ' + $field.val().substring(0, 50) + '...'
+			);
 		};
 
-		// Validate the maximum allowed variations 255.
 		const validateMaxVariations = () => {
-			const maxVariations = 250; // Maximum variations allowed by Square.
-			const currentVariations = $('#woocommerce-product-data').find('.woocommerce_variation').length;
-			
-			const $field = $('.variations_tab');
-			// Add ID if not present.
-			if (!$field.attr('id')) {
-				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
-			}
-
-			if (currentVariations > maxVariations) {
-				showFieldError($field, wc_square_admin_products.i18n.too_many_variations);
-				return false;
-			}
-
-			// Clear validation errors when variations are changed.
-			$field.removeClass('wc-square-field-error-highlight');
-			$('#square-error-' + $field.attr('id')).remove();
-			if (!$('#wc-square-validation-errors ul li').length) {
-				$('#wc-square-validation-errors').remove();
-			}
-
-			return true;
+			return validateLimit(
+				$('#woocommerce-product-data').find('.woocommerce_variation').length,
+				250,
+				$('.variations_tab'),
+				wc_square_admin_products.i18n.too_many_variations
+			);
 		};
 
-		// Validate when .save-variation-changes button is clicked., count .woocommerce_variation
-		$('#woocommerce-product-data').on('click', '.save-variation-changes, #variable_product_options button', function() {
-			validateMaxVariations();
-		});
-
-		// Validate the maximum allowed attribute values 255.
-		$('#product_attributes').on('change', '[name*="attribute_values"]', function() {
-			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
-				validateMaxAttributeValues( $(this) );
-			}
-		});
-
-		// Validate attribute name and max attributes when editing existing attribute.
-		$('#product_attributes').on('change', 'input.attribute_name', function() {
-			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
-				validateAttributeName( $(this) );
-				validateMaxAttributes();
-			}
-		});
-
-		// Validate max attributes when deleting attribute.
-		$('#product_attributes').on('click', '.product_attributes .delete', function() {
-			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
-				validateMaxAttributes();
-			}
-		});
-
-		// Run validation when the page loads or when sync checkbox changes.
-		$(document).ready(function() {
+		// Event handlers.
+		const setupValidationHandlers = () => {
 			const $syncCheckbox = $('#_' + wc_square_admin_products.synced_with_square_taxonomy);
-			
+			const $productAttributes = $('#product_attributes');
+			const $productData = $('#woocommerce-product-data');
+
+			// Validate all fields.
 			const validateAll = () => {
-				if ($syncCheckbox.prop('checked')) {
-					// Validate max attributes.
-					validateMaxAttributes();
+				if (!$syncCheckbox.prop('checked')) return;
 
-					// Validate max variations.
-					validateMaxVariations();
-					
-					// Validate all attribute names.
-					$('#product_attributes').find('input.attribute_name').each(function() {
-						validateAttributeName( $(this) );
-					});
+				// Remove existing errors.
+				$productAttributes.find('.wc-square-field-error-highlight').removeClass('wc-square-field-error-highlight');
+				$('#wc-square-validation-errors').remove();
 
-					// Validate all attribute values.
-					$('#product_attributes').find('[name*="attribute_values"]').each(function() {
-						if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).prop('checked')) {
-							validateMaxAttributeValues( $(this) );
-						}
-					});
-				}
+				validateMaxAttributes();
+				validateMaxVariations();
+				
+				$productAttributes.find('input.attribute_name').each(function() {
+					validateAttributeName($(this));
+				});
+
+				$productAttributes.find('[name*="attribute_values"]').each(function() {
+					validateMaxAttributeValues($(this));
+				});
 			};
 
-			// Run validation on page load.
-			validateAll();
+			// Event bindings.
+			$productAttributes
+				.on('change', 'input.attribute_name', function() {
+					if ($syncCheckbox.prop('checked')) {
+						validateAttributeName($(this));
+						validateMaxAttributes();
+					}
+				})
+				.on('change', '[name*="attribute_values"]', function() {
+					if ($syncCheckbox.prop('checked')) {
+						validateMaxAttributeValues($(this));
+					}
+				})
+				.on('click', '.product_attributes .delete', function() {
+					if ($syncCheckbox.prop('checked')) {
+						validateMaxAttributes();
+					}
+				});
+
+			$productData.on('click', '.save-variation-changes, #variable_product_options button', validateMaxVariations);
+
+			// Run validation on variations changes
+			$productData.on('woocommerce_variations_loaded woocommerce_variations_added woocommerce_variations_removed', validateAll);
 
 			// Run validation when sync checkbox changes.
 			$syncCheckbox.on('change', validateAll);
 
-			// Run validation when variations are loaded.
-			$( '#woocommerce-product-data' ).on( 'woocommerce_variations_loaded woocommerce_variations_added woocommerce_variations_removed', validateAll );
-		});
+			// Initial validation.
+			validateAll();
+		};
+
+		// Initialize validation on document ready.
+		$(document).ready(setupValidationHandlers);
 	}
 } );

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -38,7 +38,7 @@ jQuery( document ).ready( ( $ ) => {
 			const data = {
 				action: 'wc_square_get_quick_edit_product_details',
 				security: wc_square_admin_products.get_quick_edit_product_details_nonce,
-				product_id: $row.find( 'th.check-column input' ).val(),
+				product_id: postID,
 			};
 
 			$.post( wc_square_admin_products.ajax_url, data, ( response ) => {
@@ -153,6 +153,7 @@ jQuery( document ).ready( ( $ ) => {
 		 * Checks whether the product is variable.
 		 *
 		 * @since 2.0.0
+		 * @return {boolean} True if product is variable.
 		 */
 		const isVariable = () => {
 			return wc_square_admin_products.variable_product_types.includes( $( '#product-type' ).val() );
@@ -162,6 +163,7 @@ jQuery( document ).ready( ( $ ) => {
 		 * Checks whether the product has a SKU.
 		 *
 		 * @since 2.0.0
+		 * @return {boolean} True if product has SKU.
 		 */
 		const hasSKU = () => {
 			return '' !== $( '#_sku' ).val().trim();
@@ -171,8 +173,8 @@ jQuery( document ).ready( ( $ ) => {
 		 * Checks whether the product variations all have SKUs.
 		 *
 		 * @since 2.2.3
-		 *
-		 * @param {Array} skus
+		 * @param {Array} skus Array of SKU input elements.
+		 * @return {boolean} True if all variations have SKUs.
 		 */
 		const hasVariableSKUs = ( skus ) => {
 			if ( ! skus.length ) {
@@ -180,7 +182,6 @@ jQuery( document ).ready( ( $ ) => {
 			}
 
 			const valid = skus.filter( ( sku ) => '' !== $( sku ).val().trim() );
-
 			return valid.length === skus.length;
 		};
 
@@ -188,13 +189,13 @@ jQuery( document ).ready( ( $ ) => {
 		 * Checks whether the given skus are unique.
 		 *
 		 * @since 2.2.3
-		 *
-		 * @param {Array} skus
+		 * @param {jQuery} skus jQuery object containing SKU input elements.
+		 * @return {boolean} True if all SKUs are unique.
 		 */
 		const hasUniqueSKUs = ( skus ) => {
-			const skuValues = skus.map( ( sku ) => $( sku ).val() );
-
-			return skuValues.every( ( sku ) => skuValues.indexOf( sku ) === skuValues.lastIndexOf( sku ) );
+			const skuValues = $.makeArray( skus ).map( sku => $( sku ).val().trim() );
+			const uniqueSkus = new Set( skuValues );
+			return skuValues.length === uniqueSkus.size;
 		};
 
 		/**
@@ -725,5 +726,114 @@ jQuery( document ).ready( ( $ ) => {
 				);
 			}
 		}
+
+		/**
+		 * Shows validation errors at the top of the product data panel.
+		 * 
+		 * @param {string} selector The field selector
+		 * @param {string} message The error message
+		 */
+		const showFieldError = (selector, message) => {
+			const $field = $(selector);
+			
+			// Add error class to highlight the field
+			$field.addClass('wc-square-field-error-highlight');
+			
+			// Create or get the error container
+			let $errorContainer = $('#wc-square-validation-errors');
+			if (!$errorContainer.length) {
+				$errorContainer = $('<div id="wc-square-validation-errors" class="wc-square-validation-errors"><h4>' + __('Square Sync Validation Errors', 'woocommerce-square') + '</h4><ul></ul></div>');
+				$('#woocommerce-product-data').prepend($errorContainer);
+			}
+
+			// Add the error message if not already present
+			const $errorList = $errorContainer.find('ul');
+			const errorId = 'square-error-' + selector.replace(/[^a-zA-Z0-9]/g, '');
+			if (!$('#' + errorId).length) {
+				$errorList.append('<li id="' + errorId + '">' + message + '</li>');
+			}
+		};
+
+		/**
+		 * Validates the product for Square sync and shows errors at the top of the panel.
+		 *
+		 * @since 2.0.0
+		 */
+		const validateProductForSquareSync = () => {
+			// Remove existing error container
+			$('#wc-square-validation-errors').remove();
+			$('.wc-square-field-error-highlight').removeClass('wc-square-field-error-highlight');
+			
+			let isValid = true;
+
+			// 1. SKU Validation
+			if (!hasSKU()) {
+				if (isVariable()) {
+					showFieldError('#variable_product_options', __('Please add an SKU to every variation for syncing with Square.', 'woocommerce-square'));
+				} else {
+					showFieldError('#_sku', __('Please add an SKU to sync with Square.', 'woocommerce-square'));
+				}
+				isValid = false;
+			}
+
+			// 2. Variable Product Validation
+			if (isVariable()) {
+				const variationSkus = $('.variable_sku');
+				
+				// Check for missing SKUs
+				if (!hasVariableSKUs($.makeArray(variationSkus))) {
+					showFieldError('.variable_sku', __('Every variation must have a unique SKU.', 'woocommerce-square'));
+					isValid = false;
+				}
+				
+				// Check for duplicate SKUs
+				if (!hasUniqueSKUs(variationSkus)) {
+					showFieldError('.variable_sku', __('Variations cannot have duplicate SKUs.', 'woocommerce-square'));
+					isValid = false;
+				}
+
+				// Check parent SKU conflict
+				const parentSku = $('#_sku').val();
+				const variationSkuValues = Array.from(variationSkus).map(sku => $(sku).val());
+				if (parentSku && variationSkuValues.includes(parentSku)) {
+					showFieldError('#_sku', __('Parent SKU conflicts with a variation SKU.', 'woocommerce-square'));
+					isValid = false;
+				}
+			}
+
+			// 3. Gift Card Validation
+			if ($('#_gift_card').is(':checked')) {
+				showFieldError('#_gift_card', __('Gift card products cannot be synced with Square.', 'woocommerce-square'));
+				isValid = false;
+			}
+
+			// 4. Price Validation
+			if (!$('#_regular_price').val() && !$('#_sale_price').val()) {
+				showFieldError('#_regular_price', __('Product must have a price set to sync with Square.', 'woocommerce-square'));
+				isValid = false;
+			}
+
+			// If not valid, disable sync checkbox
+			if (!isValid) {
+				$(syncCheckboxID).prop('checked', false);
+				$(syncCheckboxID).prop('disabled', true);
+			} else {
+				$(syncCheckboxID).prop('disabled', false);
+			}
+
+			return isValid;
+		};
+
+		// Add event listeners for real-time validation
+		$('#_sku, #_regular_price, #_sale_price, #_gift_card').on('change', validateProductForSquareSync);
+		$('#product-type').on('change', () => {
+			setTimeout(validateProductForSquareSync, 100); // Delay to allow WooCommerce to update the form
+		});
+
+		// Add validation when variations are added or modified
+		$('#woocommerce-product-data').on('woocommerce_variations_added woocommerce_variations_loaded', () => {
+			$('.variable_sku').on('change', validateProductForSquareSync);
+			validateProductForSquareSync();
+		});
 	}
 } );

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -773,6 +773,11 @@ jQuery( document ).ready( ( $ ) => {
 			}
 		};
 
+		const clearAllValidationErrors = () => {
+			$('.wc-square-field-error-highlight').removeClass('wc-square-field-error-highlight');
+			$('#wc-square-validation-errors').remove();
+		};
+
 		const validateLimit = (current, max, $field, errorMessage) => {
 			$field = ensureFieldId($field);
 			
@@ -825,6 +830,15 @@ jQuery( document ).ready( ( $ ) => {
 			);
 		};
 
+		// If product type changes to variable, validate all fields.
+		$( '#product-type' ).on( 'change', () => {
+			if ( 'variable' === $( '#product-type' ).val() ) {
+				setupValidationHandlers();
+			} else {
+				clearAllValidationErrors();
+			}
+		} );
+
 		// Event handlers.
 		const setupValidationHandlers = () => {
 
@@ -839,11 +853,11 @@ jQuery( document ).ready( ( $ ) => {
 
 			// Validate all fields.
 			const validateAll = () => {
+				clearAllValidationErrors();
+
 				if (!$syncCheckbox.prop('checked')) return;
 
-				// Remove existing errors.
-				$productAttributes.find('.wc-square-field-error-highlight').removeClass('wc-square-field-error-highlight');
-				$('#wc-square-validation-errors').remove();
+				if (!isVariable()) return;
 
 				validateMaxAttributes();
 				validateMaxVariations();

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -193,9 +193,9 @@ jQuery( document ).ready( ( $ ) => {
 		 * @return {boolean} True if all SKUs are unique.
 		 */
 		const hasUniqueSKUs = ( skus ) => {
-			const skuValues = $.makeArray( skus ).map( sku => $( sku ).val().trim() );
-			const uniqueSkus = new Set( skuValues );
-			return skuValues.length === uniqueSkus.size;
+			const skuValues = skus.map( ( sku ) => $( sku ).val() );
+
+			return skuValues.every( ( sku ) => skuValues.indexOf( sku ) === skuValues.lastIndexOf( sku ) );
 		};
 
 		/**
@@ -735,7 +735,12 @@ jQuery( document ).ready( ( $ ) => {
 		 */
 		const showFieldError = (selector, message) => {
 			const $field = $(selector);
-			
+
+			// Add ID if not present.
+			if (!$field.attr('id')) {
+				$field.attr('id', 'wc-square-field-' + Math.random().toString(36).substring(2, 15));
+			}
+
 			// Add error class to highlight the field
 			$field.addClass('wc-square-field-error-highlight');
 			
@@ -748,92 +753,48 @@ jQuery( document ).ready( ( $ ) => {
 
 			// Add the error message if not already present
 			const $errorList = $errorContainer.find('ul');
-			const errorId = 'square-error-' + selector.replace(/[^a-zA-Z0-9]/g, '');
+			const errorId = 'square-error-' + $field.attr('id');
 			if (!$('#' + errorId).length) {
 				$errorList.append('<li id="' + errorId + '">' + message + '</li>');
 			}
 		};
 
-		/**
-		 * Validates the product for Square sync and shows errors at the top of the panel.
-		 *
-		 * @since 2.0.0
-		 */
-		const validateProductForSquareSync = () => {
-			// Remove existing error container
-			$('#wc-square-validation-errors').remove();
-			$('.wc-square-field-error-highlight').removeClass('wc-square-field-error-highlight');
+		// Add attribute name length validation.
+		const validateAttributeName = (name, $field) => {
+			const maxLength = 65; // Maximum length allowed by Square.
+			if (name.length > maxLength) {
+				const truncatedName = name.substring(0, maxLength) + '...';
+				showFieldError($field, wc_square_admin_products.i18n.attribute_name_too_long + ': ' + truncatedName);
+				return false;
+			}
 			
-			let isValid = true;
-
-			// 1. SKU Validation
-			if (!hasSKU()) {
-				if (isVariable()) {
-					showFieldError('#variable_product_options', __('Please add an SKU to every variation for syncing with Square.', 'woocommerce-square'));
-				} else {
-					showFieldError('#_sku', __('Please add an SKU to sync with Square.', 'woocommerce-square'));
-				}
-				isValid = false;
+			// Clear validation errors when attribute name is changed.
+			$field.removeClass('wc-square-field-error-highlight');
+			$('#square-error-' + $field.attr('id')).remove();
+			if (!$('#wc-square-validation-errors ul li').length) {
+				$('#wc-square-validation-errors').remove();
 			}
 
-			// 2. Variable Product Validation
-			if (isVariable()) {
-				const variationSkus = $('.variable_sku');
-				
-				// Check for missing SKUs
-				if (!hasVariableSKUs($.makeArray(variationSkus))) {
-					showFieldError('.variable_sku', __('Every variation must have a unique SKU.', 'woocommerce-square'));
-					isValid = false;
-				}
-				
-				// Check for duplicate SKUs
-				if (!hasUniqueSKUs(variationSkus)) {
-					showFieldError('.variable_sku', __('Variations cannot have duplicate SKUs.', 'woocommerce-square'));
-					isValid = false;
-				}
-
-				// Check parent SKU conflict
-				const parentSku = $('#_sku').val();
-				const variationSkuValues = Array.from(variationSkus).map(sku => $(sku).val());
-				if (parentSku && variationSkuValues.includes(parentSku)) {
-					showFieldError('#_sku', __('Parent SKU conflicts with a variation SKU.', 'woocommerce-square'));
-					isValid = false;
-				}
-			}
-
-			// 3. Gift Card Validation
-			if ($('#_gift_card').is(':checked')) {
-				showFieldError('#_gift_card', __('Gift card products cannot be synced with Square.', 'woocommerce-square'));
-				isValid = false;
-			}
-
-			// 4. Price Validation
-			if (!$('#_regular_price').val() && !$('#_sale_price').val()) {
-				showFieldError('#_regular_price', __('Product must have a price set to sync with Square.', 'woocommerce-square'));
-				isValid = false;
-			}
-
-			// If not valid, disable sync checkbox
-			if (!isValid) {
-				$(syncCheckboxID).prop('checked', false);
-				$(syncCheckboxID).prop('disabled', true);
-			} else {
-				$(syncCheckboxID).prop('disabled', false);
-			}
-
-			return isValid;
+			return true;
 		};
 
-		// Add event listeners for real-time validation
-		$('#_sku, #_regular_price, #_sale_price, #_gift_card').on('change', validateProductForSquareSync);
-		$('#product-type').on('change', () => {
-			setTimeout(validateProductForSquareSync, 100); // Delay to allow WooCommerce to update the form
+		// Validate attribute name when editing existing attribute.
+		$('#product_attributes').on('change', 'input.attribute_name', function() {
+			const $field = $(this);
+			const name = $field.val();
+			validateAttributeName(name, $field);
 		});
 
-		// Add validation when variations are added or modified
-		$('#woocommerce-product-data').on('woocommerce_variations_added woocommerce_variations_loaded', () => {
-			$('.variable_sku').on('change', validateProductForSquareSync);
-			validateProductForSquareSync();
+		// 
+		$(document).ready(function() {
+			if ($('#_' + wc_square_admin_products.synced_with_square_taxonomy).val() === 'yes') {
+				// loop through all attributes and validate the attribute name.
+				$('#product_attributes').find('input.attribute_name').each(function() {
+				const $field = $(this);
+				const name = $field.val();
+					validateAttributeName(name, $field);
+				});
+			}
 		});
 	}
 } );

--- a/tests/e2e/specs/c4.product-import.spec.js
+++ b/tests/e2e/specs/c4.product-import.spec.js
@@ -116,6 +116,12 @@ test( 'Handle missing products @sync', async ( { page } ) => {
 	await saveSquareSettings( page );
 
 	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=square&section=update' );
+
+	// If the sync button is disabled, the test is not applicable.Add commentMore actions
+	if ( await page.locator( '#wc-square-sync' ).isDisabled() ) {
+		return;
+	}
+
 	await page.locator( '#wc-square-sync' ).click();
 	await page.locator( '#btn-ok' ).click();
 	await expect( await page.getByText( 'Syncing now' ) ).toBeVisible();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,6 +26,8 @@ module.exports = {
 		// admin files.
 		'assets/admin/wc-square-admin-products':
 			'./src/js/admin/wc-square-admin-products.js',
+		'assets/admin/wc-square-admin-products-styles':
+			'./src/css/admin/wc-square-admin-products.scss',
 		'assets/admin/wc-square-admin-settings':
 			'./src/js/admin/wc-square-admin-settings.js',
 		'assets/admin/wc-square-payment-gateway-admin-order':


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR introduces client-side (JavaScript-based) validation to proactively catch and prevent configuration issues that would lead to sync failures with Square. The following limitations imposed by Square’s API are now validated before save:

- A product can have up to 6 item options/attributes.
- Each item option/attribute can have up to 250 values.
- A product can have up to 250 total variations.
- Attribute (option) names must be 65 characters or fewer.

![image](https://github.com/user-attachments/assets/14b4880a-1765-4dac-9bb2-ef003d613d1e)

This ensures merchants receive immediate feedback in the WooCommerce admin and avoids failed sync attempts due to preventable errors.

Please note that we are not blocking the product from being saved, as doing so could be frustrating for some merchants. Instead, we display clear errors when Square-specific limits are exceeded, which I believe provides sufficient guidance without disrupting the editing experience.

Closes https://linear.app/a8c/issue/SQUARE-56/add-pre-sync-validations-for-product-variations

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1.	Go to WooCommerce > Products and edit or create a product with variations.
2.	Add product attributes and variations that exceed Square’s limitations:
•	Add more than 6 attributes to the product.
•	Set an attribute name longer than 65 characters.
•	Assign more than 250 option values to a single attribute.
•	Create more than 250 variations for the product.
4.	Confirm that:
•	JavaScript validation errors are displayed
•	Clear error messages are shown explaining which limits have been exceeded.
5.	Reduce the values to be within Square’s limits:
•	Use 6 or fewer attributes.
•	Ensure each attribute name is 65 characters or less.
•	Limit each attribute to 250 option values.
•	Keep total product variations to 250 or fewer.
7.	Confirm that:
•	The errors are gone.
•	Sync to Square initiates without error.

### Changelog entry

> Add - Pre-sync validations for Product Variations.
