### PR TITLE
Indicate customer initiated payments.

### DIFF
--- a/includes/Gateway/API/Requests/Payments.php
+++ b/includes/Gateway/API/Requests/Payments.php
@@ -93,6 +93,12 @@ class Payments extends \WooCommerce\Square\API\Request {
 			Utilities\Money_Utility::amount_to_money( $payment_total, $order->get_currency() )
 		);
 
+		if ( defined( 'WOOCOMMERCE_CHECKOUT' ) && WOOCOMMERCE_CHECKOUT ) {
+			$customer_details = new \Square\Models\CustomerDetails();
+			$customer_details->setCustomerInitiated( true );
+			$this->square_request->setCustomerDetails( $customer_details );
+		}
+
 		/**
 		 * Filters the Square payment order note (legacy filter).
 		 *


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds the `customer_details.customer_initiated` boolean to API requests for customer initiated payments.

These are payments that include:

* Filling the Credit/Gift Card on checkout
* Checkout via an express payment method
* Cash App checkout

![Screenshot 2025-05-01 at 2 09 20 pm](https://github.com/user-attachments/assets/487d5375-ea92-450a-8d08-fea852d0b164)

Closes #276.
Closes https://linear.app/a8c/issue/SQUARE-14/update-integration-for-merchant-and-buyer-initiated-payment-flags.

@faisal-alvi Jeff asked me to ping you for a review of this issue to ensure it doesn't collide with any work to do with the 3DS work.

Tests: Unable to write tests to ensure this change is behaving as expected as the repo doesn't have PHPUnit tests so I am unable to capture the HTTP requests.

### Steps to test the changes in this Pull Request:

1. Install Subscriptions Extension
2. Install Pre-orders Extension
3. Create products:
   * $1 Simple Product
   * $1 Variable Product
   * $1/month Subscription Product
   * $1 Simple Pre-order product with a far future maturity date, charged upon release
4. Log in to the Square Developer Portal
5. Navigate to view the API Logs: https://developer.squareup.com/console/en/apps > Select App > API Logs
6. With a Credit Card
   1. Purchase the $1 Simple Product
   2. View the purchase API log in Square for the order, ensure the payment is flagged as customer initiated
   3. Purchase the $1 Variable Product
   4. View the purchase API log in Square for the order, ensure the payment is flagged as customer initiated
   5. Sign up for a $1/month subscription
   6. View the purchase API log in Square for the order, ensure the payment is flagged as customer initiated
   7. Pre-order the $1 Simpe Pre-order product, checkout using the Square Credit card.
   8. Return to the WordPress Dashboard
   9. Go to pending scheduled actions, `/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending`
   10. Click Run for the `woocommerce_scheduled_subscription_payment` action created for the earlier subscription product
   11. View the purchase API log in Square for the renewal, ensure the payment is NOT flagged as customer initiated
   12. Go to pre-orders in the WP Dashboard, `/wp-admin/admin.php?page=wc_pre_orders`
   13. Check the pre-order created above
   14. In bulk actions complete the pre-order
   15. View the purchase API log in Square for the renewal, ensure the payment is NOT flagged as customer initiated
7. Repeat for:
   * Cash App
   * Google Checkout
   * Payment methods

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - Indicate customer initiated payments in Square API requests.
