### PR TITLE
Fix "3D Secure Verification Token is missing" issue

### DIFF
--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -309,9 +309,16 @@ class Gateway extends Payment_Gateway_Direct {
 		}
 
 		try {
-			$this->get_validation_exception();
+			if ( '' === Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-buyer-verification-token' ) ) {
+				throw new \Exception( '3D Secure Verification Token is missing' );
+			}
+
 			if ( Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
 				return $is_valid;
+			}
+
+			if ( ! Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-nonce' ) ) {
+				throw new \Exception( 'Payment nonce is missing' );
 			}
 		} catch ( \Exception $exception ) {
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

As reported in the internal Slack thread [here](https://fueled10up.slack.com/archives/C01UCQGPBDJ/p1746077666242469?thread_ts=1745874484.938769&cid=C01UCQGPBDJ), there was a pre-payment validation failure when attempting to use a saved credit card.

After investigation, it was found that the issue began after this commit: https://github.com/woocommerce/woocommerce-square/pull/345/commits/2ba1929198bb6caa9af882f6ae879638954af556. In that update, individual validation checks were moved into a new function, which inadvertently broke the original sequence of checks and led to the issue.

Specifically, the following check must run in between the other validations for the saved card flow to work correctly:
```
if ( Square_Helper::get_post( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
	return $is_valid;
}
```

Please note that this is targeting the `smoke-testing` branch.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Proceed to checkout using a credit card (either saved or a new card).
2. After a successful checkout, add another product to the cart.
3. Try checking out again using the saved card.
4. The payment should be successful without any errors

### Changelog entry

> Fix - 3D Secure Verification Token is missing issue