### PR TITLE
Add "View Progress" Link for "Update" Page After Importing Products from Square

### DIFF
--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -25,7 +25,11 @@ import {
 import { useSquareSettings } from '../../settings/hooks';
 import { recordEvent, ONBOARDING_TRACK_EVENTS } from '../../../tracks';
 
-export const ConfigureSync = ( { indent = 0, isDirty = false, showViewProgressButton = true } ) => {
+export const ConfigureSync = ( {
+	indent = 0,
+	isDirty = false,
+	showViewProgressButton = true,
+} ) => {
 	const { settings, squareSettingsLoaded, setSquareSettingData } =
 		useSquareSettings();
 
@@ -378,16 +382,24 @@ export const ConfigureSync = ( { indent = 0, isDirty = false, showViewProgressBu
 										} }
 									>
 										{ importDoneNotice }
-										{ importDoneNotice && showViewProgressButton && (
-											<div style={ { marginTop: '10px' } }>
-												<a
-													href={ `${ wcSquareSettings.adminUrl }admin.php?page=wc-settings&tab=square&section=update` }
-													className="button button-primary"
+										{ importDoneNotice &&
+											showViewProgressButton && (
+												<div
+													style={ {
+														marginTop: '10px',
+													} }
 												>
-													{ __( 'View Progress →', 'woocommerce-square' ) }
-												</a>
-											</div>
-										) }
+													<a
+														href={ `${ wcSquareSettings.adminUrl }admin.php?page=wc-settings&tab=square&section=update` }
+														className="button button-primary"
+													>
+														{ __(
+															'View Progress →',
+															'woocommerce-square'
+														) }
+													</a>
+												</div>
+											) }
 									</div>
 								</InputWrapper>
 

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -25,7 +25,7 @@ import {
 import { useSquareSettings } from '../../settings/hooks';
 import { recordEvent, ONBOARDING_TRACK_EVENTS } from '../../../tracks';
 
-export const ConfigureSync = ( { indent = 0, isDirty = false } ) => {
+export const ConfigureSync = ( { indent = 0, isDirty = false, showViewProgressButton = true } ) => {
 	const { settings, squareSettingsLoaded, setSquareSettingData } =
 		useSquareSettings();
 
@@ -378,6 +378,15 @@ export const ConfigureSync = ( { indent = 0, isDirty = false } ) => {
 										} }
 									>
 										{ importDoneNotice }
+										{ importDoneNotice && showViewProgressButton && (
+											<div style={ { marginTop: '10px' } }>
+												<a
+													href="/wp-admin/admin.php?page=wc-settings&tab=square&section=update"
+												>
+													{ __( 'View Progress →', 'woocommerce-square' ) }
+												</a>
+											</div>
+										) }
 									</div>
 								</InputWrapper>
 

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -381,7 +381,8 @@ export const ConfigureSync = ( { indent = 0, isDirty = false, showViewProgressBu
 										{ importDoneNotice && showViewProgressButton && (
 											<div style={ { marginTop: '10px' } }>
 												<a
-													href="/wp-admin/admin.php?page=wc-settings&tab=square&section=update"
+													href={ `${ wcSquareSettings.adminUrl }admin.php?page=wc-settings&tab=square&section=update` }
+													className="button button-primary"
 												>
 													{ __( 'View Progress →', 'woocommerce-square' ) }
 												</a>

--- a/src/new-user-experience/onboarding/onboarding-app.js
+++ b/src/new-user-experience/onboarding/onboarding-app.js
@@ -261,7 +261,7 @@ export const OnboardingApp = () => {
 				) }
 				{ step === 'sync-settings' && (
 					<>
-						<ConfigureSync />
+						<ConfigureSync showViewProgressButton={ false } />
 						<SquareSettingsSaveButton
 							data-testid="square-settings-save-button"
 							afterSaveCallback={ () => {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Adds a "View Progress" link after triggering a product import from Square, allowing users to easily navigate to the Update page and monitor import progress.

<img width="773" alt="image" src="https://github.com/user-attachments/assets/7eb89f35-123d-446b-9ce2-2232c4ef3308" />

- The link is only shown on the settings page, not during the onboarding flow, for a better user experience.

<img width="733" alt="Image" src="https://github.com/user-attachments/assets/fa383e77-68cd-4677-abd8-26bfcd9d959c" />

Closes https://linear.app/a8c/issue/SQUARE-97/add-view-progress-button-link-to-the-update-page-after-importing.
Closes #174.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Go to WooCommerce > Settings > Square > Sync Settings.
2. Trigger a product import from Square.
3. After the import is triggered, confirm that a "View Progress" link appears below the import notice.
4. Click the "View Progress" link and verify it takes you to the Update page, where you can monitor the import progress.
5. Go through the onboarding flow and confirm that the "View Progress" link does **not** appear after importing products.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - When importing products from Square, a new "View Progress" link on the "Update" page allows ability to more closely monitor that progress.