### PR TITLE
Fix: Only sync attributes "Used for Variations" to Square

### DIFF
--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -498,7 +498,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 	/**
 	 * Helper to get only attributes used for variations.
 	 *
-	 * @since 4.9.2
+	 * @since x.x.x
 	 *
 	 * @param WC_Product $product
 	 * @return array

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -81,7 +81,8 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			$item_data->setReportingCategory( $square_category );
 		}
 
-		$attributes = $product->get_attributes();
+		// Only use attributes that are used for variations.
+		$attributes = self::get_used_variation_attributes( $product );
 
 		$product_variation_ids = $product->get_children();
 		$catalog_variations    = $item_data->getVariations() ?? array();
@@ -294,7 +295,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			$result                = wc_square()->get_api()->retrieve_options_data();
 			$options_data          = isset( $result[1] ) ? $result[1] : array();
 			$parent_product        = wc_get_product( $product->get_parent_id() );
-			$attributes            = $parent_product->get_attributes();
+			$attributes            = self::get_used_variation_attributes( $parent_product );
 			$variation_items       = $product->get_attributes();
 			$variation_item_values = array();
 
@@ -492,5 +493,22 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		$catalog_object->setPresentAtAllLocations( false );
 
 		return $catalog_object;
+	}
+
+	/**
+	 * Helper to get only attributes used for variations.
+	 *
+	 * @since 4.9.2
+	 *
+	 * @param WC_Product $product
+	 * @return array
+	 */
+	public static function get_used_variation_attributes( $product ) {
+		return array_filter(
+			$product->get_attributes(),
+			function ( $attribute ) {
+				return $attribute->get_variation();
+			}
+		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Adds a helper function to ensure only attributes marked "Used for variations" are synced to Square.
- Updates the product and variation sync logic to use this helper, preventing Square API errors when WooCommerce products have attributes not used for variations.
- Fixes `[BAD_REQUEST] Expected ItemVariation to have X Item Option Values, got Y` error when syncing variable products with unused attributes.

#### Woo Attributes ("Units" is unused):

![image](https://github.com/user-attachments/assets/e21ad258-94fd-479e-bc44-c18e01735d49)

#### Woo Variations:

![image](https://github.com/user-attachments/assets/56549912-eb1d-4d6a-b5bd-54f70bd196f5)

#### Successful Sync to Square (skipping "Units"):

![image](https://github.com/user-attachments/assets/012c6be4-8817-4f4a-88ed-dde3d933928f)

As shown above, the ‘Units’ attribute is not used for variations and is correctly skipped during sync, resulting in a successful Square sync.

Closes https://linear.app/a8c/issue/SQUARE-104/impossible-to-sync-variable-products-that-have-unused-attributes.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Create a WooCommerce variable product with multiple attributes (e.g., "Color" and "Size").
2. Mark only one attribute as "Used for variations" (e.g., only "Color").
3. Add variations using only the selected attribute.
4. Attempt to sync the product with Square.
5. Confirm that the sync succeeds and no `[BAD_REQUEST] Expected ItemVariation to have X Item Option Values, got Y` error occurs.
6. Optionally, test with products where all attributes are used for variations to confirm no regression.

### Changelog entry

> Fix - Only sync attributes used for variations to Square, preventing item option mismatch errors when WooCommerce products have unused attributes.

---

Let me know if you want to adjust the branch name, PR title, or any section!
