### PR TITLE
Ensure that the request body is correctly logged in the debug logs.

### DIFF
--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -169,6 +169,8 @@ class Request implements API_Request {
 
 				if ( is_callable( array( $arg, '__toString' ) ) ) {
 					$body[ $key ] = $arg->__toString();
+				} elseif ( $arg instanceof \JsonSerializable ) {
+					$body[ $key ] = wp_json_encode( $arg );
 				}
 			}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
While debugging an issue with the initial payment for subscriptions, it was noticed that the request body was not being logged in the debug logs. This PR fixes the issue to ensure that the request body is correctly logged.

Relates to https://linear.app/a8c/issue/SQUARE-114/square-integration-fails-on-new-subscription-orders-customer-creation

### Steps to test the changes in this Pull Request:
1. Go to Square settings (WooCommerce > Settings > Square)
2. Enable logging and save the changes
3. Place an order using the Square payment gateway and verify that the request body is logged (WooCommerce > Status > Logs)

### Changelog entry
> Fix - Ensure that the request body is correctly logged in the debug logs.
