### PR TITLE
Ensure the customer is created on the Square side without errors when adding a payment method.

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway_Direct.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Direct.php
@@ -789,7 +789,6 @@ abstract class Payment_Gateway_Direct extends Payment_Gateway {
 
 		// mock order, as all gateway API implementations require an order object for tokenization
 		$order = new WC_Order_Square( 0 );
-		$order = $this->get_order( $order );
 
 		$user = get_userdata( get_current_user_id() );
 
@@ -835,8 +834,13 @@ abstract class Payment_Gateway_Direct extends Payment_Gateway {
 
 		$order = Order_Compatibility::set_props( $order, $properties );
 
-		// other default info
-		$order->customer_id = $this->get_customer_id( $order->get_user_id() );
+		// Add payment and transaction data to the order.
+		$order = $this->get_order( $order );
+
+		if ( empty( $order->customer_id ) ) {
+			// Set customer ID if not already set.
+			$order->customer_id = $this->get_customer_id( $order->get_user_id() );
+		}
 
 		/* translators: Placeholders: %1$s - site title, %2$s - customer email. Payment method as in a specific credit card, e-check or bank account */
 		$order->description = sprintf( esc_html__( '%1$s - Add Payment Method for %2$s', 'woocommerce-square' ), sanitize_text_field( Square_Helper::get_site_name() ), $properties['billing_email'] );


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As noted in the comment on issue [here](https://linear.app/a8c/issue/SQUARE-114/square-integration-fails-on-new-subscription-orders-customer-creation#comment-6ac1d144), when a newly created user adds a payment method from **My Account**, the first attempt to create a customer fails with the error:

`At least one of given_name, family_name, company_name, email_address, or phone_number is required for a customer`

This happens due to missing customer information on the order object. However, the error is handled gracefully, and the customer is successfully created in the next step. Still, the failure logs can cause confusion during debugging, giving the impression that something is broken and also requiring one additional API call to Square to create the customer.

This PR includes a minor change to ensure the order is loaded with the required customer details so that the customer is created successfully on the first attempt, and the payment method is added under it.


Closes https://linear.app/a8c/issue/SQUARE-114/square-integration-fails-on-new-subscription-orders-customer-creation

### Steps to test the changes in this Pull Request:
1. Switch to the `trunk` branch, configure Square, and enable logging from the settings.
2. Create a new user and log in with the newly created account.
3. Navigate to **My Account > Payment Methods > Add Payment Method**, and add a new payment method (Credit card).
4. Check the logs and verify that they contain the customer creation failure log:
   `At least one of given_name, family_name, company_name, email_address, or phone_number is required for a customer`
5. Switch to this PR branch.
6. Create a new user and log in with that user’s account.
7. Go to **My Account > Payment Methods > Add Payment Method** and add a new payment method (Credit card).
8. Check the logs and verify that there are no customer creation failure logs, and that the customer and card are created successfully.

### Changelog entry
> Fix - Ensure the customer is created on the Square side without errors when adding a payment method.
