### PR TITLE
Ensure there is no fatal error at checkout when using a $0 local pickup shipping method.

### DIFF
--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -283,9 +283,9 @@ class Orders extends API\Request {
 				$line_item->setItemType( 'GIFT_CARD' );
 			}
 
-			$total_tax       = $item->get_total_tax();
-			$total_amount    = $item->get_total();
-			$subtotal_amount = $is_product ? $item->get_subtotal() : $total_amount;
+			$total_tax       = (float) $item->get_total_tax();
+			$total_amount    = (float) $item->get_total();
+			$subtotal_amount = $is_product ? (float) $item->get_subtotal() : $total_amount;
 
 			// Inlcude the tax in subtotal when prices are inclusive of taxes.
 			if ( API::TAX_TYPE_INCLUSIVE === $tax_type ) {
@@ -293,7 +293,7 @@ class Orders extends API\Request {
 			}
 
 			// Subtotal per quantity.
-			$subtotal_amount = $subtotal_amount / $item->get_quantity();
+			$subtotal_amount = $subtotal_amount / absint( $item->get_quantity() );
 
 			$line_item->setQuantity( $is_product ? (string) $item->get_quantity() : (string) 1 );
 			$line_item->setBasePriceMoney( Money_Utility::amount_to_money( $subtotal_amount, $order->get_currency() ) );
@@ -306,7 +306,7 @@ class Orders extends API\Request {
 
 			// CALCULATE DISCOUNT.
 			if ( $item instanceof \WC_Order_Item_Product ) {
-				$discount     = $item->get_subtotal() - $item->get_total();
+				$discount     = (float) $item->get_subtotal() - (float) $item->get_total();
 				$discount_uid = wc_square()->get_idempotency_key( '', false );
 
 				if ( $discount > 0 ) {
@@ -344,7 +344,7 @@ class Orders extends API\Request {
 					$item_uid            = $item->get_id();
 					$tax_uid             = $taxes[ $key ]->getUid();
 					$prev_percentage     = $taxes[ $key ]->getPercentage();
-					$adjusted_percentage = $tax_amount * 100 / $total_amount;
+					$adjusted_percentage = (float) $tax_amount * 100 / $total_amount;
 					$adjusted_percentage = number_format( (float) $adjusted_percentage, 2, '.', '' );
 
 					if ( $prev_percentage !== $adjusted_percentage ) {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in #365, placing an order fails with a fatal error when a customer uses a \$0 local pickup shipping method. Upon investigation, I found that the free local pickup shipping method returns an empty string (`""`) instead of `"0.00"`, which results in a `PHP Fatal error: Uncaught TypeError: Unsupported operand types: string / int`.

This PR adds type casting before performing the arithmetic operation to prevent the fatal type error.

**Root cause:**
On initial review, I found that this error occurs in WooCommerce 9.9.3 (which returns `""` as the shipping cost), but not in 9.8.x (which returns `"0.00"`). Further investigation is needed to identify the exact PR that introduced this change and any related details.

Closes #365 

### Steps to test the changes in this Pull Request:
1. Enable local pickup under `WooCommerce` > `Settings` > `Shipping` > `Local pickup`, and add pickup locations (keep it free).
2. Add any product to the cart and go to checkout.
3. Choose **Local pickup** as the shipping method and place the order.
4. Verify that the order is placed successfully without any issues.

### Changelog entry
> Fix - Ensure no fatal error occurs at checkout when using a free local pickup shipping method.