### PR TITLE
[Shortcode-based Checkout] Unblock UI and show a generic error when buyer verification fails.

### DIFF
--- a/src/js/frontend/wc-square.js
+++ b/src/js/frontend/wc-square.js
@@ -310,24 +310,27 @@ jQuery( document ).ready( ( $ ) => {
 		 */
 		handleSubmission() {
 			this.start( 'generate_payment_nonce' );
-      			this.get_verification_details().then(( verificationDetails ) => {
-					this.payment_form
-						.tokenize( verificationDetails )
-							.then( ( tokenResult ) => {
-								const { token, details, status } = tokenResult;
-								this.end( 'generate_payment_nonce' );
+			this.get_verification_details().then( ( verificationDetails ) => {
+				this.payment_form
+					.tokenize( verificationDetails )
+					.then( ( tokenResult ) => {
+						const { token, details, status } = tokenResult;
 
-								if ( status === 'OK' ) {
-									this.handle_card_nonce_response( token, details );
-								} else {
-									if ( tokenResult.errors ) {
-										this.handle_errors( tokenResult.errors )
-									}
-									this.end( 'generate_payment_nonce', true );
-								}
+						if ( status === 'OK' ) {
+							this.handle_card_nonce_response( token, details );
+							this.end( 'generate_payment_nonce' );
+						} else {
+							if ( tokenResult.errors ) {
+								this.handle_errors( tokenResult.errors );
+							}
+							this.end( 'generate_payment_nonce', true );
+						}
+					} )
+					.catch( ( error ) => {
+						this.end( 'generate_payment_nonce', true );
+						this.handle_errors( [ error ] );
 					} );
-				}
-			);
+			} );
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR unblocks the UI and shows a generic error on the Checkout page when the buyer cancels the SCA challenge or buyer verification fails.

> [!Note]
> We had fixed this issue earlier in PR https://github.com/woocommerce/woocommerce-square/pull/265, but it was reintroduced when the `verifyBuyer` function was removed in PR https://github.com/woocommerce/woocommerce-square/pull/342 has reintroduced. 


Closes https://linear.app/a8c/issue/SQUARE-132/failing-sca-dialogue-causes-javascript-error

### Steps to test the changes in this Pull Request:
1. Try to place order with card `5248 4800 0021 0026` on shortcode based checkout.
1. Cancel the verification Challenge once it shows up.
1. Verify that the Checkout page is unblocked and the page shows a generic error.

### Changelog entry
> Fix - Unblock UI and show a generic error when buyer verification fails.
