### PR TITLE
Enhanced Option Assignment in Multiple Variations

### DIFF
--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -391,7 +391,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						$variation_item_values[] = $option_value_object;
 					}
 
-					$variation_index++;
+					++$variation_index;
 				}
 
 				// Set the name of the variation as the combination of all attribute values.

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -90,6 +90,8 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		// if dealing with a variable product, try and match the variations
 		if ( $product->is_type( 'variable' ) ) {
 
+			$options_ids = array();
+
 			/**
 			 * If there are multiple variations, it must be a considered as Dynamic Options supported product.
 			 * Create/Update and Assign Dynamic Options only if a product
@@ -98,7 +100,6 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			if (
 				count( $attributes ) > 1
 			) {
-				$options_ids  = array();
 				$result       = wc_square()->get_api()->retrieve_options_data();
 				$options_data = $result[1] ?? array();
 
@@ -171,7 +172,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 
 						if ( $product_variation instanceof \WC_Product ) {
 
-							$catalog_variations[ $object_key ] = self::update_catalog_variation( $variation_object, $product_variation );
+							$catalog_variations[ $object_key ] = self::update_catalog_variation( $variation_object, $product_variation, $options_ids );
 
 							// consider this variation taken care of
 							unset( $product_variation_ids[ $key ] );
@@ -201,7 +202,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 				$catalog_item_variation->setItemId( $catalog_object->getId() );
 				$variation_object->setItemVariationData( $catalog_item_variation );
 
-				$catalog_variations[] = self::update_catalog_variation( $variation_object, $product_variation );
+				$catalog_variations[] = self::update_catalog_variation( $variation_object, $product_variation, $options_ids );
 			}
 		} else { // otherwise, we have a simple product
 
@@ -250,11 +251,13 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 	 * @since 2.0.0
 	 *
 	 * @param CatalogObject $catalog_object Square SDK catalog object
-	 * @param \WC_Product $product WooCommerce product
+	 * @param \WC_Product   $product        WooCommerce product
+	 * @param array         $options_ids    Array of options IDs
+	 *
 	 * @return CatalogObject
 	 * @throws \Exception
 	 */
-	public static function update_catalog_variation( CatalogObject $catalog_object, \WC_Product $product ) {
+	public static function update_catalog_variation( CatalogObject $catalog_object, \WC_Product $product, $options_ids = array() ) {
 
 		if ( 'ITEM_VARIATION' !== $catalog_object->getType() || ! $catalog_object->getItemVariationData() ) {
 			throw new \Exception( 'Type of $catalog_object must be an ITEM_VARIATION' );
@@ -305,7 +308,8 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 				$variation_data->setItemOptionValues( null );
 			} else {
 				// If there are multiple attributes, the name of the variation is the combination of all attribute values.
-				$variation_name = array();
+				$variation_name  = array();
+				$variation_index = 0;
 
 				/**
 				 * Set the `item_option_values` for the variation.
@@ -327,26 +331,21 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						$taxonomy_exists  = true;
 					} else {
 						// For custom attributes, simply use the cleaned-up attribute ID
-						$attribute_name   = ucwords( str_replace( '-', ' ', $attribute_id ) );
+						$attribute_name   = str_replace( '-', ' ', $attribute_id );
 						$attribute_id     = $attribute_name;
 						$variation_name[] = $attribute_value;
 					}
 
-					foreach ( $options_data as $option_id_transient => $option_data_transient ) {
-						$option_id       = '';
-						$option_value_id = '';
+					$option_id       = '';
+					$option_value_id = '';
+					if ( isset( $options_data[ $options_ids[ $variation_index ] ] ) ) {
+						$option_id = $options_ids[ $variation_index ];
 
-						// Check for the Square ID of $attribute_name.
-						if ( $option_data_transient['name'] === $attribute_id ) { // @TODO: If merchant changes the name of the attribute, this will create a new item at Square. Think of a way to handle this.
-							$option_id = $option_id_transient;
-							// Check for the Square ID of $attribute_value.
-							foreach ( $option_data_transient['value_ids'] as $value_id => $value_name ) {
-								if ( $value_name === $attribute_value ) {
-									$option_value_id = $value_id;
-									break;
-								}
+						foreach ( $options_data[ $options_ids[ $variation_index ] ]['value_ids'] as $value_id => $value_name ) {
+							if ( $value_name === $attribute_value ) {
+								$option_value_id = $value_id;
+								break;
 							}
-							break;
 						}
 					}
 
@@ -391,6 +390,8 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 
 						$variation_item_values[] = $option_value_object;
 					}
+
+					$variation_index++;
 				}
 
 				// Set the name of the variation as the combination of all attribute values.


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR addresses an issue where manual syncs were failing for merchants due to mismatched item option IDs in product variations during syncs with Square.

The errors stemmed from incorrect indexing and assignment of variation option IDs. Square expected specific option IDs at defined index positions, but received different ones, causing [BAD_REQUEST] errors.

While I was unable to reliably reproduce the issue through normal sync flows (despite multiple attempts), I force-generated the error via controlled code modification to simulate the failure. This approach helped me pinpoint the problem and led to a more robust fix by improving the legacy logic responsible for assigning attribute/option IDs to variation items.

The updated logic now ensures:
- Option IDs are assigned in the correct sequence and index positions, matching Square’s expectations.
- This prevents sync failures caused by ID mismatches across variations.

Reported error logs:

```
2025-07-29T00:27:21+00:00 NOTICE Failed step cycle: update_matched_products (40.03s) - [BAD_REQUEST] Expected ItemVariation to have Item Option at index 1 with ID "X2RFF4DMVWFPSOFIM2TS2J5Z", got "P7XVJUCB76CJDILJHY2CMSGL". CONTEXT: {"_legacy":true}

2025-07-29T15:34:12+00:00 NOTICE Failed step cycle: update_matched_products (2.32s) - [BAD_REQUEST] Expected ItemVariation to have Item Option at index 2 with ID "X2RFF4DMVWFPSOFIM2TS2J5Z", got "P7XVJUCB76CJDILJHY2CMSGL". CONTEXT: {"_legacy":true}
```

Internal discussion reference: [Slack thread](https://fueled.slack.com/archives/C01UCQGPBDJ/p1753881785621619)

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

Although the exact reproduction steps for this issue are unclear, the following flow can help verify the fix. The key is to ensure no BAD_REQUEST errors appear in the logs and that the product syncs successfully:

1. Create a variable product with multiple variation options and initiate a sync to Square.
2. Modify the product by changing the custom attribute names and save the product. Try some weird long names with random camelcasing and spaces (for example: "test Attribute 01", "Test attribute 01", etc.)
3. Keep checking that no BAD_REQUEST errors related to mismatched option IDs appear in the logs.
4. Repeat the above with a few different combinations of attribute names and variations to ensure consistency.

### Changelog entry

> Fix - Corrected variation option assignment logic to prevent mismatched item option IDs during manual syncs to Square.

Closes #386
Closes https://linear.app/a8c/issue/SQUARE-153