### PR TITLE
Compatibility testing with WC 10.1

### DIFF
--- a/tests/e2e/specs/d6.woo-sor.spec-with-inventory-new-editor.spec.js
+++ b/tests/e2e/specs/d6.woo-sor.spec-with-inventory-new-editor.spec.js
@@ -16,24 +16,25 @@ import {
 } from '../utils/square-sandbox';
 
 test.describe.configure( { mode: 'serial' } );
-test.beforeAll( 'Setup', async ( ) => {
-	const browser = await chromium.launch();
-	const page = await browser.newPage();
+// test.beforeAll( 'Setup', async ( ) => {
+// 	const browser = await chromium.launch();
+// 	const page = await browser.newPage();
 
-	await deleteAllProducts( page );
-	await deleteAllCatalogItems();
+// 	await deleteAllProducts( page );
+// 	await deleteAllCatalogItems();
 
-	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=square&section' );
+// 	await page.goto( '/wp-admin/admin.php?page=wc-settings&tab=square&section' );
 
-	await page.getByTestId( 'sync-settings-field' ).selectOption( { label: 'WooCommerce' } );
-	await page.getByTestId( 'push-inventory-field' ).check();
-	await saveSquareSettings( page );
+// 	await page.getByTestId( 'sync-settings-field' ).selectOption( { label: 'WooCommerce' } );
+// 	await page.getByTestId( 'push-inventory-field' ).check();
+// 	await saveSquareSettings( page );
 
-	await clearSync( page );
-	await browser.close();
-} );
+// 	await clearSync( page );
+// 	await browser.close();
+// } );
 
-test( 'OnePlus 8 pushed to Square with inventory (New Editor) @sync', async ( { page, baseURL } ) => {
+// Skipping it for now, as WooCommerce 10.1 has removed new product editor.
+test.skip( 'OnePlus 8 pushed to Square with inventory (New Editor) @sync', async ( { page, baseURL } ) => {
 	test.slow();
 
 	if ( ! ( await doesProductExist( baseURL, 'oneplus-8' ) ) ) {
@@ -130,7 +131,8 @@ test( 'OnePlus 8 pushed to Square with inventory (New Editor) @sync', async ( { 
 	expect( inventory ).toHaveProperty( 'counts[0].quantity', '62' );
 } );
 
-test( 'Update inventory from Woo to Square @sync', async ( { page } ) => {
+// Skipping it for now, as WooCommerce 10.1 has removed new product editor.
+test.skip( 'Update inventory from Woo to Square @sync', async ( { page } ) => {
 	await page.goto( '/wp-admin/edit.php?post_type=product' );
 	await page
 		.locator( 'a.row-title' )

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Version: 4.9.7
  * Plugin URI: https://woocommerce.com/products/square/
- * Requires at least: 6.6
+ * Requires at least: 6.7
  * Tested up to: 6.8
  * Requires PHP: 7.4
  * PHP tested up to: 8.3
@@ -22,8 +22,8 @@
  * @copyright Copyright (c) 2019, Automattic, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
  *
- * WC requires at least: 9.8
- * WC tested up to: 10.0
+ * WC requires at least: 9.9
+ * WC tested up to: 10.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -56,10 +56,10 @@ class WooCommerce_Square_Loader {
 	const MINIMUM_PHP_VERSION = '7.4.0';
 
 	/** minimum WordPress version required by this plugin */
-	const MINIMUM_WP_VERSION = '6.6';
+	const MINIMUM_WP_VERSION = '6.7';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '9.7';
+	const MINIMUM_WC_VERSION = '9.8';
 
 	/**
 	 * SkyVerge plugin framework version used by this plugin


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Bump WooCommerce "tested up to" version 10.1
Bump WooCommerce minimum supported version to 9.9
Bump WordPress minimum supported version to 6.7

Closes https://linear.app/a8c/issue/SQUARE-149/compatibility-testing-with-woo-101-rc1

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR
2. All tests should be passed.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 10.1.
> Dev - Bump WooCommerce minimum supported version to 9.9.
> Dev - Bump WordPress minimum supported version to 6.7.