### PR TITLE
Remove loading translations, as it is automatically handled by WordPress since version 4.6.

### DIFF
--- a/includes/Framework/Plugin.php
+++ b/includes/Framework/Plugin.php
@@ -202,10 +202,6 @@ abstract class Plugin {
 
 		// initialize the plugin admin
 		add_action( 'admin_init', array( $this, 'init_admin' ), 0 );
-
-		// hook for translations seperately to ensure they're loaded
-		add_action( 'init', array( $this, 'load_translations' ) );
-
 		add_action( 'admin_footer', array( $this, 'add_delayed_admin_notices' ) );
 
 		// add a 'Configure' link to the plugin action links
@@ -238,68 +234,6 @@ abstract class Plugin {
 	public function __wakeup() {
 		/* translators: Placeholders: %s - plugin name */
 		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'You cannot unserialize instances of %s.', 'woocommerce-square' ), esc_html( $this->get_plugin_name() ) ), '3.1.0' );
-	}
-
-
-	/**
-	 * Load plugin & framework text domains.
-	 *
-	 * @internal
-	 *
-	 * @since 3.0.0
-	 */
-	public function load_translations() {
-
-		$this->load_framework_textdomain();
-
-		// if this plugin passes along its text domain, load its translation files
-		if ( $this->text_domain ) {
-			$this->load_plugin_textdomain();
-		}
-	}
-
-
-	/**
-	 * Loads the framework textdomain.
-	 *
-	 * @since 3.0.0
-	 */
-	protected function load_framework_textdomain() {
-		$this->load_textdomain( 'woocommerce-square', dirname( plugin_basename( $this->get_framework_file() ) ) );
-	}
-
-
-	/**
-	 * Loads the plugin textdomain.
-	 *
-	 * @since 3.0.0
-	 */
-	protected function load_plugin_textdomain() {
-		$this->load_textdomain( $this->text_domain, dirname( plugin_basename( $this->get_plugin_file() ) ) );
-	}
-
-
-	/**
-	 * Loads the plugin textdomain.
-	 *
-	 * @since 3.0.0
-	 * @param string $textdomain the plugin textdomain
-	 * @param string $path the i18n path
-	 */
-	protected function load_textdomain( $textdomain, $path ) {
-
-		// user's locale if in the admin for WP 4.7+, or the site locale otherwise
-		$locale = is_admin() && is_callable( 'get_user_locale' ) ? get_user_locale() : get_locale();
-
-		/**
-		 * @see https://developer.wordpress.org/reference/hooks/plugin_locale/ plugin_locale
-		 * @since 3.0.0
-		*/
-		$locale = apply_filters( 'plugin_locale', $locale, $textdomain );
-
-		load_textdomain( $textdomain, WP_LANG_DIR . '/' . $textdomain . '/' . $textdomain . '-' . $locale . '.mo' );
-
-		load_plugin_textdomain( $textdomain, false, untrailingslashit( $path ) . '/i18n/languages' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR removes translation loading from the plugin as since WordPress 4.6, it is automatically handled by WordPress.

Closes https://linear.app/a8c/issue/SQUARE-148/load-plugin-textdomain-error-from-plugin-check

### Steps to test the changes in this Pull Request:
1. Go to general settings, Update site language to `nl_NL` or any other language where translation available.
1. Go to `Dashboard > Updates` and update translations.
1. You should see Square related strings are translated.

### Changelog entry
> Dev - Remove loading translations, as it is automatically handled by WordPress since version 4.6.
