### PR TITLE
Accurately count attribute values – 250 values, not chars

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -160,7 +160,7 @@ class Admin {
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
 						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters', 'woocommerce-square' ),
 						'too_many_attributes'         => __( 'Too many attributes, maximum allowed are 6.', 'woocommerce-square' ),
-						'too_many_attribute_values'   => __( 'Too many attribute values, maximum allowed are 250', 'woocommerce-square' ),
+						'too_many_attribute_values'   => __( 'Too many attribute values: %d values (max 250)', 'woocommerce-square' ),
 						'too_many_variations'         => __( 'Too many variations, maximum allowed are 250.', 'woocommerce-square' ),
 					),
 				)

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -160,6 +160,7 @@ class Admin {
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
 						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters', 'woocommerce-square' ),
 						'too_many_attributes'         => __( 'Too many attributes, maximum allowed are 6.', 'woocommerce-square' ),
+						/* translators: %d - maximum allowed attribute values */
 						'too_many_attribute_values'   => __( 'Too many attribute values: %d (max 250)', 'woocommerce-square' ),
 						'too_many_variations'         => __( 'Too many variations, maximum allowed are 250.', 'woocommerce-square' ),
 					),

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -160,7 +160,7 @@ class Admin {
 						'sync_stock_from_square'      => __( 'Sync stock from Square', 'woocommerce-square' ),
 						'attribute_name_too_long'     => __( 'Attribute name is too long, maximum allowed are 65 characters', 'woocommerce-square' ),
 						'too_many_attributes'         => __( 'Too many attributes, maximum allowed are 6.', 'woocommerce-square' ),
-						'too_many_attribute_values'   => __( 'Too many attribute values: %d values (max 250)', 'woocommerce-square' ),
+						'too_many_attribute_values'   => __( 'Too many attribute values: %d (max 250)', 'woocommerce-square' ),
 						'too_many_variations'         => __( 'Too many variations, maximum allowed are 250.', 'woocommerce-square' ),
 					),
 				)

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -817,7 +817,7 @@ jQuery( document ).ready( ( $ ) => {
 			);
 		};
 
-	const validateMaxAttributeValues = ($field) => {
+		const validateMaxAttributeValues = ($field) => {
 			let attrValues = $field.val();
 
 			// Count the actual number of values.
@@ -833,7 +833,7 @@ jQuery( document ).ready( ( $ ) => {
 				valueCount,
 				250,
 				$field,
-				wc_square_admin_products.i18n.too_many_attribute_values + ': ' + valueCount + ' values (max 250)'
+				wc_square_admin_products.i18n.too_many_attribute_values.replace( '%d', valueCount )
 			);
 		};
 

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -817,19 +817,23 @@ jQuery( document ).ready( ( $ ) => {
 			);
 		};
 
-		const validateMaxAttributeValues = ($field) => {
+	const validateMaxAttributeValues = ($field) => {
 			let attrValues = $field.val();
 
-			// if attrValues is array (when taxonomy attribute), convert to string and combine values by '|'.
+			// Count the actual number of values.
+			let valueCount;
 			if (Array.isArray(attrValues)) {
-				attrValues = attrValues.join('|');
+				valueCount = attrValues.length;
+			} else {
+				// If it's already a string (pipe-separated), split and count.
+				valueCount = attrValues.split('|').filter(value => value.trim() !== '').length;
 			}
 
 			return validateLimit(
-				attrValues.length,
+				valueCount,
 				250,
 				$field,
-				wc_square_admin_products.i18n.too_many_attribute_values + ': ' + attrValues.substring(0, 50) + '...'
+				wc_square_admin_products.i18n.too_many_attribute_values + ': ' + valueCount + ' values (max 250)'
 			);
 		};
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Fix attribute validation to count values instead of string length**

The WooCommerce Square plugin was incorrectly validating attribute values by checking the character length of pipe-separated strings instead of counting the actual number of attribute values. This caused validation failures for products with long attribute value names, even when they had fewer than 250 values, while allowing products with many short attribute values to pass validation even when exceeding the 250 limit.

This PR modifies `validateMaxAttributeValues()` function to count array values directly instead of converting to a string first

Closes https://linear.app/a8c/issue/SQUARE-147/attribute-limitation-is-250-values-but-plugin-js-checks-string-not.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Create a product with one attribute containing 6 values, each with 50+ characters (e.g., "Very long attribute value name that exceeds typical length for testing purposes")
2. Press tab while editing; this will trigger a values check, confirm no errors are displayed. Previously, this would fail with "Too many attribute values" error.
3. Verify the product now syncs successfully since it has only 6 values (under the 250 limit)
4. Test with a product that has 251+ attribute values to confirm validation still works correctly and error is displayed (you can do this just by copy-pasting any string (for example "Red | ")
5. Verify error message

### Changelog entry

> Fix - Accurately count attribute values – 250 values, not characters.