### PR TITLE
Ensure there is no fatal error on the product page when the product price is blank.

### DIFF
--- a/includes/Gateway/Digital_Wallet.php
+++ b/includes/Gateway/Digital_Wallet.php
@@ -459,7 +459,8 @@ class Digital_Wallet {
 			return $this->build_payment_request( WC()->cart->total );
 		}
 
-		$amount         = number_format( $quantity * $product->get_price(), 2, '.', '' );
+		$product_price  = (float) $product->get_price();
+		$amount         = number_format( $quantity * $product_price, 2, '.', '' );
 		$quantity_label = 1 < $quantity ? ' x ' . $quantity : '';
 
 		$items[] = array(

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -666,8 +666,8 @@ export async function createPreOrderProduct(page, options = {}) {
 		.fill(product.availabilityDate);
 	await page.locator('#_wc_pre_orders_fee').fill(product.preOrderFee);
 	await page
-		.locator('#_wc_pre_orders_when_to_charge')
-		.selectOption(product.whenToCharge);
+		.locator( `input[name="_wc_pre_orders_when_to_charge"][value="${ product.whenToCharge }"]` )
+		.check();
 
 	await page.locator('#publish').waitFor();
 	await page.locator('#publish').click();

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -707,6 +707,7 @@ export async function completePreOrder(page, orderId) {
 		.check();
 	await page.locator('#bulk-action-selector-top').selectOption('complete');
 	await page.locator('#doaction').click();
+	await page.locator('#confirm-complete-btn').click();
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in [#SQUARE-102](https://linear.app/a8c/issue/SQUARE-102/fatal-errorwarning-unsupported-operand-types-int-string-in-digital), the product page shows a fatal error if the product price is set to blank by some extensions (e.g., NYP or YITH Gift Cards). This happens because `$product->get_price()` returns an empty string (`""`), and a multiplication operation is performed directly on it, resulting in a PHP fatal error:

`PHP Fatal error: Uncaught TypeError: Unsupported operand types: int * string`.

This PR adds type casting before performing the arithmetic operation to prevent the fatal type error.

> [!NOTE]
> I haven’t tested this with the NYP plugin but was able to reproduce a similar issue with YITH Gift Cards. Therefore, I’ve raised this PR to fix the problem.

Closes https://linear.app/a8c/issue/SQUARE-102/fatal-errorwarning-unsupported-operand-types-int-string-in-digital

### Steps to test the changes in this Pull Request:
1. Install and activate the [YITH WooCommerce Gift Cards](https://wordpress.org/plugins/yith-woocommerce-gift-cards/) plugin.
2. Create a gift card product and add a gift card amount to it.
3. Enable digital wallets.
4. Visit the product page and confirm that there is no fatal error and that the page works as expected.

### Changelog entry
> Fix - Ensure there is no fatal error on the product page when the product price is blank.
