### PR TITLE
Add Opt-in setting for bidirectional order sync

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,8 +5,6 @@ on:
       - smoke-testing
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - trunk
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -59,6 +59,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 			'enable_customer_decline_messages',
 			'debug_mode',
 			'debug_logging_enabled',
+			'enable_order_fulfillment_sync',
 		);
 
 		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
@@ -149,6 +150,11 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 						'description'       => __( 'Enable detailed decline messages to the customer during checkout when possible, rather than a generic decline message.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => '',
+					),
+					'enable_order_fulfillment_sync' => array(
+						'description'       => __( 'Enable bidirectional order fulfillment synchronization between WooCommerce and Square orders.', 'woocommerce-square' ),
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
 			)

--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -152,7 +152,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 						'sanitize_callback' => '',
 					),
 					'enable_order_fulfillment_sync'    => array(
-						'description'       => __( 'Enable bidirectional order fulfillment synchronization between WooCommerce and Square orders.', 'woocommerce-square' ),
+						'description'       => __( 'Enable bidirectional fulfillment synchronization between WooCommerce and Square orders.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),

--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -151,7 +151,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 						'type'              => 'string',
 						'sanitize_callback' => '',
 					),
-					'enable_order_fulfillment_sync' => array(
+					'enable_order_fulfillment_sync'    => array(
 						'description'       => __( 'Enable bidirectional order fulfillment synchronization between WooCommerce and Square orders.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',

--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -496,8 +496,17 @@ class Gateway extends Payment_Gateway_Direct {
 		if ( $response->get_square_order_id() ) {
 			$this->update_order_meta( $order, 'square_order_id', $response->get_square_order_id() );
 
-			// translators: %s is the Square order ID.
-			$order->add_order_note( sprintf( esc_html__( 'Square Order ID: %s', 'woocommerce-square' ), $response->get_square_order_id() ) );
+			// Prepare the Square order URL.
+			$is_sandbox = $this->get_plugin()->get_settings_handler()->is_sandbox();
+			$square_url = $is_sandbox ? 'https://app.squareupsandbox.com/dashboard/orders/overview/' : 'https://app.squareup.com/dashboard/orders/overview/';
+
+			$order->add_order_note(
+				sprintf(
+					// translators: %s is the Square order ID linked to the Square order in the admin.
+					__( 'Square Order ID: %s', 'woocommerce-square' ),
+					'<a href="' . esc_url( $square_url . $response->get_square_order_id() ) . '" target="_blank">' . $response->get_square_order_id() . '</a>'
+				)
+			);
 		}
 
 		// store the plugin version on the order

--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -504,7 +504,7 @@ class Gateway extends Payment_Gateway_Direct {
 				sprintf(
 					// translators: %s is the Square order ID linked to the Square order in the admin.
 					__( 'Square Order ID: %s', 'woocommerce-square' ),
-					'<a href="' . esc_url( $square_url . $response->get_square_order_id() ) . '" target="_blank">' . $response->get_square_order_id() . '</a>'
+					'<a href="' . esc_url( $square_url . $response->get_square_order_id() ) . '" target="_blank">' . esc_html( $response->get_square_order_id() ) . '</a>'
 				)
 			);
 		}

--- a/includes/Gateway/API.php
+++ b/includes/Gateway/API.php
@@ -719,7 +719,7 @@ class API extends \WooCommerce\Square\API {
 	/**
 	 * Searches for Square orders.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @param array  $location_ids Array of location IDs.
 	 * @param string $start_time   Start time in the RFC 3339 format for the search.

--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -120,8 +120,8 @@ class Orders extends API\Request {
 	public function set_order_data( \WC_Order $order, \Square\Models\Order $order_model, $order_request_type = 'update' ) {
 		$order_model->setReferenceId( $order->get_order_number() );
 
-		// Set fulfillment data for create order request.
-		if ( 'create' === $order_request_type ) {
+		// Set fulfillment data for create order request if order sync is enabled.
+		if ( $this->is_order_fulfillment_sync_enabled() && 'create' === $order_request_type ) {
 			$order_model = $this->set_fulfillment_data( $order, $order_model );
 		}
 
@@ -665,6 +665,16 @@ class Orders extends API\Request {
 		$this->square_request->setQuery( $query );
 
 		$this->square_api_args = array( $this->square_request );
+	}
+
+	/**
+	 * Check if order fulfillment sync is enabled.
+	 *
+	 * @since x.x.x
+	 * @return bool True if enabled, false otherwise.
+	 */
+	private function is_order_fulfillment_sync_enabled() {	
+		return wc_square()->get_settings_handler()->is_order_fulfillment_sync_enabled();
 	}
 
 }

--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -179,7 +179,7 @@ class Orders extends API\Request {
 	/**
 	 * Sets the fulfillment data for an order.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @param \WC_Order            $order        WooCommerce order object.
 	 * @param \Square\Models\Order $order_model Square order object.
@@ -611,7 +611,7 @@ class Orders extends API\Request {
 	/**
 	 * Sets the data for searching orders.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @param array  $location_ids Array of location IDs to search in.
 	 * @param string $start_time   Start time for the search (ISO 8601 format).
@@ -670,7 +670,7 @@ class Orders extends API\Request {
 	/**
 	 * Check if order fulfillment sync is enabled.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @return bool True if enabled, false otherwise.
 	 */
 	public function is_order_fulfillment_sync_enabled() {

--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -673,7 +673,7 @@ class Orders extends API\Request {
 	 * @since x.x.x
 	 * @return bool True if enabled, false otherwise.
 	 */
-	private function is_order_fulfillment_sync_enabled() {	
+	public function is_order_fulfillment_sync_enabled() {
 		return wc_square()->get_settings_handler()->is_order_fulfillment_sync_enabled();
 	}
 

--- a/includes/Gateway/API/Responses/Search_Orders.php
+++ b/includes/Gateway/API/Responses/Search_Orders.php
@@ -7,7 +7,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * The Search Orders API response object.
  *
- * @since x.x.x
+ * @since 4.9.9
  *
  * @method \Square\Models\SearchOrdersResponse get_data()
  */
@@ -16,7 +16,7 @@ class Search_Orders extends \WooCommerce\Square\Gateway\API\Response {
 	/**
 	 * Gets the orders from the response.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @return array
 	 */
@@ -28,7 +28,7 @@ class Search_Orders extends \WooCommerce\Square\Gateway\API\Response {
 	/**
 	 * Gets the cursor for pagination.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @return string
 	 */
@@ -40,7 +40,7 @@ class Search_Orders extends \WooCommerce\Square\Gateway\API\Response {
 	/**
 	 * Gets the response data as an array with orders and cursor.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @return array
 	 */

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -1208,8 +1208,17 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 		if ( $response->get_square_order_id() ) {
 			$this->update_order_meta( $order, 'square_order_id', $response->get_square_order_id() );
 
-			// translators: %s is the Square order ID.
-			$order->add_order_note( sprintf( esc_html__( 'Square Order ID: %s', 'woocommerce-square' ), $response->get_square_order_id() ) );
+			// Prepare the Square order URL.
+			$is_sandbox = $this->get_plugin()->get_settings_handler()->is_sandbox();
+			$square_url = $is_sandbox ? 'https://app.squareupsandbox.com/dashboard/orders/overview/' : 'https://app.squareup.com/dashboard/orders/overview/';
+
+			$order->add_order_note(
+				sprintf(
+					// translators: %s is the Square order ID linked to the Square order in the admin.
+					__( 'Square Order ID: %s', 'woocommerce-square' ),
+					'<a href="' . esc_url( $square_url . $response->get_square_order_id() ) . '" target="_blank">' . $response->get_square_order_id() . '</a>'
+				)
+			);
 		}
 
 		// store the plugin version on the order

--- a/includes/Handlers/Order_Sync.php
+++ b/includes/Handlers/Order_Sync.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Square - Order Sync Handler
  *
- * @since x.x.x
+ * @since 4.9.9
  */
 
 namespace WooCommerce\Square\Handlers;
@@ -14,13 +14,13 @@ use WooCommerce\Square\Sync\Order_Polling;
 /**
  * Handles syncing orders between WooCommerce and Square.
  *
- * @since x.x.x
+ * @since 4.9.9
  */
 class Order_Sync {
 	/**
 	 * Initialize hooks.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 */
 	public function init() {
 		// Initialize order polling system.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -152,7 +152,7 @@ class Plugin extends Payment_Gateway_Plugin {
 	/**
 	 * Unschedule order sync event if order sync is disabled.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 */
 	public function unschedule_order_sync() {
 		if ( ! $this->get_settings_handler()->is_order_fulfillment_sync_enabled() && as_has_scheduled_action( WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array(), wc_square()->get_id() ) ) {
@@ -815,7 +815,7 @@ class Plugin extends Payment_Gateway_Plugin {
 	/**
 	 * Gets the order sync handler instance.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @return Order_Sync
 	 */

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -144,6 +144,21 @@ class Plugin extends Payment_Gateway_Plugin {
 		add_action( 'action_scheduler_init', array( $this, 'schedule_token_migration_job' ) );
 		add_action( 'wc_square_init_payment_token_migration_v2', array( $this, 'register_payment_tokens_migration_scheduler' ) );
 		add_action( 'wc_square_init_payment_token_migration', '__return_false' );
+
+		// Unschedule order sync event if order sync is disabled.
+		add_action( 'admin_init', array( $this, 'unschedule_order_sync' ) );
+	}
+
+	/**
+	 * Unschedule order sync event if order sync is disabled.
+	 *
+	 * @since x.x.x
+	 */
+	public function unschedule_order_sync() {
+		if ( ! $this->get_settings_handler()->is_order_fulfillment_sync_enabled() && as_has_scheduled_action( WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array(), wc_square()->get_id() ) ) {
+			// Delete the order sync event.
+			as_unschedule_all_actions( WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array(), wc_square()->get_id() );
+		}
 	}
 
 	/**
@@ -171,9 +186,6 @@ class Plugin extends Payment_Gateway_Plugin {
 		if ( class_exists( '\WooCommerce\Square\Handlers\Async_Request' ) ) {
 			$this->async_request_handler = new Async_Request();
 		}
-
-		$this->order_sync_handler = new Order_Sync();
-		$this->order_sync_handler->init();
 	}
 
 
@@ -260,6 +272,12 @@ class Plugin extends Payment_Gateway_Plugin {
 
 		if ( ! $this->admin_handler && is_admin() ) {
 			$this->admin_handler = new Admin( $this );
+		}
+
+		// Initialize order sync handler if order sync is enabled.
+		if ( $this->get_settings_handler()->is_order_fulfillment_sync_enabled() ) {
+			$this->order_sync_handler = new Order_Sync();
+			$this->order_sync_handler->init();
 		}
 
 		// WooPayments compatibility.

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -644,6 +644,24 @@ class Settings extends \WC_Settings_API {
 		return (bool) apply_filters( 'wc_square_override_product_images_enabled', 'yes' === $this->get_option( 'override_product_images' ) );
 	}
 
+	/**
+	 * Determines if order fulfillment sync is enabled.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public function is_order_fulfillment_sync_enabled() {
+		/**
+		 * Filter to enable/disable order fulfillment sync.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param boolean 'should_sync' Boolean flag to toggle order fulfillment sync feature.
+		 */
+		return (bool) apply_filters( 'wc_square_order_fulfillment_sync_enabled', 'yes' === $this->get_option( 'enable_order_fulfillment_sync' ) );
+	}
+
 
 	/**
 	 * Determines if product sync is enabled.

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -647,7 +647,7 @@ class Settings extends \WC_Settings_API {
 	/**
 	 * Determines if order fulfillment sync is enabled.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 *
 	 * @return bool
 	 */
@@ -655,7 +655,7 @@ class Settings extends \WC_Settings_API {
 		/**
 		 * Filter to enable/disable order fulfillment sync.
 		 *
-		 * @since x.x.x
+		 * @since 4.9.9
 		 *
 		 * @param boolean 'should_sync' Boolean flag to toggle order fulfillment sync feature.
 		 */

--- a/includes/Sync/Order_Importer.php
+++ b/includes/Sync/Order_Importer.php
@@ -6,7 +6,7 @@
  * Used by both webhook handlers and scheduled polling.
  *
  * @package WooCommerce\Square\Sync
- * @since x.x.x
+ * @since 4.9.9
  */
 
 namespace WooCommerce\Square\Sync;
@@ -20,14 +20,14 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class to handle importing Square orders into WooCommerce.
  *
- * @since x.x.x
+ * @since 4.9.9
  */
 class Order_Importer {
 
 	/**
 	 * Update existing WooCommerce order with Square order data.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param \WC_Order $wc_order Existing WooCommerce order.
 	 * @param \Square\Models\Order $square_order Square order object.
 	 * @return array Update result with 'updated' flag and message.
@@ -130,7 +130,7 @@ class Order_Importer {
 	/**
 	 * Update fulfillment data from Square order.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param \WC_Order $wc_order WooCommerce order.
 	 * @param \Square\Models\Order $square_order Square order.
 	 */
@@ -203,7 +203,7 @@ class Order_Importer {
 	/**
 	 * Find existing WooCommerce order by Square order ID.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param string $square_order_id Square order ID.
 	 * @return \WC_Order|false
 	 */

--- a/includes/Sync/Order_Mapper.php
+++ b/includes/Sync/Order_Mapper.php
@@ -5,7 +5,7 @@
  * Maps data between Square and WooCommerce order formats.
  *
  * @package WooCommerce\Square\Sync
- * @since   x.x.x
+ * @since   4.9.9
  */
 
 namespace WooCommerce\Square\Sync;
@@ -15,13 +15,13 @@ namespace WooCommerce\Square\Sync;
  *
  * Provides static methods to map order data between Square and WooCommerce.
  *
- * @since x.x.x
+ * @since 4.9.9
  */
 class Order_Mapper {
 	/**
 	 * Map Square order state to WooCommerce order status.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param string $square_state Square order state.
 	 * @return string WooCommerce order status.
 	 */
@@ -39,7 +39,7 @@ class Order_Mapper {
 	/**
 	 * Check if order status change is allowed.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param string $from_status Current WooCommerce status.
 	 * @param string $to_status New status from Square.
 	 * @return bool True if status change is allowed.
@@ -51,7 +51,7 @@ class Order_Mapper {
 		/**
 		 * Filters the allowed status changes.
 		 *
-		 * @since x.x.x
+		 * @since 4.9.9
 		 *
 		 * @param bool $allowed_status_changes True if status change is allowed.
 		 * @param string $from_status Current WooCommerce status.

--- a/includes/Sync/Order_Polling.php
+++ b/includes/Sync/Order_Polling.php
@@ -18,15 +18,6 @@ defined( 'ABSPATH' ) || exit;
  * @since x.x.x
  */
 class Order_Polling {
-
-	/**
-	 * Action Scheduler hook name for order polling.
-	 *
-	 * @since x.x.x
-	 * @var string
-	 */
-	const CRON_HOOK = 'wc_square_sync_orders';
-
 	/**
 	 * Initialize the polling system.
 	 *
@@ -37,7 +28,7 @@ class Order_Polling {
 		add_action( 'init', array( $this, 'maybe_schedule_polling' ) );
 
 		// Add action to poll square orders via Action Scheduler.
-		add_action( self::CRON_HOOK, array( $this, 'poll_square_orders' ) );
+		add_action( WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array( $this, 'poll_square_orders' ) );
 	}
 
 	/**
@@ -46,7 +37,7 @@ class Order_Polling {
 	 * @since x.x.x
 	 */
 	public function maybe_schedule_polling() {
-		if ( false === as_next_scheduled_action( self::CRON_HOOK, array(), wc_square()->get_id() ) ) {
+		if ( false === as_next_scheduled_action( WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array(), wc_square()->get_id() ) ) {
 			$this->schedule_polling();
 		}
 	}
@@ -59,7 +50,7 @@ class Order_Polling {
 	public function schedule_polling() {
 		$interval = $this->get_polling_interval_seconds();
 
-		as_schedule_recurring_action( time() + $interval, $interval, self::CRON_HOOK, array(), wc_square()->get_id() );
+		as_schedule_recurring_action( time() + $interval, $interval, WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array(), wc_square()->get_id() );
 
 		wc_square()->log( "Scheduled Square order polling with interval: {$interval} seconds", 'sync' );
 	}

--- a/includes/Sync/Order_Polling.php
+++ b/includes/Sync/Order_Polling.php
@@ -5,7 +5,7 @@
  * Handles scheduled polling to sync orders from Square to WooCommerce.
  *
  * @package WooCommerce\Square\Sync
- * @since x.x.x
+ * @since 4.9.9
  */
 
 namespace WooCommerce\Square\Sync;
@@ -15,13 +15,13 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Order Polling Class.
  *
- * @since x.x.x
+ * @since 4.9.9
  */
 class Order_Polling {
 	/**
 	 * Initialize the polling system.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 */
 	public function __construct() {
 		// Add action to schedule polling.
@@ -34,7 +34,7 @@ class Order_Polling {
 	/**
 	 * Maybe schedule the polling Action Scheduler job.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 */
 	public function maybe_schedule_polling() {
 		if ( false === as_next_scheduled_action( WC_SQUARE_SYNC_ORDERS_EVENT_HOOK, array(), wc_square()->get_id() ) ) {
@@ -45,7 +45,7 @@ class Order_Polling {
 	/**
 	 * Schedule the polling Action Scheduler job.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 */
 	public function schedule_polling() {
 		$interval = $this->get_polling_interval_seconds();
@@ -58,7 +58,7 @@ class Order_Polling {
 	/**
 	 * Poll Square for new orders.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 */
 	public function poll_square_orders() {
 		// Capture sync start time to avoid missing orders updated during sync.
@@ -92,7 +92,7 @@ class Order_Polling {
 	/**
 	 * Fetch recent Square orders.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param string $sync_start_time Optional sync start time for bounded time window.
 	 * @return array Array of Square order objects.
 	 */
@@ -120,7 +120,7 @@ class Order_Polling {
 	/**
 	 * Search Square orders since a specific time with bounded time window.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param \WooCommerce\Square\Gateway\API $api API instance.
 	 * @param string                          $since_time ISO 8601 timestamp.
 	 * @param string                          $sync_start_time Optional sync start time for bounded time window.
@@ -181,7 +181,7 @@ class Order_Polling {
 	/**
 	 * Process Square orders to create or update WooCommerce orders.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param array $square_orders Array of Square order objects.
 	 */
 	private function process_square_orders( $square_orders ) {
@@ -280,14 +280,14 @@ class Order_Polling {
 	/**
 	 * Get polling interval in seconds.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @return int
 	 */
 	private function get_polling_interval_seconds() {
 		/**
 		 * Filters the polling interval in seconds for Square orders.
 		 *
-		 * @since x.x.x
+		 * @since 4.9.9
 		 * @param int $interval The polling interval in seconds.
 		 * @return int The polling interval in seconds.
 		 */
@@ -297,7 +297,7 @@ class Order_Polling {
 	/**
 	 * Get last polling time.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @return string ISO 8601 timestamp.
 	 */
 	private function get_last_polling_time() {
@@ -320,7 +320,7 @@ class Order_Polling {
 	/**
 	 * Update last polling time.
 	 *
-	 * @since x.x.x
+	 * @since 4.9.9
 	 * @param string $timestamp Optional timestamp to set. Defaults to current time.
 	 */
 	private function update_last_polling_time( $timestamp = null ) {

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -47,6 +47,7 @@ export const ConfigureSync = ( {
 		hide_missing_products = 'no',
 		sync_interval = '0.25',
 		is_connected = false,
+		enable_order_fulfillment_sync = 'no',
 	} = settings;
 
 	const sync_interval_options = [
@@ -336,6 +337,36 @@ export const ConfigureSync = ( {
 												sync_interval: value,
 											} )
 										}
+									/>
+								</InputWrapper>
+
+								<InputWrapper
+									label={ __(
+										'Order Fulfillment Sync',
+										'woocommerce-square'
+									) }
+									description={ __(
+										'Enable bidirectional order fulfillment synchronization between WooCommerce and Square orders. This will sync fulfillment status changes from Square back to WooCommerce and include fulfillment data when creating new orders.',
+										'woocommerce-square'
+									) }
+									indent={ indent }
+								>
+									<SquareCheckboxControl
+										data-testid="order-fulfillment-sync-field"
+										checked={
+											enable_order_fulfillment_sync ===
+											'yes'
+										}
+										onChange={ ( value ) =>
+											setSquareSettingData( {
+												enable_order_fulfillment_sync:
+													value ? 'yes' : 'no',
+											} )
+										}
+										label={ __(
+											'Enable bidirectional order fulfillment sync',
+											'woocommerce-square'
+										) }
 									/>
 								</InputWrapper>
 

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -346,7 +346,7 @@ export const ConfigureSync = ( {
 										'woocommerce-square'
 									) }
 									description={ __(
-										'Enable bidirectional order fulfillment synchronization between WooCommerce and Square orders. This will sync fulfillment status changes from Square back to WooCommerce and include fulfillment data when creating new orders.',
+										'Enable bidirectional fulfillment synchronization between WooCommerce and Square orders. This will sync fulfillment status changes from Square back to WooCommerce and include fulfillment data when creating new orders.',
 										'woocommerce-square'
 									) }
 									indent={ indent }

--- a/src/new-user-experience/onboarding/data/reducers.js
+++ b/src/new-user-experience/onboarding/data/reducers.js
@@ -120,6 +120,7 @@ export const SQUARE_SETTINGS_DEFAULT_STATE = {
 	enable_customer_decline_messages: 'no',
 	debug_mode: 'off',
 	debug_logging_enabled: 'no',
+	enable_order_fulfillment_sync: 'no',
 };
 
 const squareSettingsReducer = (

--- a/src/new-user-experience/utils.js
+++ b/src/new-user-experience/utils.js
@@ -192,6 +192,9 @@ export const getSquareSettings = async () => {
 		debug_logging_enabled:
 			settings.debug_logging_enabled ||
 			SQUARE_SETTINGS_DEFAULT_STATE.debug_logging_enabled,
+		enable_order_fulfillment_sync:
+			settings.enable_order_fulfillment_sync ||
+			SQUARE_SETTINGS_DEFAULT_STATE.enable_order_fulfillment_sync,
 	};
 
 	return squareSettings;

--- a/tests/e2e/specs/d9.order-sync-fulfillment.spec.js
+++ b/tests/e2e/specs/d9.order-sync-fulfillment.spec.js
@@ -11,6 +11,19 @@ import {
 	gotoOrderEditPage,
 } from '../utils/helper';
 
+test.beforeEach(async ({ page }) => {
+	await page.goto('/wp-admin/admin.php?page=wc-settings&tab=square');
+
+	// Check only if already not enabled.
+	const isEnabled = await page.locator('[data-testid="order-fulfillment-sync-field"]').isChecked();
+	if (!isEnabled) {
+		await page.locator('[data-testid="order-fulfillment-sync-field"]').check();
+		await page.locator('[data-testid="square-settings-save-button"]').click();
+	}
+
+	await page.waitForTimeout(2000);
+});
+
 test.describe('Order Sync and Fulfillment Tests @sync', () => {
 
 	test('Should create order with fulfillment data and verify WooCommerce integration', async ({ page }) => {

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -44,6 +44,10 @@ if ( ! defined( 'WC_SQUARE_OPTION_ANY' ) ) {
 	define( 'WC_SQUARE_OPTION_ANY', 'Any' );
 }
 
+if ( ! defined( 'WC_SQUARE_SYNC_ORDERS_EVENT_HOOK' ) ) {
+	define( 'WC_SQUARE_SYNC_ORDERS_EVENT_HOOK', 'wc_square_sync_orders' );
+}
+
 /**
  * The plugin loader class.
  *


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR builds on the main bidirectional order sync implementation by introducing an opt-in setting that merchants can enable if desired (default: disabled).

- When enabled, WooCommerce orders will sync to Square with fulfillment data.
- Merchants will see the “Fulfillment” button in the Square Dashboard.
- Fulfilling an order in Square will sync back to WooCommerce and automatically update the Woo order status to Completed

<img width="1186" height="1032" alt="image" src="https://github.com/user-attachments/assets/54274381-6983-4e86-ac70-0bf069dd5341" />

Additionally, a direct link to the Square Order ID is added in Woo order notes.

<img width="1118" height="719" alt="image" src="https://github.com/user-attachments/assets/84c62886-b995-4b11-a960-0f1e0c91357b" />

Closes https://linear.app/a8c/issue/SQUARE-126/implement-two-way-order-sync.
Closes https://linear.app/a8c/issue/SQUARE-98/created-orders-do-not-appear-in-the-merchants-square-dashboard

### Steps to test the changes in this Pull Request:

1. Go to `WP Admin → WooCommerce → Settings → Square → Order Fulfillment Sync` and enable the setting.
2. Place an order in WooCommerce. Confirm it syncs to Square and is available for fulfillment.
3. Fulfill the order in the Square Dashboard.
4. Wait 15 minutes, or manually run the `wc_square_sync_orders` event from:
`/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending`
5. Confirm the WooCommerce order status is updated to `Completed`.
6. Disable the setting from Step 1.
7. Place another order in WooCommerce.
8. Confirm it syncs to Square, but there is no fulfillment option. The Square order status should still be Completed.
9. Confirm that no `wc_square_sync_orders` event exists under Pending Actions in Action Scheduler.
10. Edit the order in WooCommerce and confirm the order notes include a direct link to the Square Order ID.

### Changelog entry

> Add - Opt-in setting for bidirectional order sync
