### PR TITLE
Ensure sync isn’t interrupted in case of a category insert failure.

### DIFF
--- a/includes/Handlers/Category.php
+++ b/includes/Handlers/Category.php
@@ -177,6 +177,11 @@ class Category {
 
 			$inserted_term = wp_insert_term( $name, 'product_cat' );
 
+			if ( is_wp_error( $inserted_term ) ) {
+				wc_square()->log( 'Error inserting category: ' . $inserted_term->get_error_message() );
+				return null;
+			}
+
 			$category_id = isset( $inserted_term['term_id'] ) ? $inserted_term['term_id'] : null;
 		}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in [SQUARE-158](https://linear.app/a8c/issue/SQUARE-158/square-sync-failing-due-to-improper-wp-error-handling-and-php-timeouts), currently, when an issue occurs during category creation, the sync gets stuck and stops the process. This happens because the Square response includes deleted term data. Deleted term data does not contain category information, so category creation is attempted with a null name, causing the sync to fail.

This PR adds proper error handling to ensure the sync continues running without issues in such cases.

Closes https://linear.app/a8c/issue/SQUARE-158/square-sync-failing-due-to-improper-wp-error-handling-and-php-timeouts

### Steps to test the changes in this Pull Request:
1. Set up the Square plugin and enable sync with Square as the source of record (SOR).
2. In the Square dashboard, create a category and then delete it quickly.
3. In WP Admin, wait for the interval polling to trigger automatically, or manually trigger it from Scheduled Actions.
4. Verify that the sync is processed without any issues. (On `trunk`, it gets stuck while updating category data due to the error in category creation.)

### Changelog entry
> Fix - Ensure sync isn’t interrupted in case of a category insert failure.