### PR TITLE
Relocate Order Fulfillment Sync Opt-in Setting

### DIFF
--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -502,8 +502,9 @@ export const ConfigureSync = ( {
 								}
 								onChange={ ( value ) =>
 									setSquareSettingData( {
-										enable_order_fulfillment_sync:
-											value ? 'yes' : 'no',
+										enable_order_fulfillment_sync: value
+											? 'yes'
+											: 'no',
 									} )
 								}
 								label={ __(

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -342,36 +342,6 @@ export const ConfigureSync = ( {
 
 								<InputWrapper
 									label={ __(
-										'Order Fulfillment Sync',
-										'woocommerce-square'
-									) }
-									description={ __(
-										'Enable bidirectional fulfillment synchronization between WooCommerce and Square orders. This will sync fulfillment status changes from Square back to WooCommerce and include fulfillment data when creating new orders.',
-										'woocommerce-square'
-									) }
-									indent={ indent }
-								>
-									<SquareCheckboxControl
-										data-testid="order-fulfillment-sync-field"
-										checked={
-											enable_order_fulfillment_sync ===
-											'yes'
-										}
-										onChange={ ( value ) =>
-											setSquareSettingData( {
-												enable_order_fulfillment_sync:
-													value ? 'yes' : 'no',
-											} )
-										}
-										label={ __(
-											'Enable bidirectional order fulfillment sync',
-											'woocommerce-square'
-										) }
-									/>
-								</InputWrapper>
-
-								<InputWrapper
-									label={ __(
 										'Import Products',
 										'woocommerce-square'
 									) }
@@ -513,6 +483,35 @@ export const ConfigureSync = ( {
 								) }
 							</>
 						) }
+
+						<InputWrapper
+							label={ __(
+								'Order Fulfillment Sync',
+								'woocommerce-square'
+							) }
+							description={ __(
+								'Enable bidirectional fulfillment synchronization between WooCommerce and Square orders. This will sync fulfillment status changes from Square back to WooCommerce and include fulfillment data when creating new orders.',
+								'woocommerce-square'
+							) }
+							indent={ indent }
+						>
+							<SquareCheckboxControl
+								data-testid="order-fulfillment-sync-field"
+								checked={
+									enable_order_fulfillment_sync === 'yes'
+								}
+								onChange={ ( value ) =>
+									setSquareSettingData( {
+										enable_order_fulfillment_sync:
+											value ? 'yes' : 'no',
+									} )
+								}
+								label={ __(
+									'Enable bidirectional order fulfillment sync',
+									'woocommerce-square'
+								) }
+							/>
+						</InputWrapper>
 					</div>
 				</Section>
 			) }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR moves the Order Fulfillment Sync (Opt-in) setting out of the Sync SOR Setting to make it a standalone setting, regardless of the selected SOR.

Closes https://linear.app/a8c/issue/SQUARE-174/move-the-new-fulfillment-sync-opt-in-setting-out-of-the-inventory-sync.

### Woo SOR:
<img width="1312" height="1374" alt="image" src="https://github.com/user-attachments/assets/3dfb5ae3-c99e-4ae2-bec3-117ab049230b" />

### Square SOR:
<img width="1124" height="1406" alt="image" src="https://github.com/user-attachments/assets/33876cad-2588-4bcb-9c89-3d9054916808" />

### No SOR:
<img width="1372" height="784" alt="image" src="https://github.com/user-attachments/assets/e809607d-8a88-4f80-953a-76b5b6b85640" />


### Steps to test the changes in this Pull Request:

1. Go to WooCommerce → Settings → Square
2. Set "Sync Settings" to "Disabled"
3. Verify that the "Order Fulfillment Sync" setting is still visible and can be enabled
4. Enable the setting and save changes
5. Verify the setting persists after saving
6. Set SOR to "Square"
7. Repeat steps 3 to 5.
8. Set SOR to WooCommerce
9. Repeat steps 3 to 5.
10. Verify that order sync still works only when the Opt-in setting is enabled, and confirm it does not work when the setting is disabled.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Change - Relocate Order Fulfillment Sync Opt-in Setting