### PR TITLE
[A11y] Update `aria-label` to include a warning that Buy with GPay opens in a new window

### DIFF
--- a/includes/Gateway/Digital_Wallet.php
+++ b/includes/Gateway/Digital_Wallet.php
@@ -153,6 +153,7 @@ class Digital_Wallet {
 				'google_pay_color'         => $this->gateway->get_option( 'digital_wallets_google_pay_button_color', 'black' ),
 				'apple_pay_color'          => $this->gateway->get_option( 'digital_wallets_apple_pay_button_color', 'black' ),
 				'apple_pay_type'           => $this->gateway->get_option( 'digital_wallets_button_type', 'buy' ),
+				'buy_with_gpay_text'       => __( 'Buy with GPay', 'woocommerce-square' ),
 				'opens_in_new_window_text' => __( 'opens in a new window', 'woocommerce-square' ),
 			);
 		}

--- a/includes/Gateway/Digital_Wallet.php
+++ b/includes/Gateway/Digital_Wallet.php
@@ -153,6 +153,7 @@ class Digital_Wallet {
 				'google_pay_color'         => $this->gateway->get_option( 'digital_wallets_google_pay_button_color', 'black' ),
 				'apple_pay_color'          => $this->gateway->get_option( 'digital_wallets_apple_pay_button_color', 'black' ),
 				'apple_pay_type'           => $this->gateway->get_option( 'digital_wallets_button_type', 'buy' ),
+				'opens_in_new_window_text' => __( 'opens in a new window', 'woocommerce-square' ),
 			);
 		}
 

--- a/src/blocks/digital-wallets/hooks.js
+++ b/src/blocks/digital-wallets/hooks.js
@@ -141,15 +141,15 @@ export function useGooglePay( payments, paymentRequest ) {
 						const button =
 							googlePayRef.current.querySelector( 'button' );
 						if ( button ) {
+							const existingAriaLabel =
+								button.getAttribute( 'aria-label' ) || '';
 							const opensInNewWindowText = __(
 								'opens in a new window',
 								'woocommerce-square'
 							);
 							button.setAttribute(
 								'aria-label',
-								`${
-									button.getAttribute( 'aria-label' ) || ''
-								} (${ opensInNewWindowText })`
+								`${ existingAriaLabel } (${ opensInNewWindowText })`
 							);
 						}
 					} );

--- a/src/blocks/digital-wallets/hooks.js
+++ b/src/blocks/digital-wallets/hooks.js
@@ -142,7 +142,8 @@ export function useGooglePay( payments, paymentRequest ) {
 							googlePayRef.current.querySelector( 'button' );
 						if ( button ) {
 							const existingAriaLabel =
-								button.getAttribute( 'aria-label' ) || '';
+								button.getAttribute( 'aria-label' ) ||
+								__( 'Buy with GPay', 'woocommerce-square' );
 							const opensInNewWindowText = __(
 								'opens in a new window',
 								'woocommerce-square'

--- a/src/blocks/digital-wallets/hooks.js
+++ b/src/blocks/digital-wallets/hooks.js
@@ -8,6 +8,7 @@ import {
 	verifyBuyer,
 	buildVerificationDetails,
 } from './utils';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Initialises Square.
@@ -129,11 +130,29 @@ export function useGooglePay( payments, paymentRequest ) {
 		( async () => {
 			try {
 				const __googlePay = await payments.googlePay( paymentRequest );
-				await __googlePay.attach( googlePayRef.current, {
-					buttonColor: getSquareServerData().googlePayColor,
-					buttonSizeMode: 'fill',
-					buttonType: 'long',
-				} );
+				await __googlePay
+					.attach( googlePayRef.current, {
+						buttonColor: getSquareServerData().googlePayColor,
+						buttonSizeMode: 'fill',
+						buttonType: 'long',
+					} )
+					.then( () => {
+						// Append 'opens in a new window' to the aria-label of the Google Pay button.
+						const button =
+							googlePayRef.current.querySelector( 'button' );
+						if ( button ) {
+							const opensInNewWindowText = __(
+								'opens in a new window',
+								'woocommerce-square'
+							);
+							button.setAttribute(
+								'aria-label',
+								`${
+									button.getAttribute( 'aria-label' ) || ''
+								} (${ opensInNewWindowText })`
+							);
+						}
+					} );
 
 				setGooglePay( __googlePay );
 			} catch ( e ) {}

--- a/src/blocks/digital-wallets/hooks.js
+++ b/src/blocks/digital-wallets/hooks.js
@@ -8,7 +8,6 @@ import {
 	verifyBuyer,
 	buildVerificationDetails,
 } from './utils';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Initialises Square.
@@ -141,16 +140,14 @@ export function useGooglePay( payments, paymentRequest ) {
 						const button =
 							googlePayRef.current.querySelector( 'button' );
 						if ( button ) {
+							const opensInNewWindowText =
+								getSquareServerData().opensInNewWindowText;
 							const existingAriaLabel =
 								button.getAttribute( 'aria-label' ) ||
-								__( 'Buy with GPay', 'woocommerce-square' );
-							const opensInNewWindowText = __(
-								'opens in a new window',
-								'woocommerce-square'
-							);
+								getSquareServerData().buyWithGpayText;
 							button.setAttribute(
 								'aria-label',
-								`${ existingAriaLabel } (${ opensInNewWindowText })`
+								`${ existingAriaLabel }, ${ opensInNewWindowText }`
 							);
 						}
 					} );

--- a/src/blocks/square-utils/utils.js
+++ b/src/blocks/square-utils/utils.js
@@ -51,6 +51,8 @@ const getSquareServerData = () => {
 		shouldChargeOrderNonce: squareData.should_charge_order_nonce || '',
 		isChangePaymentMethod: squareData.is_change_payment_method || false,
 		orderId: squareData.order_id || '',
+		opensInNewWindowText: squareData.opens_in_new_window_text || '',
+		buyWithGpayText: squareData.buy_with_gpay_text || '',
 	};
 
 	return cachedSquareData;

--- a/src/js/frontend/wc-square-digital-wallet.js
+++ b/src/js/frontend/wc-square-digital-wallet.js
@@ -175,11 +175,26 @@ jQuery( document ).ready( ( $ ) => {
 				/**
 				 * Create a Google Pay button in the target element.
 				 */
-				this.googlePay.attach( '#wc-square-google-pay', {
-					buttonSizeMode: 'fill',
-					buttonType: 'long',
-					buttonColor: this.args.google_pay_color,
-				} );
+				this.googlePay
+					.attach( '#wc-square-google-pay', {
+						buttonSizeMode: 'fill',
+						buttonType: 'long',
+						buttonColor: this.args.google_pay_color,
+					} )
+					.then( () => {
+						// Append 'opens in a new window' to the aria-label of the Google Pay button.
+						const button = $(
+							'#wc-square-google-pay button'
+						).first();
+						if ( button.length > 0 ) {
+							button.attr(
+								'aria-label',
+								`${ button.attr( 'aria-label' ) || '' } (${
+									this.args.opens_in_new_window_text
+								})`
+							);
+						}
+					} );
 
 				/**
 				 * Click event handler for when the Google Pay button is clicked.

--- a/src/js/frontend/wc-square-digital-wallet.js
+++ b/src/js/frontend/wc-square-digital-wallet.js
@@ -188,7 +188,8 @@ jQuery( document ).ready( ( $ ) => {
 						).first();
 						if ( button.length > 0 ) {
 							const existingAriaLabel =
-								button.attr( 'aria-label' ) || '';
+								button.attr( 'aria-label' ) ||
+								this.args.buy_with_gpay_text;
 							button.attr(
 								'aria-label',
 								`${ existingAriaLabel } (${ this.args.opens_in_new_window_text })`

--- a/src/js/frontend/wc-square-digital-wallet.js
+++ b/src/js/frontend/wc-square-digital-wallet.js
@@ -187,11 +187,11 @@ jQuery( document ).ready( ( $ ) => {
 							'#wc-square-google-pay button'
 						).first();
 						if ( button.length > 0 ) {
+							const existingAriaLabel =
+								button.attr( 'aria-label' ) || '';
 							button.attr(
 								'aria-label',
-								`${ button.attr( 'aria-label' ) || '' } (${
-									this.args.opens_in_new_window_text
-								})`
+								`${ existingAriaLabel } (${ this.args.opens_in_new_window_text })`
 							);
 						}
 					} );

--- a/src/js/frontend/wc-square-digital-wallet.js
+++ b/src/js/frontend/wc-square-digital-wallet.js
@@ -192,7 +192,7 @@ jQuery( document ).ready( ( $ ) => {
 								this.args.buy_with_gpay_text;
 							button.attr(
 								'aria-label',
-								`${ existingAriaLabel } (${ this.args.opens_in_new_window_text })`
+								`${ existingAriaLabel }, ${ this.args.opens_in_new_window_text }`
 							);
 						}
 					} );


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in SQUARE-176, currently Buy with Gpay button opens new window without warning. This PR updates the `aria-label` attribute of the button to add a warning for "opens in a new window".

> [!NOTE]
> The approach followed in this PR might not be the best possible one, but the button markup is rendered by the Google Pay script. So, we don’t have any other way to fix this except by handling it this way, or alternatively, we could report the issue upstream and wait for it to be fixed and released there.

Closes https://linear.app/a8c/issue/SQUARE-176/accessibility-buttonlink-opens-new-window-or-tab-without-warning

### Steps to test the changes in this Pull Request:
1. Configure Square Digital wallets.
1. Go to any single product page 
1. Turn on the screen reader.
1. Focus on the "Buy with Gpay" button and Verify that it announces the Buy with GPay and the warning that the link opens in a new tab
1. Go to cart and checkout pages (Block and Classic both) and verify the same.

### Changelog entry
> Fix - Ensure users are warned that clicking “Buy with GPay” opens in a new window.
