### PR TITLE
Sync Only the Utilized Option Values

### DIFF
--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -661,7 +661,7 @@ class Product_Import extends Stepped_Job {
 			$options = $catalog_object->getItemData()->getItemOptions() ? $catalog_object->getItemData()->getItemOptions() : array();
 
 			if ( count( $options ) ) {
-				$data['attributes']                      = $this->extract_attributes_from_square_options( $options );
+				$data['attributes']                      = $this->extract_attributes_from_square_options( $options, $data['variations'] );
 				$data['custom_meta']['_dynamic_options'] = true;
 			} else {
 				$data['attributes']                      = $this->extract_attributes_from_square_variations( $data['variations'] );
@@ -807,13 +807,30 @@ class Product_Import extends Stepped_Job {
 	 *
 	 * @since 4.9.0
 	 *
-	 * @param array $data the product data
-	 * @return int
+	 * @param array $options    the Square options
+	 * @param array $variations the product variations to determine which option values are actually used
+	 * @return array
 	 * @throws \Exception
 	 */
-	protected function extract_attributes_from_square_options( $options ) {
+	protected function extract_attributes_from_square_options( $options, $variations = array() ) {
 
 		$data_attributes = array();
+
+		// Collect all option values that are actually used by variations.
+		$used_option_values = array();
+		foreach ( $variations as $variation ) {
+			if ( isset( $variation['attributes'] ) ) {
+				foreach ( $variation['attributes'] as $attribute ) {
+					if ( isset( $attribute['name'] ) && isset( $attribute['option'] ) ) {
+						$attribute_name = $attribute['name'];
+						if ( ! isset( $used_option_values[ $attribute_name ] ) ) {
+							$used_option_values[ $attribute_name ] = array();
+						}
+						$used_option_values[ $attribute_name ][] = $attribute['option'];
+					}
+				}
+			}
+		}
 
 		foreach ( $options as $option ) {
 			$option_id = $option->getItemOptionId();
@@ -845,12 +862,20 @@ class Product_Import extends Stepped_Job {
 				set_transient( 'wc_square_options_data', $options_data );
 			}
 
+			// Filter option values to only include those actually used by variations.
+			$clean_option_name = str_replace( 'pa_', '', $option_name );
+			$filtered_values   = $option_values;
+
+			if ( isset( $used_option_values[ $clean_option_name ] ) ) {
+				$filtered_values = array_intersect( $option_values, array_unique( $used_option_values[ $clean_option_name ] ) );
+			}
+
 			$data_attributes[] = array(
-				'name'      => str_replace( 'pa_', '', $option_name ),
+				'name'      => $clean_option_name,
 				'slug'      => str_replace( 'pa_', '', sanitize_title( $option_name ) ),
 				'visible'   => true,
 				'variation' => true,
-				'options'   => $option_values,
+				'options'   => $filtered_values,
 				'pa_prefix' => strpos( $option_name, 'pa_' ) !== false,
 			);
 		}

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -819,7 +819,7 @@ class Product_Import extends Stepped_Job {
 		// Collect all option values that are actually used by variations.
 		$used_option_values = array();
 		foreach ( $variations as $variation ) {
-			if ( isset( $variation['attributes'] ) ) {
+			if ( isset( $variation['attributes'] ) && is_array( $variation['attributes'] ) ) {
 				foreach ( $variation['attributes'] as $attribute ) {
 					if ( isset( $attribute['name'] ) && isset( $attribute['option'] ) ) {
 						$attribute_name = $attribute['name'];


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR fixes an issue where Square product imports were creating unnecessary attribute terms in WooCommerce. Previously, when importing products from Square, the plugin would import ALL possible option values from Square's Option Name, even if the specific product didn't use all of those values.

- Modified `extract_attributes_from_square_options()` method to accept variations data
- Added logic to collect only the option values actually used by the product's variations
- Filter attribute options to only include values that are genuinely used by the product

Closes https://linear.app/a8c/issue/SQUARE-159/general-product-options-being-synced-to-woo.

### Steps to test the changes in this Pull Request:

1. **Create Square Product with Partial Option Usage**:
   - In Square Dashboard, go to Items → Options and create an option called "Colour" with 6-7 terms (e.g., Navy, Grey, Green, Black, Red, Yellow, Pink)
   - Create a product in Square that uses this "Colour" option but only uses some of the terms (e.g., only Navy, Grey, Green)
   - Create variations for the product using only the selected terms

2. **Import Product to WooCommerce**:
   - In WooCommerce admin, go to WooCommerce → Settings → Square
   - Use "Import all Products from Square" functionality
   - Verify the imported product appears correctly

3. **Verify Attribute Terms**:
   - Edit the imported product in WooCommerce
   - Check the Attributes tab
   - Confirm that only the attribute terms actually used by the product variations are present (Navy, Grey, Green)
   - Verify that unused terms (Black, Red, Yellow, Pink) are NOT present in the attribute

### Changelog entry
> Fix - Sync only the utilized Option values.