### PR TITLE
[Accessibility] SQUARE-178: Set outline offset to prevent outline cut off for GPay button.

### DIFF
--- a/src/css/frontend/wc-square-digital-wallet.scss
+++ b/src/css/frontend/wc-square-digital-wallet.scss
@@ -32,6 +32,10 @@
     background-color: white;
 }
 
+#express-payment-method-square-credit-card #gpay-button-online-api-id.focus{
+    outline-offset: -2px;
+}
+
 /*
  * Google Pay Button Styles
  */


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in SQUARE-178, outline getting cut off when we focus on the Google pay button. PR fixes this issue by setting `outline-offset`.

| Before | After |
| --- | --- |
|<img width="862" height="286" alt="Screenshot 2025-09-05 at 4 51 43 PM" src="https://github.com/user-attachments/assets/abed7d33-4d4f-4fcc-9a33-a49fd017ffc4" />|<img width="862" height="286" alt="Screenshot 2025-09-05 at 4 46 03 PM" src="https://github.com/user-attachments/assets/0ad62a77-1c67-4ce1-bc99-8a17c45e3877" />|
|<img width="1025" height="218" alt="Screenshot 2025-09-05 at 5 04 05 PM" src="https://github.com/user-attachments/assets/2c766d6f-5a23-4c43-b6ca-e7399850a778" />|<img width="1025" height="218" alt="Screenshot 2025-09-05 at 5 02 54 PM" src="https://github.com/user-attachments/assets/71046e46-67f3-4091-95d6-2722b3ac6687" />|


Closes https://linear.app/a8c/issue/SQUARE-178/accessibility-focus-indicator-can-be-improved

### Steps to test the changes in this Pull Request:
1. Install and set up plugin and enable digital wallet payment methods. 
2. Add a product to the cart and visit the cart page (block-based cart).
3. Focus on the express payment button and notice that the outline is cut off and not fully visible.
4. Visit checkout page and make sure that outline is cut off and not fully visible while on focus.

### Changelog entry
<!-- 


Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Ensure the outline is properly visible when the Google Pay button is focused.
