### PR TITLE
Add Support for Multiple Categories Sync

### DIFF
--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -59,7 +59,8 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		$item_data->setName( $product->get_name() );
 		$item_data->setDescriptionHtml( $product->get_description() );
 
-		$square_category_id = 0;
+		$square_categories  = array();
+		$reporting_category = null;
 
 		foreach ( $product->get_category_ids() as $category_id ) {
 
@@ -67,18 +68,23 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 
 			if ( ! empty( $map['square_id'] ) ) {
 
-				$square_category_id = $map['square_id'];
-				break;
+				$square_category = new \Square\Models\CatalogObjectCategory();
+				$square_category->setId( $map['square_id'] );
+				$square_categories[] = $square_category;
+
+				if ( ! $reporting_category ) {
+					$reporting_category = $square_category;
+				}
 			}
 		}
 
-		// if a category with a Square ID was found
-		if ( $square_category_id ) {
-			$square_category = new \Square\Models\CatalogObjectCategory();
-			$square_category->setId( $square_category_id );
-			$item_data->setCategories( array( $square_category ) );
-			// Set the reporting category.
-			$item_data->setReportingCategory( $square_category );
+		// if categories with Square IDs were found
+		if ( ! empty( $square_categories ) ) {
+			$item_data->setCategories( $square_categories );
+
+			if ( $reporting_category ) {
+				$item_data->setReportingCategory( $reporting_category );
+			}
 		}
 
 		// Only use attributes that are used for variations.

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -558,8 +558,6 @@ class Product_Import extends Stepped_Job {
 			return null;
 		}
 
-		$square_category_id  = Category::get_square_category_id( $catalog_object->getItemData() );
-		$category_id         = Category::get_category_id_by_square_id( $square_category_id );
 		$product_name        = $catalog_object->getItemData()->getName();
 		$product_description = Product::get_catalog_item_description( $catalog_object->getItemData() );
 
@@ -600,13 +598,29 @@ class Product_Import extends Stepped_Job {
 			'sku'         => '', // make sure to reset SKU when simple product is updated to variable.
 			'description' => $product_description,
 			'image_id'    => Product::get_catalog_item_thumbnail_id( $catalog_object ),
-			'categories'  => array( $category_id ),
+			'categories'  => array(), // Will be populated below.
 			'square_meta' => array(
 				'item_id'      => $catalog_object->getId(),
 				'item_version' => $catalog_object->getVersion(),
 			),
 			'custom_meta' => array(),
 		);
+
+		// Process multiple categories from Square
+		$item_data  = $catalog_object->getItemData();
+		$categories = array();
+		if ( $item_data->getCategories() && is_array( $item_data->getCategories() ) ) {
+			foreach ( $item_data->getCategories() as $category ) {
+				if ( $category instanceof \Square\Models\CatalogObjectCategory ) {
+					// $category_id = Category::import_or_update( $category );
+					$category_id = Category::get_category_id_by_square_id( $category->getId() );
+					if ( $category_id ) {
+						$categories[] = $category_id;
+					}
+				}
+			}
+		}
+		$data['categories'] = array_unique( $categories );
 
 		// variable product
 		if ( 'variable' === $data['type'] ) {

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -612,9 +612,9 @@ class Product_Import extends Stepped_Job {
 			'custom_meta' => array(),
 		);
 
-		// Process multiple categories from Square
-		$item_data  = $catalog_object->getItemData();
-		$categories = array();
+		// Process multiple categories from Square.
+		$item_data            = $catalog_object->getItemData();
+		$categories           = array();
 		$missing_category_ids = array();
 
 		if ( $item_data->getCategories() && is_array( $item_data->getCategories() ) ) {

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -186,12 +186,18 @@ class Product_Import extends Stepped_Job {
 				continue;
 			}
 
-			// import or update categories related to the products that are being imported
-			$catalog_category_id = Category::get_square_category_id( $catalog_object->getItemData() );
-
-			if ( $catalog_category_id && isset( $categories[ $catalog_category_id ] ) ) {
-				Category::import_or_update( $categories[ $catalog_category_id ] );
-				unset( $categories[ $catalog_category_id ] ); // don't import/update the same category multiple times per batch
+			// Import or update categories related to the products that are being imported.
+			$item_data = $catalog_object->getItemData();
+			if ( $item_data->getCategories() && is_array( $item_data->getCategories() ) ) {
+				foreach ( $item_data->getCategories() as $category ) {
+					if ( $category instanceof \Square\Models\CatalogObjectCategory ) {
+						$catalog_category_id = $category->getId();
+						if ( $catalog_category_id && isset( $categories[ $catalog_category_id ] ) ) {
+							Category::import_or_update( $categories[ $catalog_category_id ] );
+							unset( $categories[ $catalog_category_id ] ); // don't import/update the same category multiple times per batch.
+						}
+					}
+				}
 			}
 
 			$data = $this->extract_product_data( $catalog_object, $product );
@@ -609,17 +615,41 @@ class Product_Import extends Stepped_Job {
 		// Process multiple categories from Square
 		$item_data  = $catalog_object->getItemData();
 		$categories = array();
+		$missing_category_ids = array();
+
 		if ( $item_data->getCategories() && is_array( $item_data->getCategories() ) ) {
 			foreach ( $item_data->getCategories() as $category ) {
 				if ( $category instanceof \Square\Models\CatalogObjectCategory ) {
-					// $category_id = Category::import_or_update( $category );
 					$category_id = Category::get_category_id_by_square_id( $category->getId() );
 					if ( $category_id ) {
 						$categories[] = $category_id;
+					} else {
+						$missing_category_ids[] = $category->getId();
 					}
 				}
 			}
 		}
+
+		// Fetch and import missing categories.
+		if ( ! empty( $missing_category_ids ) ) {
+			try {
+				$response = wc_square()->get_api()->batch_retrieve_catalog_objects( $missing_category_ids );
+				if ( $response->get_data() instanceof \Square\Models\BatchRetrieveCatalogObjectsResponse ) {
+					$missing_categories = $response->get_data()->getObjects();
+					if ( $missing_categories && is_array( $missing_categories ) ) {
+						foreach ( $missing_categories as $missing_category ) {
+							$imported_category_id = Category::import_or_update( $missing_category );
+							if ( $imported_category_id ) {
+								$categories[] = $imported_category_id;
+							}
+						}
+					}
+				}
+			} catch ( \Exception $e ) {
+				wc_square()->log( 'Error fetching missing categories for product ' . $product_name . ': ' . $e->getMessage() );
+			}
+		}
+
 		$data['categories'] = array_unique( $categories );
 
 		// variable product


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR implements support for multiple categories in WooCommerce-Square synchronization, addressing the limitation where only one category was being synced despite both Square and WooCommerce supporting multiple categories.

- **Woo_SOR.php**: Updated `update_catalog_item()` method to sync all mapped categories instead of just the first one
- **Product_Import.php**: Enhanced `extract_product_data()` method to import all categories from Square items

Closes https://linear.app/a8c/issue/SQUARE-110/syncs-only-one-category-overwriting-multiple-even-though-both-square.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. **Test WooCommerce → Square Sync:**
   - Sync the product from WooCommerce to Square
   - Verify in Square dashboard that the product has all assigned categories
   - Confirm the first category is set as the reporting category

2. **Test Square → WooCommerce Sync:**
   - Create/update a product in Square with multiple categories
   - Sync from Square to WooCommerce
   - Verify the WooCommerce product has all categories assigned correctly

3. **Test Edge Cases:**
   - Products with no categories (should sync without errors)
   - Existing single-category products (should continue working as before)

### Changelog entry

> Add - Support for multiple categories in WooCommerce-Square product synchronization.