### PR TITLE
Fix PDF Credit Note Generation Crash by `WC_Order` check

### DIFF
--- a/includes/Handlers/Order.php
+++ b/includes/Handlers/Order.php
@@ -978,6 +978,11 @@ class Order {
 	 * @return array
 	 */
 	public function filter_order_item_totals( $total_rows, $order ) {
+		// Ensure $order is an instance of WC_Order before calling get_payment_method().
+		if ( ! $order instanceof \WC_Order ) {
+			return $total_rows;
+		}
+
 		$charge_type = wc_square()->get_gateway( $order->get_payment_method() )->get_order_meta( $order, 'charge_type' );
 
 		if ( Payment_Gateway::CHARGE_TYPE_PARTIAL !== $charge_type ) {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes a critical issue where the Square plugin's `filter_order_item_totals` function causes fatal errors when generating PDF credit notes with third-party PDF invoice plugins.

The `filter_order_item_totals` function assumes the `$order` parameter is always a `WC_Order` object and calls `$order->get_payment_method()` without validation. However, when generating credit notes, PDF plugins pass a `WC_Order_Refund` object, which doesn't have the `get_payment_method()` method, causing a fatal error.

Closes https://linear.app/a8c/issue/SQUARE-180/square-plugin-crashes-pdf-credit-note-generation-for-3pd-plugin.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

I wasn’t able to reproduce the issue myself, but the fix is straightforward and non-harmful. Here are the steps that may help reproduce the issue and confirm the fix.

1. **Setup Test Environment:**
   - Active WooCommerce Square plugin
   - Install a third-party PDF plugin (e.g., PDF Invoices & Packing Slips for WooCommerce)
   - Create a test order with Square payment method

2. **Test Regular PDF Generation:**
   - Generate a PDF invoice for the test order
   - Verify the PDF generates successfully

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent fatal error when generating PDF credit notes with third-party PDF plugins by adding type check for `WC_Order` objects in `filter_order_item_totals` function.
