### PR TITLE
Update the 4.9.1 changelog to mention the removal of a filter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -60,6 +60,7 @@
 
 = 4.9.1 - 2025-05-05 =
 * Add - Set the onboarding URL for the "Complete setup" button on the new payment settings page.
+* Change - Remove the `wc_square_update_product_set_variation_name` filter.
 * Fix - Issue with Product Price override update logic.
 * Fix - Show detailed error messages on Checkout Page based on Debug Mode settings.
 * Fix - Ensure that debug logs for payment gateways are being generated as expected.

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 4.9.1 - 2025-05-05 =
 * Add - Set the onboarding URL for the "Complete setup" button on the new payment settings page.
+* Change - Remove the `wc_square_update_product_set_variation_name` filter.
 * Fix - Issue with Product Price override update logic.
 * Fix - Show detailed error messages on Checkout Page based on Debug Mode settings.
 * Fix - Ensure that debug logs for payment gateways are being generated as expected.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It was brought to our attention that the changelog for the 3.3.0 release mentions the addition of a filter, `wc_square_update_product_set_variation_name`, but that filter couldn't be found anywhere in the codebase.

In doing some research, found that the filter was removed in #329 (though unclear on exactly why) and that PR went out in the 4.9.1 release. We should have mentioned the removal of that filter in the changelog for that release so opening this PR to add that changelog entry in.

Closes https://linear.app/a8c/issue/SQUARE-189/changelog-entry-references-non-existent-filter-wc-square-update

### Steps to test the changes in this Pull Request:

Verify the changelog entries look good

### Changelog entry

n/a
