### PR TITLE
fix/SQUARE-190: Fix missing attribute names after Product Import

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -627,7 +627,7 @@ class API extends Base {
 		$objects = $response->get_data()->getObjects() ? $response->get_data()->getObjects() : array();
 
 		foreach ( $objects as $object ) {
-			$options_data[ $object->getId() ]['name'] = $object->getItemOptionData()->getDisplayName();
+			$options_data[ $object->getId() ]['name'] = $object->getItemOptionData()->getName();
 
 			$option_values_object = $object->getItemOptionData()->getValues();
 			$option_values        = array();

--- a/includes/API.php
+++ b/includes/API.php
@@ -26,6 +26,7 @@ namespace WooCommerce\Square;
 use WooCommerce\Square\Framework\Api\Base;
 use WooCommerce\Square\API\Requests;
 use WooCommerce\Square\API\Responses;
+use Square\Models\CatalogObject;
 use Square\Models\ListCatalogResponse;
 use Square\SquareClient;
 use Square\Environment;
@@ -610,7 +611,13 @@ class API extends Base {
 
 		// Stop if transient exists and we don't want to refresh.
 		if ( $options_data && ! $refresh ) {
-			return array( '', $options_data, $cursor );
+			if ( $this->options_transient_needs_refresh( $options_data ) ) {
+				$refresh      = true;
+				$options_data = array();
+				delete_transient( 'wc_square_options_data' );
+			} else {
+				return array( '', $options_data, $cursor );
+			}
 		}
 
 		// If transient doesn't exist, initialize the array.
@@ -627,7 +634,8 @@ class API extends Base {
 		$objects = $response->get_data()->getObjects() ? $response->get_data()->getObjects() : array();
 
 		foreach ( $objects as $object ) {
-			$options_data[ $object->getId() ]['name'] = $object->getItemOptionData()->getName();
+			$option_name                              = $this->get_item_option_name_from_catalog_object( $object );
+			$options_data[ $object->getId() ]['name'] = $option_name;
 
 			$option_values_object = $object->getItemOptionData()->getValues();
 			$option_values        = array();
@@ -643,7 +651,7 @@ class API extends Base {
 
 		$cursor = $response->get_data()->getCursor();
 		if ( ! $cursor ) {
-			set_transient( 'wc_square_options_data', $options_data );
+			set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
 		}
 
 		return array( $response, $options_data, $cursor );
@@ -749,6 +757,61 @@ class API extends Base {
 		}
 
 		return $option;
+	}
+
+	/**
+	 * Determines the best available name for a catalog option.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Square\Models\CatalogObject $catalog_object Catalog option object.
+	 * @return string
+	 */
+	public function get_item_option_name_from_catalog_object( ?CatalogObject $catalog_object ) {
+
+		if ( ! $catalog_object instanceof CatalogObject || ! $catalog_object->getItemOptionData() ) {
+			return '';
+		}
+
+		$option_data = $catalog_object->getItemOptionData();
+		$name        = $option_data->getName();
+		$name        = is_string( $name ) ? trim( $name ) : '';
+
+		if ( '' === $name && method_exists( $option_data, 'getDisplayName' ) ) {
+			$display_name = $option_data->getDisplayName();
+			$name         = is_string( $display_name ) ? trim( $display_name ) : '';
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Checks if the cached options data is missing names and needs refreshing.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $options_data Cached options data.
+	 * @return bool
+	 */
+	private function options_transient_needs_refresh( $options_data ) {
+
+		if ( ! is_array( $options_data ) ) {
+			return true;
+		}
+
+		foreach ( $options_data as $option_data ) {
+			$name = '';
+
+			if ( is_array( $option_data ) && isset( $option_data['name'] ) ) {
+				$name = is_string( $option_data['name'] ) ? trim( $option_data['name'] ) : '';
+			}
+
+			if ( '' === $name ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -782,10 +782,11 @@ class Product_Import extends Stepped_Job {
 				$option_matched = $options_data[ $option_id ]['value_ids'][ $option_value_id ];
 			} else {
 				// Fetch option data from Square.
-				$response    = wc_square()->get_api()->retrieve_catalog_object( $option_id );
-				$option_name = $response->get_data()->getObject()->getItemOptionData()->getName();
+				$response      = wc_square()->get_api()->retrieve_catalog_object( $option_id );
+				$option_object = $response->get_data()->getObject();
+				$option_name   = wc_square()->get_api()->get_item_option_name_from_catalog_object( $option_object );
 
-				$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
+				$option_values_object = $option_object && $option_object->getItemOptionData() ? $option_object->getItemOptionData()->getValues() : array();
 				$option_matched       = '';
 				$option_values        = array();
 				$option_value_ids     = array();
@@ -807,7 +808,7 @@ class Product_Import extends Stepped_Job {
 					'value_ids' => $option_value_ids,
 				);
 
-				set_transient( 'wc_square_options_data', $options_data );
+				set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
 			}
 
 			$attributes[] = array(
@@ -888,8 +889,9 @@ class Product_Import extends Stepped_Job {
 			} else {
 				// Fetch option name from Square.
 				$response             = wc_square()->get_api()->retrieve_catalog_object( $option_id );
-				$option_name          = $response->get_data()->getObject()->getItemOptionData()->getName();
-				$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
+				$option_object        = $response->get_data()->getObject();
+				$option_name          = wc_square()->get_api()->get_item_option_name_from_catalog_object( $option_object );
+				$option_values_object = $option_object && $option_object->getItemOptionData() ? $option_object->getItemOptionData()->getValues() : array();
 				$option_value_ids     = array();
 				$option_values        = array();
 
@@ -903,7 +905,7 @@ class Product_Import extends Stepped_Job {
 					'values'    => $option_values,
 					'value_ids' => array_combine( $option_value_ids, $option_values ),
 				);
-				set_transient( 'wc_square_options_data', $options_data );
+				set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
 			}
 
 			// Filter option values to only include those actually used by variations.

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -783,7 +783,7 @@ class Product_Import extends Stepped_Job {
 			} else {
 				// Fetch option data from Square.
 				$response    = wc_square()->get_api()->retrieve_catalog_object( $option_id );
-				$option_name = $response->get_data()->getObject()->getItemOptionData()->getDisplayName();
+				$option_name = $response->get_data()->getObject()->getItemOptionData()->getName();
 
 				$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
 				$option_matched       = '';
@@ -888,7 +888,7 @@ class Product_Import extends Stepped_Job {
 			} else {
 				// Fetch option name from Square.
 				$response             = wc_square()->get_api()->retrieve_catalog_object( $option_id );
-				$option_name          = $response->get_data()->getObject()->getItemOptionData()->getDisplayName();
+				$option_name          = $response->get_data()->getObject()->getItemOptionData()->getName();
 				$option_values_object = $response->get_data()->getObject()->getItemOptionData()->getValues();
 				$option_value_ids     = array();
 				$option_values        = array();


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

**Note: This bug is only reproducible in production**

In `trunk`, option metadata from Square was cached in the `wc_square_options_data` transient. Some Square responses lacked `item_option_data.name` when we first fetched them, so those transient entries stored an empty string for name. Because `retrieve_options_data()` short-circuited whenever the transient existed, later imports kept reusing those incomplete records and never refreshed them. As a result, WooCommerce products imported with attribute values but without attribute labels.

The fix updates `retrieve_options_data()` so that it treats any cached option missing a name as stale. When it finds an entry like that, it deletes the transient, pulls fresh option data from Square, and rebuilds the cache using `get_item_option_name_from_catalog_object()`, which falls back to display_name if the primary name is empty. Whenever the importer refreshes these option details, it now stores the result with a TTL, ensuring subsequent imports reuse complete labels instead of blanks.



Closes https://linear.app/a8c/issue/SQUARE-190/square-exportimport-process-loses-attribute-names

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

Please follow the instructions from the Linear ticket.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Missing attribute names after Product Import.
