### PR TITLE
Add the new deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,78 @@
+name: Deploy Product
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 1.3.7)'
+        required: true
+        type: string
+      deploy_wordpress:
+        description: 'Deploy to WordPress.org'
+        required: false
+        default: true
+        type: boolean
+      deploy_github:
+        description: 'Deploy to GitHub'
+        required: false
+        default: true
+        type: boolean
+      simulate:
+        description: 'Dry run mode'
+        required: false
+        default: true
+        type: boolean
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to deploy (e.g., 1.3.7)'
+        required: true
+        type: string
+      deploy_wordpress:
+        description: 'Deploy to WordPress.org'
+        required: false
+        default: true
+        type: boolean
+      deploy_github:
+        description: 'Deploy to GitHub'
+        required: false
+        default: true
+        type: boolean
+      simulate:
+        description: 'Dry run mode'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the private action repository
+      - name: Checkout woo-product-deploy action
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: woocommerce/woo-product-deploy
+          ref: trunk
+          path: ./.github/actions/woo-product-deploy
+          token: ${{ secrets.ORG_DEPLOY_SECRET }}  # Need PAT with access to the action repository
+
+      # Use the action we checked out
+      - name: Deploy Product
+        uses: ./.github/actions/woo-product-deploy
+        with:
+          repo_url: https://github.com/woocommerce/woocommerce-square
+          branch: trunk
+          version: ${{ github.event.inputs.version }}
+          node_version: '20'
+          npm_version: '10'
+          simulate: ${{ github.event.inputs.simulate }}
+          wporg_release: ${{ github.event.inputs.deploy_wordpress }}
+          github_release: ${{ github.event.inputs.deploy_github }}
+          deploy_pat: ${{ secrets.ORG_DEPLOY_SECRET }}
+          wporg_username: ${{ secrets.WPORG_USERNAME }}
+          wporg_password: ${{ secrets.WPORG_PASSWORD }}
+          partner_user: ${{ secrets.ORG_PARTNER_USER }}
+          partner_secret: ${{ secrets.ORG_PARTNER_SECRET }}
+          wccom_product_id: 1770503


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds in the new deploy GitHub Action workflow, which will be used going forward to publish releases to WordPress.org and GitHub.

> [!NOTE] 
> We will need two secrets set on this repo: `WPORG_USERNAME` and `WPORG_PASSWORD` in order for the deployment to WordPress.org to work

Closes https://linear.app/a8c/issue/SQUARE-200/tracking-issue-for-pr-419-add-the-new-deploy-workflow
Closes #420 

### Steps to test the changes in this Pull Request:

Verify the workflow file looks accurate. No way to test until this is merged in and we are ready to do a new release.

### Changelog entry

> Dev - Add new deploy workflow.
