### PR TITLE
Improved sync settings language for better clarity

### DIFF
--- a/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
+++ b/includes/Admin/Rest/WC_REST_Square_Settings_Controller.php
@@ -112,7 +112,7 @@ class WC_REST_Square_Settings_Controller extends WC_Square_REST_Base_Controller 
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 					'system_of_record'                 => array(
-						'description'       => __( 'Choose where data will be updated for synced products.', 'woocommerce-square' ),
+						'description'       => __( 'Choose the origin for updates to synced products.', 'woocommerce-square' ),
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					),

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -139,7 +139,7 @@ export const ConfigureSync = ( {
 								sprintf(
 									/* translators: %1$s and %2$s are placeholders for the link to the documentation, %3$s and %4$s are placeholders for the link to the support forum */
 									__(
-										"Choose where data will be updated for synced products. Inventory in Square is always checked for adjustments when sync is enabled. %1$sLearn more%2$s about choosing a system of record or %3$screate a ticket%4$s if you're experiencing technical issues.",
+										"Choose the origin for updates to synced products. Inventory in Square is always checked for adjustments when sync is enabled. %1$sLearn more%2$s about choosing a system of record or %3$screate a ticket%4$s if you're experiencing technical issues.",
 										'woocommerce-square'
 									),
 									'<a href="https://woocommerce.com/document/woocommerce-square/#section-8" target="_blank">',


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

| Before | After |
|---------|---------|
| <img width="864" height="479" alt="Screenshot 2025-11-12 at 5 56 40 PM" src="https://github.com/user-attachments/assets/52b14fa2-5f25-4897-ba0e-a7095346fa0d" /> | <img width="844" height="473" alt="Screenshot 2025-11-12 at 5 56 27 PM" src="https://github.com/user-attachments/assets/e4d46ca5-68a2-4d43-8049-24bc4bf25e78" /> |

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This fix changes the language in a description for the Square settings page for better understanding.

Closes #267.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Check out to this branch: `fix/267`
2. `npm run build`
3. Head to `/wp-admin/admin.php?page=wc-settings&tab=square`
4. Notice/verify the change in language.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Improve sync settings language for better clarity.
