### PR TITLE
Ensure gateway title displayed.

### DIFF
--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -146,6 +146,32 @@ class Gateway extends Payment_Gateway_Direct {
 	}
 
 	/**
+	 * Get the payment method title or show default if not set.
+	 *
+	 * @since x.x.x
+	 * @return string payment method title to show on checkout
+	 */
+	public function get_title() {
+		if ( $this->title ) {
+			return $this->title;
+		}
+		return esc_html__( 'Credit Card', 'woocommerce-square' );
+	}
+
+	/**
+	 * Get the payment method description or show default if not set.
+	 *
+	 * @since x.x.x
+	 * @return string payment method description to show on checkout
+	 */
+	public function get_description() {
+		if ( $this->description ) {
+			return $this->description;
+		}
+		return esc_html__( 'Pay securely using your credit card.', 'woocommerce-square' );
+	}
+
+	/**
 	 * Ajax callback to return payment token by token ID.
 	 *
 	 * @since 4.2.0

--- a/includes/Gateway/Blocks_Handler.php
+++ b/includes/Gateway/Blocks_Handler.php
@@ -117,7 +117,7 @@ class Blocks_Handler extends AbstractPaymentMethodType {
 	public function get_payment_method_data() {
 		return empty( $this->get_gateway() ) ? array() : array_merge(
 			array(
-				'title'                      => $this->get_setting( 'title' ),
+				'title'                      => $this->get_title(),
 				'application_id'             => $this->get_gateway()->get_application_id(),
 				'location_id'                => $this->plugin->get_settings_handler()->get_location_id(),
 				'is_sandbox'                 => $this->plugin->get_settings_handler()->is_sandbox(),

--- a/includes/Gateway/Cash_App_Pay_Blocks_Handler.php
+++ b/includes/Gateway/Cash_App_Pay_Blocks_Handler.php
@@ -149,7 +149,7 @@ class Cash_App_Pay_Blocks_Handler extends AbstractPaymentMethodType {
 	 */
 	private function get_description() {
 		$description = $this->get_setting( 'description', null );
-		return null !== $description ? $description : esc_html__( 'Pay securely using Cash App Pay.', 'woocommerce-square' );
+		return null === $description ? esc_html__( 'Pay securely using Cash App Pay.', 'woocommerce-square' ) : $description;
 	}
 
 	/**

--- a/includes/Gateway/Cash_App_Pay_Blocks_Handler.php
+++ b/includes/Gateway/Cash_App_Pay_Blocks_Handler.php
@@ -106,8 +106,8 @@ class Cash_App_Pay_Blocks_Handler extends AbstractPaymentMethodType {
 			return array();
 		}
 		return array(
-			'title'                      => $this->get_setting( 'title' ),
-			'description'                => $this->get_setting( 'description' ),
+			'title'                      => $this->get_title(),
+			'description'                => $this->get_description(),
 			'application_id'             => $this->get_gateway()->get_application_id(),
 			'location_id'                => $this->plugin->get_settings_handler()->get_location_id(),
 			'is_sandbox'                 => $this->plugin->get_settings_handler()->is_sandbox(),
@@ -127,6 +127,28 @@ class Cash_App_Pay_Blocks_Handler extends AbstractPaymentMethodType {
 			'is_continuation'            => $this->get_gateway()->is_cash_app_pay_continuation(),
 			'reference_id'               => WC()->cart ? WC()->cart->get_cart_hash() : '',
 		);
+	}
+
+	/**
+	 * Helper function to get title of Square Cash App gateway to be displayed as Label on checkout block.
+	 * Defaults to "Cash App Pay"
+	 *
+	 * @since x.x.x
+	 * @return string
+	 */
+	private function get_title() {
+		return ! empty( $this->get_setting( 'title' ) ) ? $this->get_setting( 'title' ) : esc_html__( 'Cash App Pay', 'woocommerce-square' );
+	}
+
+	/**
+	 * Helper function to get description of Square Cash App gateway to be displayed on checkout block.
+	 * Defaults to "Cash App Pay"
+	 *
+	 * @since x.x.x
+	 * @return string
+	 */
+	private function get_description() {
+		return ! empty( $this->get_setting( 'description' ) ) ? $this->get_setting( 'description' ) : esc_html__( 'Pay securely using Cash App Pay.', 'woocommerce-square' );
 	}
 
 	/**

--- a/includes/Gateway/Cash_App_Pay_Blocks_Handler.php
+++ b/includes/Gateway/Cash_App_Pay_Blocks_Handler.php
@@ -142,13 +142,14 @@ class Cash_App_Pay_Blocks_Handler extends AbstractPaymentMethodType {
 
 	/**
 	 * Helper function to get description of Square Cash App gateway to be displayed on checkout block.
-	 * Defaults to "Cash App Pay"
+	 * Defaults to "Pay securely using Cash App Pay."
 	 *
 	 * @since x.x.x
 	 * @return string
 	 */
 	private function get_description() {
-		return ! empty( $this->get_setting( 'description' ) ) ? $this->get_setting( 'description' ) : esc_html__( 'Pay securely using Cash App Pay.', 'woocommerce-square' );
+		$description = $this->get_setting( 'description', null );
+		return null !== $description ? $description : esc_html__( 'Pay securely using Cash App Pay.', 'woocommerce-square' );
 	}
 
 	/**

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -239,7 +239,7 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 	 * Get the default payment method title, which is configurable within the
 	 * admin and displayed on checkout
 	 *
-	 * @since x.x.x
+	 * @since 4.5.0
 	 * @return string payment method title to show on checkout
 	 */
 	protected function get_default_title() {

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -239,13 +239,26 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 	 * Get the default payment method title, which is configurable within the
 	 * admin and displayed on checkout
 	 *
-	 * @since 4.5.0
+	 * @since x.x.x
 	 * @return string payment method title to show on checkout
 	 */
 	protected function get_default_title() {
 		return esc_html__( 'Cash App Pay', 'woocommerce-square' );
 	}
 
+	/**
+	 * Get the default payment method title, which is configurable within the
+	 * admin and displayed on checkout
+	 *
+	 * @since x.x.x
+	 * @return string payment method title to show on checkout
+	 */
+	public function get_title() {
+		if ( $this->title ) {
+			return $this->title;
+		}
+		return $this->get_default_title();
+	}
 
 	/**
 	 * Get the default payment method description, which is configurable

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -62,6 +62,19 @@ class Gift_Card extends Payment_Gateway {
 	}
 
 	/**
+	 * Get the payment method title or show default if not set.
+	 *
+	 * @since x.x.x
+	 * @return string payment method title to show on checkout
+	 */
+	public function get_title() {
+		if ( $this->title ) {
+			return $this->title;
+		}
+		return esc_html__( 'Square Gift Card', 'woocommerce-square' );
+	}
+
+	/**
 	 * Returns true if the gateway is properly configured to perform transactions
 	 *
 	 * @since 4.7.0


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Ensures the default gateway titles are displayed if not set in the options.

This fixes an issue in which check-out pages does not show any text for the payment method when the settings page for the gateway has not been visited by the merchant. This can happen if they click the enable button on WooCommerce > Settings > Payments page without clicking the manage button.

| Bug on Shortcode checkout | Bug on Block checkout |
| --- | --- |
| <img width="1014" height="386" alt="Screenshot 2025-07-30 at 2 07 41 pm" src="https://github.com/user-attachments/assets/de1f503a-b962-4c75-8cfe-3bfd0b13c298" /> | <img width="843" height="179" alt="Screenshot 2025-07-30 at 2 06 00 pm" src="https://github.com/user-attachments/assets/7f8745b8-a947-419d-9dc8-dbac983467e7" /> |

Closes https://linear.app/a8c/issue/SQUARE-150/checkout-title-does-not-display-prior-to-managing-and-saving-payment

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. In the database delete the options `woocommerce_square_cash_app_pay_settings` and `woocommerce_square_credit_card_settings`.
2. Log in to the dashboard and visit the WooCommerce > Settings > Payments page
3. Click the enable button for Square, **do not click** the manage button.
4. Click the enable button for Cash App Pay (Square), **do not click** the manage button.
5. Repeat the following steps for both the block and shortcode checkouts:
   1. Add a product to the cart
   2. Proceed to checkout
   3. Ensure the default titles for each payment methods is displayed

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Ensure default titles are displayed for payment methods if not set by the merchant.
