### PR TITLE
Bump WooCommerce "tested up to" version 10.4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ jobs:
     if: "${{ ( github.event_name == 'pull_request' ) ||  github.event_name == 'push' }}"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         type: [ '@general', '@cashapp', '@sync', '@giftcard' ]
     env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ jobs:
       SQUARE_APPLICATION_ID: ${{ secrets.SQUARE_APPLICATION_ID }}
       SQUARE_ACCESS_TOKEN: ${{ secrets.SQUARE_ACCESS_TOKEN }}
       SQUARE_LOCATION_ID: ${{ secrets.SQUARE_LOCATION_ID }}
-      GH_TOKEN: ${{ secrets.BOT_GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.ORG_DOWNLOADS }}
     permissions:
       pull-requests: write
     name: E2E tests (${{ matrix.type }})

--- a/tests/e2e/specs/b6.gift-card-partial-refund.spec.js
+++ b/tests/e2e/specs/b6.gift-card-partial-refund.spec.js
@@ -68,5 +68,4 @@ test( 'Partial Refund – Gift card order @giftcard', async ( { page } ) => {
 
 	await doSquareRefund( page, '0.45' );
 	await expect( await page.getByText( 'Square Refund in the amount of $0.45 approved' ) ).toBeVisible();
-	await expect( await page.getByText( 'Order status changed from Pending payment to Processing.' ) ).toBeVisible();
 } );

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -707,7 +707,6 @@ export async function completePreOrder(page, orderId) {
 		.check();
 	await page.locator('#bulk-action-selector-top').selectOption('complete');
 	await page.locator('#doaction').click();
-	await page.locator('#confirm-complete-btn').click();
 }
 
 /**

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -22,8 +22,8 @@
  * @copyright Copyright (c) 2019, Automattic, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
  *
- * WC requires at least: 10.1
- * WC tested up to: 10.3
+ * WC requires at least: 10.2
+ * WC tested up to: 10.4
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -63,7 +63,7 @@ class WooCommerce_Square_Loader {
 	const MINIMUM_WP_VERSION = '6.7';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '10.1';
+	const MINIMUM_WC_VERSION = '10.2';
 
 	/**
 	 * SkyVerge plugin framework version used by this plugin


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://linear.app/a8c/issue/SQUARE-213/compatibility-testing-with-woo-104-beta

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR
2. All tests should be passed.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 10.4.
> Dev - Bump WooCommerce minimum supported version to 10.2.