### PR TITLE
Ensure that the order is not marked as 'On Hold' when saving the card fails after a successful payment.

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -2094,8 +2094,18 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 				$order = $this->get_payment_tokens_handler()->create_token( $order, $response );
 			} catch ( \Exception $e ) {
 
-				// handle the case of a "tokenize-after-sale" request failing by marking the order as on-hold with an explanatory note
-				if ( ! $response->transaction_held() && ! ( $this->supports( self::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->perform_credit_card_authorization( $order ) ) ) {
+				/*
+				 * Handle the request failing by marking the order as on-hold with an explanatory note
+				 *
+				 * Exclude the tokenize_after_sale() case, to avoid marking the order as on-hold when tokenization is done after sale.
+				 * This is for handling the edge case where Square successfully charge for the order, but failed to tokenize/save the same card.
+				 * @see https://linear.app/a8c/issue/SQUARE-208/store-then-charge-cards
+				 */
+				if (
+					! $response->transaction_held() &&
+					! ( $this->supports( self::FEATURE_CREDIT_CARD_AUTHORIZATION ) && $this->perform_credit_card_authorization( $order ) ) &&
+					! $this->tokenize_after_sale()
+				) {
 
 					// transaction has already been successful, but we've encountered an issue with the post-tokenization, add an order note to that effect and continue on
 					$message = sprintf(

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -2098,7 +2098,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 				 * Handle the request failing by marking the order as on-hold with an explanatory note
 				 *
 				 * Exclude the tokenize_after_sale() case, to avoid marking the order as on-hold when tokenization is done after sale.
-				 * This is for handling the edge case where Square successfully charge for the order, but failed to tokenize/save the same card.
+				 * This is for handling the edge case where Square successfully charged for the order, but failed to tokenize/save the same card.
 				 * @see https://linear.app/a8c/issue/SQUARE-208/store-then-charge-cards
 				 */
 				if (


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR introduces changes to prevent the order from being marked as **"On Hold"** when the order amount is successfully charged but card tokenization fails on Square’s side. This situation occurs when a customer completes checkout with the **"Save payment method"** option selected.
Currently, the plugin marks the order as **"On Hold"** to draw the merchant’s attention to the card tokenization failure. This PR updates that behavior by skipping the order status update and instead only adding an order note to report the tokenization failure.

> [!NOTE]
> For subscriptions, if card saving/tokenization fails, future renewal payments will fail because the card details are not stored. The customer will need to add or update the payment method for the subscription at that time.

Closes https://linear.app/a8c/issue/SQUARE-208/store-then-charge-cards

### Steps to test the changes in this Pull Request:
This issue cannot be reproduced directly and must be simulated based on the steps provided below:

1. Add a product to the cart.
2. Manually apply the plugin changes as [suggested](https://linear.app/a8c/issue/SQUARE-208/store-then-charge-cards#comment-6ee9297a).
3. Place an order using a Square credit card and select the **"Save payment method"** option while entering card details.
4. Verify that:
    - An order note is added for the failed card data save attempt.
    - The order remains in **Processing** status.

### Changelog entry
> Fix - Ensure that the order is not marked as 'On Hold' when saving the card fails after a successful payment.
