### PR TITLE
Do not force image replacement during product updates.

### DIFF
--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -482,7 +482,7 @@ class Product_Import extends Stepped_Job {
 			$this->save_product_meta( $product_id, $data );
 
 			// save the image, if included
-			Product::update_image_from_square( $product_id, $data['image_id'], true );
+			Product::update_image_from_square( $product_id, $data['image_id'], false );
 
 			// save/update variations
 			if ( isset( $data['type'], $data['variations'] ) && 'variable' === $data['type'] && is_array( $data['variations'] ) ) {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Turns off forced image updates in the `update_product()` method in order to respect the setting `Enable to override Product images from Square`.

When this setting is turned off, updates to images in Square should not replace the images in WooCommerce. 

Closes https://linear.app/a8c/issue/SQUARE-202/image-override-setting-is-ignored

### Steps to test the changes in this Pull Request:

1. Go to the WooCommerce Square Settings screen
2. Ensure the option `Enable to override Product images from Square` is turned off (unchecked)
3. Create a product in the Square dashboard, https://app.squareupsandbox.com/dashboard/items/library
4. Ensure the product has an image defined
5. Fill out other product settings however you desire
6. Publish the product
7. Return to the WooCommerce Square Settings screen
8. Click the "Import all products from square" button 
9. Click "import products" in the dialog box
10. Wait for the syncing to complete, the product should appear in the WooCommerce Dashboard > Products section
11. Ensure the image was imported from Square
12. Return to the Square dashboard
13. Edit the product created earlier
14. Upload a new image
15. Delete the primary image uploaded earlier, the new image will become the primary image
16. Save the product
17. Return to the WooCommerce Square Settings screen
18. Click the "import all products from square button"
19. Check "Update existing products during import" in the dialog box
20. Click the "import products" button in the dialog box
21. Wait for the syncing to complete
22. Return to the product in the WooCommerce Dashboard
23. Ensure the image has not been replaced with the new image uploaded in Square


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent images being updated from square when the "Enable to override Product images from Square" setting is turned off.
