### PR TITLE
Update apimatic/unirest-php package to 4.0.7.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -159,16 +159,16 @@
         },
         {
             "name": "apimatic/unirest-php",
-            "version": "4.0.5",
+            "version": "4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apimatic/unirest-php.git",
-                "reference": "e16754010c16be5473289470f129d87a0f41b55e"
+                "reference": "bdfd5f27c105772682c88ed671683f1bd93f4a3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apimatic/unirest-php/zipball/e16754010c16be5473289470f129d87a0f41b55e",
-                "reference": "e16754010c16be5473289470f129d87a0f41b55e",
+                "url": "https://api.github.com/repos/apimatic/unirest-php/zipball/bdfd5f27c105772682c88ed671683f1bd93f4a3c",
+                "reference": "bdfd5f27c105772682c88ed671683f1bd93f4a3c",
                 "shasum": ""
             },
             "require": {
@@ -218,9 +218,9 @@
             "support": {
                 "email": "opensource@apimatic.io",
                 "issues": "https://github.com/apimatic/unirest-php/issues",
-                "source": "https://github.com/apimatic/unirest-php/tree/4.0.5"
+                "source": "https://github.com/apimatic/unirest-php/tree/4.0.7"
             },
-            "time": "2023-04-25T14:19:45+00:00"
+            "time": "2025-06-17T09:09:48+00:00"
         },
         {
             "name": "php-jsonpointer/php-jsonpointer",


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Updates the `apimatic/unirest-php` package to 4.0.7 to include the fix for https://github.com/apimatic/unirest-php/issues/59

Upstream changes included in this update:
* https://github.com/apimatic/unirest-php/issues/61
* https://github.com/apimatic/unirest-php/issues/60 (the fix for the issue in WC Sq)
* https://github.com/apimatic/unirest-php/issues/56

This is to resolve a fatal error that can occur after a server migration.

Closes https://linear.app/a8c/issue/SQUARE-109/possible-one-off-fatal-error-crashes-wp-admin-after-server-migration

### Steps to test the changes in this Pull Request:

As this updates a package used by the Square SDK all critical flows should be tested.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Resolve fatal errors that may occur after a server migration.
> Dev - Update apimatic/unirest-php package to 4.0.7.
