### PR TITLE
Error Logging for Gift Card Failure Due to session being cleared

### DIFF
--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -451,13 +451,11 @@ class Gift_Card extends Payment_Gateway {
 				} else {
 					$response['is_error'] = true;
 
-					if ( is_array( $gift_card_data ) && $this->debug_log() ) {
-						$log = new \WC_Logger();
-
+					if ( is_array( $gift_card_data ) ) {
 						foreach ( $gift_card_data as $square_error ) {
 							if ( $square_error instanceof \Square\Models\Error ) {
 								/** @var \Square\Models\Error $square_error */
-								$log->log( 'error', 'Gift card error: ' . $square_error->getDetail(), array( 'source' => 'woocommerce-square-gift-card' ) );
+								wc_square()->log( 'error', 'Gift card error: ' . $square_error->getDetail(), array( 'source' => 'woocommerce-square-gift-card' ) );
 							}
 						}
 					}
@@ -465,10 +463,7 @@ class Gift_Card extends Payment_Gateway {
 			} else {
 				$response['is_error'] = true;
 
-				if ( $this->debug_log() ) {
-					$log = new \WC_Logger();
-					$log->log( 'error', 'Gift card error: Payment token (woocommerce_square_gift_card_payment_token) is missing from session.', array( 'source' => 'woocommerce-square-gift-card' ) );
-				}
+				wc_square()->log( 'error', 'Gift card error: Payment token (woocommerce_square_gift_card_payment_token) is missing from session.', array( 'source' => 'woocommerce-square-gift-card' ) );
 			}
 		}
 

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -451,19 +451,24 @@ class Gift_Card extends Payment_Gateway {
 				} else {
 					$response['is_error'] = true;
 
-					if ( is_array( $gift_card_data ) ) {
+					if ( is_array( $gift_card_data ) && $this->debug_log() ) {
 						$log = new \WC_Logger();
 
 						foreach ( $gift_card_data as $square_error ) {
 							if ( $square_error instanceof \Square\Models\Error ) {
 								/** @var \Square\Models\Error $square_error */
-								$log->log( 'error', $square_error->getDetail() );
+								$log->log( 'error', 'Gift card error: ' . $square_error->getDetail(), array( 'source' => 'woocommerce-square-gift-card' ) );
 							}
 						}
 					}
 				}
 			} else {
 				$response['is_error'] = true;
+
+				if ( $this->debug_log() ) {
+					$log = new \WC_Logger();
+					$log->log( 'error', 'Gift card error: Payment token (woocommerce_square_gift_card_payment_token) is missing from session.', array( 'source' => 'woocommerce-square-gift-card' ) );
+				}
 			}
 		}
 


### PR DESCRIPTION
Enhance gift card error logging with debug_log() checks, message prefixes, and source context, and add logging for missing payment tokens.

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


When a gift card application fails due to a missing payment token in the session, users see the error message "There was an error while applying the gift card" but no log entry is created. This makes it difficult for store owners and developers to diagnose why gift cards aren't working.

This PR adds error logging when:

The woocommerce_square_gift_card_payment_token is missing from the session
The Square API returns errors (improved existing logging with source context)
Both logging cases now:

- Respect the Debug Mode setting via $this->debug_log()
- Include a descriptive source context (woocommerce-square-gift-card) for easy filtering in WooCommerce logs
- Prefix error messages with "Gift card error:" for clarity

Closes #38.
Closes https://linear.app/a8c/issue/SQUARE-83/gift-card-failure-not-logged

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

⚠️ Note: The error logging code paths are only executed in Production mode, not Sandbox mode. Sandbox mode uses hardcoded balance values and bypasses the API calls where these errors would occur. Full testing requires a Production Square account.

1. Enable Debug Mode in WooCommerce → Settings → Payments → Square → Gift Cards (set to "Save to Log")
2. Ensure Square Credit Card gateway and Gift Cards are enabled
3. Add a product to cart and proceed to checkout
4. Apply a valid Square gift card
5. Clear the session token by adding this temporary code to your theme's `functions.php`:
```php
add_action( 'init', function() {
    if ( isset( $_GET['clear_gc_token'] ) && $_GET['clear_gc_token'] === '1' ) {
        if ( WC()->session ) {
            WC()->session->set( 'woocommerce_square_gift_card_payment_token', null );
        }
        wp_die( 'Gift card token cleared!' );
    }
});
```
6. Visit `yoursite.com/?clear_gc_token=1` to clear the token
7. Return to checkout - the gift card form should reset
8. Check WooCommerce → Status → Logs for a woocommerce-square-gift-card-* log file
9. Verify the log contains: Gift card error: Payment token (woocommerce_square_gift_card_payment_token) is missing from session.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - Error logging when gift card application fails due to missing session token or Square API errors.