### PR TITLE
Set default inventory tracking to false when the `track_inventory` key is missing in sync and product handlers.

### DIFF
--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -445,7 +445,7 @@ class Product {
 		}
 
 		$inventory_tracking_data = $inventory_tracking[ $square_id ] ?? array();
-		$is_inventory_tracking   = $inventory_tracking_data['track_inventory'] ?? true;
+		$is_inventory_tracking   = $inventory_tracking_data['track_inventory'] ?? false;
 		$sold_out                = $inventory_tracking_data['sold_out'] ?? false;
 
 		if ( $is_inventory_tracking ) {
@@ -499,7 +499,7 @@ class Product {
 				$square_id               = $catalog_object->getId();
 				$stock                   = $inventory_hash[ $square_id ] ?? 0;
 				$inventory_tracking_data = $inventory_tracking[ $square_id ] ?? array();
-				$is_inventory_tracking   = $inventory_tracking_data['track_inventory'] ?? true;
+				$is_inventory_tracking   = $inventory_tracking_data['track_inventory'] ?? false;
 				$sold_out                = $inventory_tracking_data['sold_out'] ?? false;
 
 				$product_id = $products_map[ $square_id ]['product_id'];

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -293,7 +293,7 @@ class Interval_Polling extends Stepped_Job {
 		$catalog_objects_to_update      = array();
 
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {
-			$is_tracking_inventory = $inventory_data['track_inventory'] ?? true;
+			$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 			$sold_out              = $inventory_data['sold_out'] ?? false;
 			$product               = Product::get_product_by_square_variation_id( $catalog_object_id );
 			if ( $product instanceof \WC_Product ) {
@@ -317,7 +317,7 @@ class Interval_Polling extends Stepped_Job {
 				$product = Product::get_product_by_square_variation_id( $catalog_object_id );
 				if ( $product instanceof \WC_Product ) {
 					$inventory_data        = $catalog_objects_tracking_stats[ $catalog_object_id ] ?? array();
-					$is_tracking_inventory = $inventory_data['track_inventory'] ?? true;
+					$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 					$sold_out              = $inventory_data['sold_out'] ?? false;
 
 					/* If catalog object is tracked and has a quantity > 0 set in Square. */
@@ -421,7 +421,7 @@ class Interval_Polling extends Stepped_Job {
 			// Square can return multiple "types" of counts, WooCommerce only distinguishes whether a product is in stock or not
 			if ( $product instanceof \WC_Product ) {
 				$inventory_data        = $catalog_objects_tracking_stats[ $catalog_object_id ] ?? array();
-				$is_tracking_inventory = $inventory_data['track_inventory'] ?? true;
+				$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 				$sold_out              = $inventory_data['sold_out'] ?? false;
 
 				if ( $is_tracking_inventory ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1569,7 +1569,7 @@ class Manual_Synchronization extends Stepped_Job {
 		$catalog_objects_tracking_stats = Helper::get_catalog_objects_tracking_stats( $catalog_object_ids );
 
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {
-			$is_tracking_inventory = $inventory_data['track_inventory'] ?? true;
+			$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 			$sold_out              = $inventory_data['sold_out'] ?? false;
 
 			if ( in_array( $catalog_object_id, $in_progress['processed_variation_ids'], false ) ) { // phpcs:disable WordPress.PHP.StrictInArray.FoundNonStrictFalse

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -318,7 +318,7 @@ class Product_Import extends Stepped_Job {
 
 				if ( $product && $product instanceof \WC_Product ) {
 					$inventory_data        = $catalog_objects_hash[ $catalog_object->getId() ] ?? array();
-					$is_tracking_inventory = $inventory_data['track_inventory'] ?? true;
+					$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 					$sold_out              = $inventory_data['sold_out'] ?? false;
 
 					/* If catalog object is tracked and has a quantity > 0 set in Square. */


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When products are imported to Square via CSV with inventory tracking disabled, the Square API response does not include the track_inventory field. The current code defaults this missing field to true, which incorrectly enables "Manage Stock" in WooCommerce, resulting in products showing as "Out of Stock."

Products created directly in Square's dashboard work correctly because they explicitly set track_inventory: false in the API response.

This PR changes the default value from true to false when the track_inventory key is missing, ensuring CSV-imported products without inventory tracking are correctly imported as "In Stock" with stock management disabled.

Closes https://linear.app/a8c/issue/SQUARE-214/csv-imported-products-with-non-tracked-inventory-are-set-to-manage.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Import a product to Square using the CSV import feature with "location availability" enabled but "stock tracking" disabled.

Use this [test.csv](https://github.com/user-attachments/files/24049726/test.csv) file if needed.

2. Verify in the Square dashboard that the product has location availability enabled but stock tracking disabled.
3. In WooCommerce, go to WooCommerce → Settings → Square and run a product import/sync.
4. Navigate to the imported product in WooCommerce and check its inventory settings.
5. Expected: The product should show as "In Stock" with "Manage stock?" set to disabled (unchecked).
6. Before fix: The product incorrectly showed as "Out of Stock" with "Manage stock?" enabled and quantity set to 0.

Additional verification:

1. Create a product directly in Square's dashboard with stock tracking disabled.
2. Import this product to WooCommerce.
3. Verify both products (CSV-imported and dashboard-created) now behave consistently, both showing as "In Stock" with stock management disabled.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - CSV-imported products from Square with inventory tracking disabled are now correctly imported as "In Stock" instead of "Out of Stock" with stock management enabled.