### PR TITLE
Bump minumum requred WP and WooCommerce versions.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Square ===
 Contributors: woocommerce, automattic
 Tags: credit card, square, woocommerce, inventory sync
-Requires at least: 6.5
+Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 5.1.2

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -22,7 +22,7 @@
  * @copyright Copyright (c) 2019, Automattic, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
  *
- * WC requires at least: 10.1
+ * WC requires at least: 10.2
  * WC tested up to: 10.4
  */
 
@@ -63,7 +63,7 @@ class WooCommerce_Square_Loader {
 	const MINIMUM_WP_VERSION = '6.7';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '10.1';
+	const MINIMUM_WC_VERSION = '10.2';
 
 	/**
 	 * SkyVerge plugin framework version used by this plugin

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Version: 5.1.2
  * Plugin URI: https://woocommerce.com/products/square/
- * Requires at least: 6.5
+ * Requires at least: 6.7
  * Tested up to: 6.9
  * Requires PHP: 7.4
  * PHP tested up to: 8.4


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [x] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This bumps the minimum required versions of core software to:

* WordPress 6.7
* WooCommerce 10.2

These version bumps were reverted for the 5.1.2 security release as the functional changes in the release did not require any recent features so I wanted to avoid the potential of people not upgrading due to apparent version constraints.

Future versions are intended to follow the standard support protocol for the number of versions the extension supports.

Closes https://linear.app/a8c/issue/SQUARE-224/bump-wc-and-wp-minimums

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

N/A The version bumps were tested in earlier PRs:
* WP see #423
* Woo see #426



### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce minimum supported version to 10.2.
> Dev - Bump WordPress minimum supported version to 6.7.
