### PR TITLE
Add notice for Square SOR and inventory sync in bulk edit screen

### DIFF
--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -31,6 +31,39 @@ jQuery( document ).ready( ( $ ) => {
 
 	// products quick edit screen.
 	if ( 'edit-product' === pagenow ) {
+		// Add notice near stock field in bulk edit when Square SOR and inventory sync is enabled.
+		if ( wc_square_admin_products.is_square_sor && wc_square_admin_products.is_inventory_sync_enabled ) {
+			// Use MutationObserver to detect when bulk edit form is inserted into the DOM.
+			const bulkEditObserver = new MutationObserver( ( mutations ) => {
+				mutations.forEach( ( mutation ) => {
+					mutation.addedNodes.forEach( ( node ) => {
+						if ( node.nodeType === 1 && node.id === 'bulk-edit' ) {
+							const $bulkEdit = $( node );
+							// Find the "In stock?" field label which is the start of stock-related fields.
+							// In bulk edit, stock fields are wrapped in <label> elements, not .inline-edit-group.
+							const $stockStatusField = $bulkEdit.find( 'select.stock_status' ).closest( 'label' );
+
+							// Add notice if not already present.
+							if ( $stockStatusField.length && ! $bulkEdit.find( '.wc-square-bulk-edit-notice' ).length ) {
+								const bulkEditNotice = '<div class="wc-square-bulk-edit-notice notice notice-warning inline" style="margin: 10px 0; padding: 8px 12px;">' +
+									'<p style="margin: 0;">' +
+									__( 'Inventory updates made here will not apply to Square-synced products. Stock values for these products are managed in Square and will be overwritten during the next sync.', 'woocommerce-square' ) +
+									'</p>' +
+									'</div>';
+								$stockStatusField.before( bulkEditNotice );
+							}
+						}
+					} );
+				} );
+			} );
+
+			// Start observing the table body for bulk edit form insertion.
+			const tableBody = document.querySelector( '#the-list' );
+			if ( tableBody && tableBody.parentNode ) {
+				bulkEditObserver.observe( tableBody.parentNode, { childList: true, subtree: true } );
+			}
+		}
+
 		// when clicking the quick edit button fetch the default Synced with Square checkbox
 		$( '#the-list' ).on( 'click', '.editinline', ( e ) => {
 			const $row = $( e.target ).closest( 'tr' );

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -32,7 +32,7 @@ jQuery( document ).ready( ( $ ) => {
 	// products quick edit screen.
 	if ( 'edit-product' === pagenow ) {
 		// Add notice near stock field in bulk edit when Square SOR and inventory sync is enabled.
-		if ( wc_square_admin_products.is_square_sor && wc_square_admin_products.is_inventory_sync_enabled ) {
+		if ( wc_square_admin_products.is_inventory_sync_enabled ) {
 			// Use MutationObserver to detect when bulk edit form is inserted into the DOM.
 			const bulkEditObserver = new MutationObserver( ( mutations ) => {
 				mutations.forEach( ( mutation ) => {


### PR DESCRIPTION
<img width="766" height="219" alt="image" src="https://github.com/user-attachments/assets/379df1f4-322c-4c1f-8c87-159cf4f13209" />

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adds the above notice.

Closes https://linear.app/a8c/issue/SQUARE-204/bulk-stock-changes-in-wc-dont-sync-to-square.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Set up Square with WooCommerce as the System of Record (SoR)
2. Ensure "Sync inventory" is enabled in WooCommerce > Settings > Square
3. Create or select 2+ products that are synced with Square and have stock management enabled (e.g., Product A with qty 10, Product B with qty 11)
4. In Products list, select the products and click "Edit" under Bulk actions
5. In the bulk edit panel, notice the above screenshot.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - Show a notice for Square SOR and inventory sync in bulk edit screen.