### PR TITLE
Ensure there is no fatal error when the WooCommerce version is below the minimum supported version

### DIFF
--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -29,6 +29,7 @@ export async function clearCart( page ) {
 	await page.goto( '/cart' );
 
 	if ( await page.locator( '.wp-block-woocommerce-cart-items-block' ).isVisible() ) {
+		await page.locator( 'tr[aria-label="Loading products in cart…"]' ).first().waitFor({ state: 'hidden' });
 		const removeBtns = await page.$$( '.wc-block-cart-item__remove-link' );
 
 		for ( const button of removeBtns ) {

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -89,7 +89,7 @@ class WooCommerce_Square_Loader {
 	 */
 	protected function __construct() {
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
-		add_action( 'before_woocommerce_init', array( $this, 'declare_features_compatibility' ) );
+
 		/*
 		 * Bootstrap the extension on plugins_loaded.
 		 *
@@ -149,6 +149,8 @@ class WooCommerce_Square_Loader {
 		wc_square();
 
 		add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_block_integrations' ), 5, 1 );
+
+		add_action( 'before_woocommerce_init', array( $this, 'declare_features_compatibility' ) );
 	}
 
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
PR fixes the fatal error when the installed WooCommerce version is below the minimum supported version by the Square plugin.

**Root cause:**
We [check](https://github.com/woocommerce/woocommerce-square/blob/12b078a57bd9acc5f3396fce09f6b70938e10c4f/woocommerce-square.php#L134-L136) for environment compatibility and only load the plugin when it meets the minimum compatible version and other requirements. However, `declare_features_compatibility` was being called regardless of environment compatibility, which ultimately resulted in a fatal error in a non-compatible environment. This PR fixes the issue by ensuring that `declare_features_compatibility` is called only when the environment is compatible and the plugin is loaded.

Closes https://linear.app/a8c/issue/SQUARE-226/fatal-error-when-woocommerce-version-is-below-minimum-supported

### Steps to test the changes in this Pull Request:
1. Install an older version of WooCommerce that is lower than the minimum supported version by the Square plugin (for example, install WooCommerce 10.1.x when the minimum supported version is 10.2).
2. Install and activate the WooCommerce Square plugin.
3. Verify there is no fatal error.

### Changelog entry
> Fix - Ensure that there is no fatal error when the WooCommerce version is below the minimum supported version.
