### PR TITLE
SQUARE-201: Prevent fatal error on incompatible environments.

### DIFF
--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -353,7 +353,7 @@ class WooCommerce_Square_Loader {
 			$error_message .= sprintf(
 				// translators: link to documentation
 				__( '&bull;&nbsp;<strong>Invalid OPcache config: </strong><a href="%s" target="_blank">Please ensure the <code>save_comments</code> PHP option is enabled.</a> You may need to contact your hosting provider to change caching options.', 'woocommerce-square' ),
-				'https://woocommerce.com/document/woocommerce-square/troubleshooting/#section-3'
+				'https://woocommerce.com/document/woocommerce-square/troubleshooting/#recommended-caching-settings'
 			);
 		}
 

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -326,13 +326,18 @@ class WooCommerce_Square_Loader {
 	 * @return bool
 	 */
 	public function is_environment_compatible() {
-		$is_wc_compatible        = $this->is_wc_compatible();
-		$is_wp_compatible        = $this->is_wp_compatible();
-		$is_php_valid            = $this->is_php_version_valid();
-		$is_opcache_config_valid = $this->is_opcache_save_message_enabled();
-		$error_message           = '';
+		static $error_message_registered = false;
+		$is_wc_compatible                = $this->is_wc_compatible();
+		$is_wp_compatible                = $this->is_wp_compatible();
+		$is_php_valid                    = $this->is_php_version_valid();
+		$is_opcache_config_valid         = $this->is_opcache_save_message_enabled();
+		$error_message                   = '';
 
 		if ( ! $is_php_valid || ! $is_opcache_config_valid || ! $is_wc_compatible || ! $is_wp_compatible ) {
+			if ( $error_message_registered ) {
+				// Error message has already been registered, do not register again.
+				return false;
+			}
 			$error_message .= sprintf(
 				// translators: plugin name
 				__( '<strong>All features in %1$s have been disabled</strong> due to unsupported settings:<br>', 'woocommerce-square' ),
@@ -389,7 +394,8 @@ class WooCommerce_Square_Loader {
 			);
 		}
 
-		if ( ! empty( $error_message ) ) {
+		if ( ! empty( $error_message ) && ! $error_message_registered ) {
+			$error_message_registered = true;
 			$this->add_admin_notice(
 				'bad_environment',
 				'error',
@@ -456,6 +462,10 @@ class WooCommerce_Square_Loader {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 
+			if ( ! $this->is_environment_compatible() ) {
+				// Environment not compatible, do not configure features.
+				return;
+			}
 			new \WooCommerce\Square\Admin\Product_Editor_Compatibility();
 		}
 	}

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -352,7 +352,7 @@ class WooCommerce_Square_Loader {
 		if ( ! $is_opcache_config_valid ) {
 			$error_message .= sprintf(
 				// translators: link to documentation
-				__( '&bull;&nbsp;<strong>Invalid OPcache config: </strong><a href="%s" target="_blank">Please ensure the <code>save_comments</code> PHP option is enabled.</a> You may need to contact your hosting provider to change caching options.', 'woocommerce-square' ),
+				__( '&bull;&nbsp;<strong>Invalid OPcache config: </strong><a href="%s" target="_blank">Please ensure the <code>save_comments</code> PHP option is enabled.</a> You may need to contact your hosting provider to change caching options.<br />', 'woocommerce-square' ),
 				'https://woocommerce.com/document/woocommerce-square/troubleshooting/#recommended-caching-settings'
 			);
 		}

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -463,7 +463,12 @@ class WooCommerce_Square_Loader {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 
 			if ( ! $this->is_environment_compatible() ) {
-				// Environment not compatible, do not configure features.
+				/*
+				 * Environment not compatible, do not configure features.
+				 *
+				 * The autoloader is not configured if the environment is not compatible,
+				 * so calling the line below will result in a fatal error on such systems.
+				 */
 				return;
 			}
 			new \WooCommerce\Square\Admin\Product_Editor_Compatibility();


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Bypasses the call to `new Product_Editor_Compatibility()` in the feature compatibility declaration on environments that do not meet minimum requirements. This prevents a fatal error as the autoloader is not configured on incompatible environments.

Some related changes are made to the `::is_environment_compatible()` method:

* the function can be called multiple times without registering an admin notice each time
* formatting fix in the text for opcache incompatibility notice
* documentation fix for the link in the opcache  incompatibility notice (the anchor has changed)

During development, rather than configure an incompatible environment, I hacked the `::is_environment_compatible()` by hard coding `$is_wc_compatible = false;` rather than call the checks. I repeated for various configurations of the compatibility checks at the start of the method

Closes https://linear.app/a8c/issue/SQUARE-201/square-for-woocommerce-crashes-sites-hosted-on-kinsta
Closes https://linear.app/a8c/issue/SQUARE-226/fatal-error-when-woocommerce-version-is-below-minimum-supported

### Steps to test the changes in this Pull Request:

1. On a compatible environment, ensure the plugin features run as normal.
2. Faux test an incompatible environment:
   Run this check for various combinations of `$is_wc_compatible`, `$is_wp_compatible`, `$is_php_valid` and `$is_opcache_config_valid` had coded to false.
   1. Hack `::is_environment_compatible()` as documented above.
   2. Ensure the site does not throw a fatal error
   3. Ensure that WooCommerce does **not** show the message "WooCommerce has detected that some of your active plugins are incompatible with currently enabled WooCommerce features. Please review the details."


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Prevent fatal errors occurring on incompatible environments.
