### PR TITLE
Prevent public querying of sync with square taxonomy.

### DIFF
--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -535,8 +535,10 @@ class Product {
 			array(
 				'hierarchical'          => false,
 				'update_count_callback' => '_update_generic_term_count',
+				'public'                => false,
 				'show_ui'               => false,
 				'show_in_nav_menus'     => false,
+				'publicly_queryable'    => false,
 				'query_var'             => is_admin(),
 				'rewrite'               => false,
 			)


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Register the `wc_square_synced` taxonomy as private, ie unable to be publicly queried. This prevents the general public from being able to view the "yes" term on the front end of the site if they know how to put together the query string arguments.

Closes https://linear.app/a8c/issue/SQUARE-161/wc-square-synced-taxonomy-page-is-public-and-there-is-no-option-to

> [!Note]
>
> I've made this change on the basis that the taxo was always intended to be private but coded up incorrectly. If there is some background that the requires this to be public, please let me know.

### Steps to test the changes in this Pull Request:

1. Configure Square as the source of truth
2. Wait for an import to complete
3. Create and publish a Simple product to WooCommerce directly, do _not_ check the sync with Square checkbox.
4. Visit the URL structure described in the ticket linked above, replacing the host name with your test site.
5. Ensure the resulting page is a 404 File Not Found.


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Set the "Synced with Square" taxonomy to private.
