### PR TITLE
Improve UX clarity between "Sync Now" and "Import all Products from Square" buttons

### DIFF
--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -169,12 +169,16 @@ class Settings_Page extends \WC_Settings_Page {
 				<div class="wc-backbone-modal-content">
 					<section class="wc-backbone-modal-main" role="main">
 						<header class="wc-backbone-modal-header">
-							<h1><?php esc_html_e( 'Import Products From Square', 'woocommerce-square' ); ?></h1>
+							<h1><?php esc_html_e( 'Import New Products From Square', 'woocommerce-square' ); ?></h1>
 							<button class="modal-close modal-close-link dashicons dashicons-no-alt">
 								<span class="screen-reader-text"><?php esc_html_e( 'Close modal window', 'woocommerce-square' ); ?></span>
 							</button>
 						</header>
 						<article>
+							<p style="background: #f0f6fc; border-left: 4px solid #2271b1; padding: 10px 12px; margin-bottom: 16px;">
+								<strong><?php esc_html_e( 'This is for importing new products.', 'woocommerce-square' ); ?></strong>
+								<?php esc_html_e( 'To update existing synced products, use "Sync Now" on the Update tab instead.', 'woocommerce-square' ); ?>
+							</p>
 							<p><?php esc_html_e( 'You are about to import all new products, variations and categories from Square. This will create a new product in WooCommerce for every product retrieved from Square. If you have products in the trash from the previous imports, these will be ignored in the import.', 'woocommerce-square' ); ?></p>
 							<hr>
 							<h4><?php esc_html_e( 'Do you wish to import existing product updates from Square?', 'woocommerce-square' ); ?></h4>

--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -169,7 +169,7 @@ class Settings_Page extends \WC_Settings_Page {
 				<div class="wc-backbone-modal-content">
 					<section class="wc-backbone-modal-main" role="main">
 						<header class="wc-backbone-modal-header">
-							<h1><?php esc_html_e( 'Import New Products From Square', 'woocommerce-square' ); ?></h1>
+							<h1><?php esc_html_e( 'Import Products From Square', 'woocommerce-square' ); ?></h1>
 							<button class="modal-close modal-close-link dashicons dashicons-no-alt">
 								<span class="screen-reader-text"><?php esc_html_e( 'Close modal window', 'woocommerce-square' ); ?></span>
 							</button>

--- a/includes/Admin/Settings_Page.php
+++ b/includes/Admin/Settings_Page.php
@@ -175,10 +175,6 @@ class Settings_Page extends \WC_Settings_Page {
 							</button>
 						</header>
 						<article>
-							<p style="background: #f0f6fc; border-left: 4px solid #2271b1; padding: 10px 12px; margin-bottom: 16px;">
-								<strong><?php esc_html_e( 'This is for importing new products.', 'woocommerce-square' ); ?></strong>
-								<?php esc_html_e( 'To update existing synced products, use "Sync Now" on the Update tab instead.', 'woocommerce-square' ); ?>
-							</p>
 							<p><?php esc_html_e( 'You are about to import all new products, variations and categories from Square. This will create a new product in WooCommerce for every product retrieved from Square. If you have products in the trash from the previous imports, these will be ignored in the import.', 'woocommerce-square' ); ?></p>
 							<hr>
 							<h4><?php esc_html_e( 'Do you wish to import existing product updates from Square?', 'woocommerce-square' ); ?></h4>

--- a/includes/Admin/Sync_Page.php
+++ b/includes/Admin/Sync_Page.php
@@ -264,40 +264,6 @@ class Sync_Page {
 		<?php
 	}
 
-
-	/**
-	 * Outputs an informational notice about importing new products from Square.
-	 *
-	 * @since 4.8.0
-	 */
-	private static function output_import_products_notice() {
-
-		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
-			return;
-		}
-
-		$settings_url = admin_url( 'admin.php?page=wc-settings&tab=square' );
-
-		?>
-		<div class="wc-square-import-notice" style="background: #f0f6fc; border-left: 4px solid #2271b1; padding: 12px 16px; margin: 20px 0;">
-			<p style="margin: 0 0 8px 0;">
-				<strong><?php esc_html_e( 'Looking to import new products from Square?', 'woocommerce-square' ); ?></strong>
-			</p>
-			<p style="margin: 0;">
-				<?php
-				printf(
-					/* translators: Placeholders: %1$s - opening <a> tag, %2$s - closing </a> tag */
-					esc_html__( 'The "Sync Now" button only updates products that are already synced with Square. To import new products from Square that don\'t exist in WooCommerce yet, use the %1$sImport all Products from Square%2$s button on the Settings tab.', 'woocommerce-square' ),
-					'<a href="' . esc_url( $settings_url ) . '"><strong>',
-					'</strong></a>'
-				);
-				?>
-			</p>
-		</div>
-		<?php
-	}
-
-
 	/**
 	 * Outputs tabular HTML with sync record logs and UI.
 	 *
@@ -386,17 +352,19 @@ class Sync_Page {
 				<div class="wc-backbone-modal-content">
 					<section class="wc-backbone-modal-main" role="main">
 						<header class="wc-backbone-modal-header">
-							<h1><?php esc_html_e( 'Sync existing products with Square', 'woocommerce-square' ); ?></h1>
+							<h1><?php esc_html_e( 'Sync products with Square', 'woocommerce-square' ); ?></h1>
 							<button class="modal-close modal-close-link dashicons dashicons-no-alt">
 								<span class="screen-reader-text"><?php esc_html_e( 'Close modal window', 'woocommerce-square' ); ?></span>
 							</button>
 						</header>
 						<article>
 							<?php $square_settings = wc_square()->get_settings_handler(); ?>
+							<?php if ( $square_settings->is_product_sync_enabled() ) : ?>
 							<p style="background: #fcf9e8; border-left: 4px solid #dba617; padding: 10px 12px; margin-bottom: 16px;">
 								<strong><?php esc_html_e( 'Note:', 'woocommerce-square' ); ?></strong>
 								<?php esc_html_e( 'This will only update products that are already synced with Square. New products in Square will not be imported. To import new products, use "Import all Products from Square" on the Settings tab.', 'woocommerce-square' ); ?>
 							</p>
+							<?php endif; ?>
 							<?php ob_start(); ?>
 							<ul>
 								<?php if ( $square_settings->is_system_of_record_square() ) : ?>
@@ -418,7 +386,7 @@ class Sync_Page {
 							<?php
 							printf(
 								/* translators: Placeholders: %1$s - the name of the system of record set in the sync settings (e.g. Square or WooCommerce), %3%s - unordered HTML list of additional information item(s) */
-								esc_html__( 'You are about to sync existing products with Square. %1$s is your system of record set in the sync settings. For all products currently synced with Square: %2$s', 'woocommerce-square' ),
+								esc_html__( 'You are about to sync products with Square. %1$s is your system of record set in the sync settings. For all products currently synced with Square: %2$s', 'woocommerce-square' ),
 								esc_html( $square_settings->get_system_of_record_name() ),
 								$additional_info // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The contents of $additional_info is already escaped above.
 							);

--- a/includes/Admin/Sync_Page.php
+++ b/includes/Admin/Sync_Page.php
@@ -49,7 +49,6 @@ class Sync_Page {
 			<h2><?php esc_html_e( 'Update', 'woocommerce-square' ); ?></h2>
 			<?php self::output_system_record_of_data_info(); ?>
 			<?php self::output_sync_status(); ?>
-			<?php self::output_import_products_notice(); ?>
 
 			<h2><?php esc_html_e( 'Sync records', 'woocommerce-square' ); ?></h2>
 			<?php self::output_sync_records(); ?>
@@ -253,9 +252,11 @@ class Sync_Page {
 							<?php echo ! empty( $disabled_reason ) ? sprintf( 'disabled="disabled" title="%s"', esc_attr( $disabled_reason ) ) : ''; ?>
 						><?php esc_html_e( 'Sync now', 'woocommerce-square' ); ?></button>
 						<div id="wc-square-sync-progress-spinner" class="spinner" style="float:none; <?php echo $sync_in_progress ? 'visibility:visible;' : ''; ?>"></div>
-						<p class="description" style="margin-top: 8px; font-style: italic; color: #646970;">
-							<?php esc_html_e( 'Updates existing synced products only. Does not import new products from Square.', 'woocommerce-square' ); ?>
-						</p>
+						<?php if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) : ?>
+							<p class="description" style="margin-top: 8px; font-style: italic; color: #646970;">
+								<?php esc_html_e( 'Updates existing synced products only. Does not import new products from Square.', 'woocommerce-square' ); ?>
+							</p>
+						<?php endif; ?>
 					</td>
 				</tr>
 			</tbody>

--- a/includes/Admin/Sync_Page.php
+++ b/includes/Admin/Sync_Page.php
@@ -49,6 +49,7 @@ class Sync_Page {
 			<h2><?php esc_html_e( 'Update', 'woocommerce-square' ); ?></h2>
 			<?php self::output_system_record_of_data_info(); ?>
 			<?php self::output_sync_status(); ?>
+			<?php self::output_import_products_notice(); ?>
 
 			<h2><?php esc_html_e( 'Sync records', 'woocommerce-square' ); ?></h2>
 			<?php self::output_sync_records(); ?>
@@ -250,12 +251,48 @@ class Sync_Page {
 							id="wc-square-sync"
 							class="button button-large"
 							<?php echo ! empty( $disabled_reason ) ? sprintf( 'disabled="disabled" title="%s"', esc_attr( $disabled_reason ) ) : ''; ?>
-						><?php esc_html_e( 'Sync now', 'woocommerce-square' ); ?></span></button>
+						><?php esc_html_e( 'Sync now', 'woocommerce-square' ); ?></button>
 						<div id="wc-square-sync-progress-spinner" class="spinner" style="float:none; <?php echo $sync_in_progress ? 'visibility:visible;' : ''; ?>"></div>
+						<p class="description" style="margin-top: 8px; font-style: italic; color: #646970;">
+							<?php esc_html_e( 'Updates existing synced products only. Does not import new products from Square.', 'woocommerce-square' ); ?>
+						</p>
 					</td>
 				</tr>
 			</tbody>
 		</table>
+		<?php
+	}
+
+
+	/**
+	 * Outputs an informational notice about importing new products from Square.
+	 *
+	 * @since 4.8.0
+	 */
+	private static function output_import_products_notice() {
+
+		if ( ! wc_square()->get_settings_handler()->is_product_sync_enabled() ) {
+			return;
+		}
+
+		$settings_url = admin_url( 'admin.php?page=wc-settings&tab=square' );
+
+		?>
+		<div class="wc-square-import-notice" style="background: #f0f6fc; border-left: 4px solid #2271b1; padding: 12px 16px; margin: 20px 0;">
+			<p style="margin: 0 0 8px 0;">
+				<strong><?php esc_html_e( 'Looking to import new products from Square?', 'woocommerce-square' ); ?></strong>
+			</p>
+			<p style="margin: 0;">
+				<?php
+				printf(
+					/* translators: Placeholders: %1$s - opening <a> tag, %2$s - closing </a> tag */
+					esc_html__( 'The "Sync Now" button only updates products that are already synced with Square. To import new products from Square that don\'t exist in WooCommerce yet, use the %1$sImport all Products from Square%2$s button on the Settings tab.', 'woocommerce-square' ),
+					'<a href="' . esc_url( $settings_url ) . '"><strong>',
+					'</strong></a>'
+				);
+				?>
+			</p>
+		</div>
 		<?php
 	}
 
@@ -348,13 +385,17 @@ class Sync_Page {
 				<div class="wc-backbone-modal-content">
 					<section class="wc-backbone-modal-main" role="main">
 						<header class="wc-backbone-modal-header">
-							<h1><?php esc_html_e( 'Sync products with Square', 'woocommerce-square' ); ?></h1>
+							<h1><?php esc_html_e( 'Sync existing products with Square', 'woocommerce-square' ); ?></h1>
 							<button class="modal-close modal-close-link dashicons dashicons-no-alt">
 								<span class="screen-reader-text"><?php esc_html_e( 'Close modal window', 'woocommerce-square' ); ?></span>
 							</button>
 						</header>
 						<article>
 							<?php $square_settings = wc_square()->get_settings_handler(); ?>
+							<p style="background: #fcf9e8; border-left: 4px solid #dba617; padding: 10px 12px; margin-bottom: 16px;">
+								<strong><?php esc_html_e( 'Note:', 'woocommerce-square' ); ?></strong>
+								<?php esc_html_e( 'This will only update products that are already synced with Square. New products in Square will not be imported. To import new products, use "Import all Products from Square" on the Settings tab.', 'woocommerce-square' ); ?>
+							</p>
 							<?php ob_start(); ?>
 							<ul>
 								<?php if ( $square_settings->is_system_of_record_square() ) : ?>
@@ -376,7 +417,7 @@ class Sync_Page {
 							<?php
 							printf(
 								/* translators: Placeholders: %1$s - the name of the system of record set in the sync settings (e.g. Square or WooCommerce), %3%s - unordered HTML list of additional information item(s) */
-								esc_html__( 'You are about to sync products with Square. %1$s is your system of record set in the sync settings. For all products synced with Square: %2$s', 'woocommerce-square' ),
+								esc_html__( 'You are about to sync existing products with Square. %1$s is your system of record set in the sync settings. For all products currently synced with Square: %2$s', 'woocommerce-square' ),
 								esc_html( $square_settings->get_system_of_record_name() ),
 								$additional_info // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The contents of $additional_info is already escaped above.
 							);

--- a/includes/Admin/Sync_Page.php
+++ b/includes/Admin/Sync_Page.php
@@ -359,7 +359,7 @@ class Sync_Page {
 						</header>
 						<article>
 							<?php $square_settings = wc_square()->get_settings_handler(); ?>
-							<?php if ( $square_settings->is_product_sync_enabled() ) : ?>
+							<?php if ( $square_settings->is_system_of_record_square() ) : ?>
 							<p style="background: #fcf9e8; border-left: 4px solid #dba617; padding: 10px 12px; margin-bottom: 16px;">
 								<strong><?php esc_html_e( 'Note:', 'woocommerce-square' ); ?></strong>
 								<?php esc_html_e( 'This will only update products that are already synced with Square. New products in Square will not be imported. To import new products, use "Import all Products from Square" on the Settings tab.', 'woocommerce-square' ); ?>
@@ -386,7 +386,7 @@ class Sync_Page {
 							<?php
 							printf(
 								/* translators: Placeholders: %1$s - the name of the system of record set in the sync settings (e.g. Square or WooCommerce), %3%s - unordered HTML list of additional information item(s) */
-								esc_html__( 'You are about to sync products with Square. %1$s is your system of record set in the sync settings. For all products currently synced with Square: %2$s', 'woocommerce-square' ),
+								esc_html__( 'You are about to sync products with Square. %1$s is your system of record set in the sync settings. For all products synced with Square: %2$s', 'woocommerce-square' ),
 								esc_html( $square_settings->get_system_of_record_name() ),
 								$additional_info // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- The contents of $additional_info is already escaped above.
 							);

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -424,6 +424,7 @@ class Settings extends \WC_Settings_API {
 				<a id="wc_square_import_products" href='#' class='button js-import-square-products <?php echo ( ! $this->get_location_id() ? 'disabled' : '' ); ?>'>
 					<?php echo esc_html__( 'Import all products from Square', 'woocommerce-square' ); ?>
 				</a>
+				<p class="description" style="margin-top: 8px;"><?php esc_html_e( 'Use this to bring new products from Square into WooCommerce. This is different from "Sync Now" which only updates products that are already synced.', 'woocommerce-square' ); ?></p>
 				<p class="description wc_square_save_changes_message" style="display: none;"><?php esc_html_e( 'You have made changes to the settings. Please save the changes to enable the button.', 'woocommerce-square' ); ?></p>
 			</td>
 		</tr>

--- a/includes/Settings.php
+++ b/includes/Settings.php
@@ -424,7 +424,11 @@ class Settings extends \WC_Settings_API {
 				<a id="wc_square_import_products" href='#' class='button js-import-square-products <?php echo ( ! $this->get_location_id() ? 'disabled' : '' ); ?>'>
 					<?php echo esc_html__( 'Import all products from Square', 'woocommerce-square' ); ?>
 				</a>
-				<p class="description" style="margin-top: 8px;"><?php esc_html_e( 'Use this to bring new products from Square into WooCommerce. This is different from "Sync Now" which only updates products that are already synced.', 'woocommerce-square' ); ?></p>
+				<?php if ( $this->is_system_of_record_square() ) : ?>
+					<p class="description" style="margin-top: 8px;"><?php esc_html_e( 'Use this to bring new products from Square into WooCommerce. This is different from "Sync Now" which only updates products that are already synced.', 'woocommerce-square' ); ?></p>
+				<?php else : ?>
+					<p class="description" style="margin-top: 8px;"><?php esc_html_e( 'Use this to bring products from Square into WooCommerce.', 'woocommerce-square' ); ?></p>
+				<?php endif; ?>
 				<p class="description wc_square_save_changes_message" style="display: none;"><?php esc_html_e( 'You have made changes to the settings. Please save the changes to enable the button.', 'woocommerce-square' ); ?></p>
 			</td>
 		</tr>

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -347,6 +347,10 @@ export const ConfigureSync = ( {
 									) }
 									indent={ indent }
 									className="import-products-wrapper"
+									description={ __(
+										'Use this to bring new products from Square into WooCommerce. This is different from "Sync Now" which only updates products that are already synced.',
+										'woocommerce-square'
+									) }
 								>
 									<Button
 										data-testid="import-products-button"
@@ -406,12 +410,35 @@ export const ConfigureSync = ( {
 
 								{ isOpen && (
 									<Modal
-										title="Import Products From Square"
+										title={ __(
+											'Import New Products From Square',
+											'woocommerce-square'
+										) }
 										size={ 'large' }
 										onRequestClose={ closeModal }
 									>
 										<div className="import-modal-cover">
 											<div className="import-modal-content">
+												<p
+													style={ {
+														background: '#f0f6fc',
+														borderLeft:
+															'4px solid #2271b1',
+														padding: '10px 12px',
+														marginBottom: '16px',
+													} }
+												>
+													<strong>
+														{ __(
+															'This is for importing new products.',
+															'woocommerce-square'
+														) }
+													</strong>{ ' ' }
+													{ __(
+														'To update existing synced products, use "Sync Now" on the Update tab instead.',
+														'woocommerce-square'
+													) }
+												</p>
 												<p>
 													{ __(
 														'You are about to import all new products, variations and categories from Square. This will create a new product in WooCommerce for every product retrieved from Square. If you have products in the trash from the previous imports, these will be ignored in the import.',

--- a/src/new-user-experience/modules/configure-sync/index.js
+++ b/src/new-user-experience/modules/configure-sync/index.js
@@ -347,10 +347,17 @@ export const ConfigureSync = ( {
 									) }
 									indent={ indent }
 									className="import-products-wrapper"
-									description={ __(
-										'Use this to bring new products from Square into WooCommerce. This is different from "Sync Now" which only updates products that are already synced.',
-										'woocommerce-square'
-									) }
+									description={
+										system_of_record === 'square'
+											? __(
+													'Use this to bring new products from Square into WooCommerce. This is different from "Sync Now" which only updates products that are already synced.',
+													'woocommerce-square'
+											  )
+											: __(
+													'Use this to bring products from Square into WooCommerce.',
+													'woocommerce-square'
+											  )
+									}
 								>
 									<Button
 										data-testid="import-products-button"
@@ -411,7 +418,7 @@ export const ConfigureSync = ( {
 								{ isOpen && (
 									<Modal
 										title={ __(
-											'Import New Products From Square',
+											'Import Products From Square',
 											'woocommerce-square'
 										) }
 										size={ 'large' }
@@ -419,26 +426,6 @@ export const ConfigureSync = ( {
 									>
 										<div className="import-modal-cover">
 											<div className="import-modal-content">
-												<p
-													style={ {
-														background: '#f0f6fc',
-														borderLeft:
-															'4px solid #2271b1',
-														padding: '10px 12px',
-														marginBottom: '16px',
-													} }
-												>
-													<strong>
-														{ __(
-															'This is for importing new products.',
-															'woocommerce-square'
-														) }
-													</strong>{ ' ' }
-													{ __(
-														'To update existing synced products, use "Sync Now" on the Update tab instead.',
-														'woocommerce-square'
-													) }
-												</p>
 												<p>
 													{ __(
 														'You are about to import all new products, variations and categories from Square. This will create a new product in WooCommerce for every product retrieved from Square. If you have products in the trash from the previous imports, these will be ignored in the import.',


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR improves clarity between the "Sync Now" and "Import all Products from Square" actions to reduce merchant confusion.

**Problem:** Merchants were confused because both buttons lead to similar-looking pages, but they do different things:
- "Sync Now" only updates *existing* linked products
- "Import all Products from Square" brings *new* products from Square into WooCommerce

This caused support cases where merchants couldn't understand why new products added in Square weren't appearing after using "Sync Now".

**Solution:** Added descriptive helper text in key locations to clarify the difference:

1. **Update tab:** Added helper text below the "Sync Now" button and a warning notice in the sync modal explaining it only updates existing synced products (when Square is the system of record)

2. **Settings tab (PHP):** Added description text below the "Import all Products from Square" button explaining how it differs from "Sync Now"

3. **Settings tab (React):** Added the same description text and localized the import modal title

Closes #447  
Closes https://linear.app/a8c/issue/SQUARE-225/improve-ux-clarity-between-sync-now-and-import-all-products-from.

### Steps to test the changes in this Pull Request:

1. Set Square as the System of Record in WooCommerce > Settings > Square
2. Navigate to WooCommerce > Settings > Square > Update tab
3. Verify the "Sync Now" button now shows helper text: "Updates existing synced products only..."
4. Click "Sync Now" and verify the modal includes a yellow warning note about scope
5. Navigate to WooCommerce > Settings > Square > Settings tab
6. Verify the "Import all Products from Square" button has description text below it
7. Test both the React-based settings (new experience) and legacy PHP settings

### Changelog entry

> Add - Helper text and notices to clarify the difference between "Sync Now" and "Import all Products from Square".