### PR TITLE
Ensure that there is no `DivisionByZeroError` fatal error in Square when the total amount is zero and the tax amount is non-zero.

### DIFF
--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -443,8 +443,15 @@ class Orders extends API\Request {
 					$item_uid            = $item->get_id();
 					$tax_uid             = $taxes[ $key ]->getUid();
 					$prev_percentage     = $taxes[ $key ]->getPercentage();
-					$adjusted_percentage = (float) $tax_amount * 100 / $total_amount;
-					$adjusted_percentage = number_format( (float) $adjusted_percentage, 2, '.', '' );
+					$adjusted_percentage = $prev_percentage;
+					/*
+					 * $total_amount could be 0 for some cases, eg: Retail Delivery Fee via Avalara AvaTax for Minnesota (MN) and Colorado (CO).
+					 * @see https://linear.app/a8c/issue/SQUARE-232/divisionbyzeroerror-in-square-gateway-with-zero-amount-fee-tax
+					 */
+					if ( ! empty( $total_amount ) ) {
+						$adjusted_percentage = (float) $tax_amount * 100 / $total_amount;
+						$adjusted_percentage = number_format( (float) $adjusted_percentage, 2, '.', '' );
+					}
 
 					if ( $prev_percentage !== $adjusted_percentage ) {
 						// Create a new tax.


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in SQUARE-232, Square for WooCommerce throws a `DivisionByZeroError` when processing checkout for orders that include a zero-amount fee line with non-zero tax (Retail Delivery Fee via Avalara AvaTax) for Minnesota (MN) and Colorado (CO). This PR fixes this issue by avoiding division by zero. 

Closes https://linear.app/a8c/issue/SQUARE-232/divisionbyzeroerror-in-square-gateway-with-zero-amount-fee-tax

### Steps to test the changes in this Pull Request:
1. Install and activate:
    -  Square for WooCommerce (5.1.2)
    - Avalara AvaTax
2. Configure tax:
    - Enable taxes in WooCommerce
3. Create a test order:
    - Add products to cart
    - Set shipping/billing address to MN or CO
    - Proceed to checkout
    - Avalara adds a "Retail Delivery Fee" with:
    - Total: $0.00
    - Tax: $0.28 (or applicable amount)
    - Select Square payment method
4. Click on place order and make sure order placed without any error. Order currently fails with `DivisionByZeroError` error on the `trunk`.

### Changelog entry
> Fix - Ensure that there is no `DivisionByZeroError` fatal error in Square when the total amount is zero and the tax amount is non-zero.
