### PR TITLE
Fix Partial-Total Verification when Gift Card is used

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -1947,24 +1947,24 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	}
 
 	/**
-	 * Returns true if the order total equals to the sum of partial totals.
-	 * False otherwise.
+	 * Returns true if the order total equals the sum of partial totals (gift card + other gateway).
+	 * Uses integer comparison in smallest currency unit to avoid float precision errors.
 	 *
 	 * @param \WC_Order $order WooCommerce order object.
-	 * @return boolean
+	 * @return bool True if order total matches sum of partial totals (within 1 unit tolerance).
 	 */
 	protected function verify_order_total( $order ) {
-		// Get the decimal precision and factor.
-		$decimals = wc_get_price_decimals();
+		// Cap decimals to avoid factor overflow (e.g. 10^100 causes int/float overflow).
+		$decimals = min( wc_get_price_decimals(), 10 );
 		$factor   = pow( 10, $decimals );
 
-		// Convert the order total, gift card total, and other gateway total to integers using the factor.
-		// This will avoid the issue of float precision errors.
 		$order_total         = (int) round( (float) $order->get_total() * $factor );
 		$gift_card_total     = (int) round( (float) $order->payment->partial_total->gift_card * $factor );
 		$other_gateway_total = (int) round( (float) $order->payment->partial_total->other_gateway * $factor );
+		$sum                 = $gift_card_total + $other_gateway_total;
 
-		return $order_total === $gift_card_total + $other_gateway_total;
+		// Allow 1 unit in smallest currency unit for float/rounding edge cases.
+		return abs( $order_total - $sum ) <= 1;
 	}
 
 	/**

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -1954,9 +1954,15 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 	 * @return boolean
 	 */
 	protected function verify_order_total( $order ) {
-		$order_total         = (float) $order->get_total();
-		$gift_card_total     = $order->payment->partial_total->gift_card;
-		$other_gateway_total = $order->payment->partial_total->other_gateway;
+		// Get the decimal precision and factor.
+		$decimals = wc_get_price_decimals();
+		$factor   = pow( 10, $decimals );
+
+		// Convert the order total, gift card total, and other gateway total to integers using the factor.
+		// This will avoid the issue of float precision errors.
+		$order_total         = (int) round( (float) $order->get_total() * $factor );
+		$gift_card_total     = (int) round( (float) $order->payment->partial_total->gift_card * $factor );
+		$other_gateway_total = (int) round( (float) $order->payment->partial_total->other_gateway * $factor );
 
 		return $order_total === $gift_card_total + $other_gateway_total;
 	}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The check used strict float comparison (===) on amounts like 62.48 and 12.48. Because of binary float representation, those values are not always stored exactly, so the sum can differ by a tiny amount and the check wrongly fails.

We now compare amounts in the smallest currency unit (integer math) instead of floats: we scale by `10^decimals`, round to integers, and require the order total to match the sum of partial totals within 1 unit. We also cap decimals at 10 so the scale factor never overflows PHP’s int/float range (e.g. when the store uses something like 100 decimals).

- **`verify_order_total()`** no longer compares order total to the sum of partial totals (gift card + other gateway) using raw floats. Float representation of decimal amounts (e.g. 62.48, 12.48) can differ slightly and cause `===` to fail even when amounts are correct.
- Totals are now scaled by `10^wc_get_price_decimals()`, rounded, and compared as integers so that “order total equals gift + other” is evaluated in the smallest currency unit and is robust to float precision.

Closes https://linear.app/a8c/issue/SQUARE-242/the-sum-of-partial-totals-does-not-match-the-order-total.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. (`in trunk`) Create an order that uses a Square gift card for part of the total (e.g. order total 62.48, gift card 50, remaining 12.48 on card). For ease, to make the sandbox gift card amount from $1 to $50, put this file in the `/mu-plugins` folder: [square-gift-card-amount-overwrite.php](https://gist.github.com/faisal-alvi/c0a9c3e6fdbcc563fcf5e2b4d07f8575)
2. Proceed to checkout and place the order with the split payment (gift card + other gateway).
3. See the error in `trunk` > `"The sum of partial totals does not match the order total."`
4. Switch to the fixed branch and try again.
5. Confirm the order completes without any error.
6. Repeat with different amounts and with 2-decimal and higher-decimal store settings to ensure verification still passes when amounts are correct.

### Changelog entry

> Fix - Partial-Total Verification when Gift Card is used