### PR TITLE
Docs: Add minimal agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+## Project Knowledge
+
+- WooCommerce Square plugin: WooCommerce payments + catalog/inventory sync with Square.
+- Main PHP runtime code is in `includes/`.
+- JS/CSS sources are in `src/`; built artifacts are in `build/`.
+- Plugin bootstrap and version constants are in `woocommerce-square.php`.
+
+## CRITICAL
+
+- Keep `CLAUDE.md` as `@AGENTS.md` so this file is the single source of truth.
+- Edit `src/`, not `build/`; do not edit `vendor/` or WordPress/WooCommerce core.
+- Never commit secrets (Square credentials stay in local env files/secrets).
+
+## Commands
+
+- Setup: `nvm use && npm ci && composer install`
+- Build package: `npm run build`
+- JS lint: `npm run lint:js`
+- PHP lint: `./vendor/bin/phpcs`
+- Start local env: `npm run env:start`
+- Stop local env: `npm run env:stop`
+- Env health check: `curl -fsS -I http://localhost:8888 | head -n 1`
+- Square plugin status (CLI): `wp-env run cli wp plugin is-active woocommerce-square && echo ACTIVE || echo INACTIVE`
+- E2E tests: `npm run test:e2e` (requires Square credentials in `tests/e2e/config/.env`)
+
+## Conventions
+
+- Main development branch is `trunk`; release branches use `release/{version}`.
+- Changelog entries in `changelog.txt` use prefixes: `Add -`, `Fix -`, `Dev -`.
+- Playwright E2E test titles MUST include one tag: `@general`, `@giftcard`, `@cashapp`, or `@sync`.
+
+## Architectural Notes
+
+- Bootstrap flow is defined by `WooCommerce_Square_Loader` in `woocommerce-square.php`.
+- Plugin namespace `WooCommerce\\Square\\` maps to `includes/`.
+- `build/` is generated output from `src/`; avoid hand edits.
+
+## Common Pitfalls
+
+- `npm run env:start` can exit non-zero when optional test plugins are unavailable; confirm env status using the health check command.
+- Browser-level Square status checks should use `/wp-admin/plugins.php` and `tr[data-slug="woocommerce-square"]`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Across Automattic, we're attempting to improve the agent experience of our codebases. At a high level, this includes the following:

- **Guidelines**: The repo tells agents what they need to know: project structure, conventions, gotchas, and explicit instructions via AGENTS.md, CLAUDE.md, and skills. A developer can point an agent at the repo and it understands how to work in it. See the Field Guide article linked above the table.
- **Build & Tests**: An agent can build the project and run tests on its own. It can verify its code compiles and doesn't break existing functionality without human hand-holding.
- **E2E Verification**: An agent can check that its changes actually work — not just that tests pass, but that the feature behaves correctly from a user's perspective (e.g. local dev server, preview URL).
- **Isolated ENV**: An agent can work in a sandboxed environment where it's safe to experiment. Mistakes don't touch production or shared state, so developers can let agents run with less supervision.

### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Add AGENTS.md and CLAUDE.md with minimal guidance for agents. 

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Checkout branch
2. Ask agent (Claude Code or Codex) to do things like build the plugin or to use playwright to determine the state of the plugin.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Add - Agent guidance for development.

Closes #456

Closes #457

Closes #458

Closes #460

Closes #461