### PR TITLE
CI: bump plugin-check action to v1.1.5

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Run plugin check
-      uses: wordpress/plugin-check-action@70f38272b2beee386e973f319591baa2fc7dff16 # v1.1.2
+      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
       with:
         exclude-checks: |
           plugin_readme


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

This PR updates the GitHub Action pin in `woocommerce-square/.github/workflows/plugin-check.yml`:

- `wordpress/plugin-check-action` from `70f38272b2beee386e973f319591baa2fc7dff16` (`v1.1.2`)
- to `6f5a57e173c065a394b78688f75df543e4011902` (`v1.1.5`)

Reason:
- The previous action version path led to Plugin Check failures in CI with:
  - `Error: Required file 'cli.php' doesn't exist (from runtime argument)`
- `v1.1.5` includes the upstream fix to use `plugin-check.zip` and is intended to resolve this CI failure mode.

### Steps to test the changes in this Pull Request:

1. Check out this branch and confirm the action pin in `woocommerce-square/.github/workflows/plugin-check.yml`.
2. Open/update a PR from this branch (or push) to trigger the **WordPress Plugin Checks** workflow.
3. Verify the `test` job completes without the `Required file 'cli.php' doesn't exist` error.

Also, see that the plugin checks comment exists on this PR.

### Changelog entry

> Dev - Bump WordPress `plugin-check-action` to `v1.1.5` in CI to address Plugin Check runner path failures.

Closes #463 