### PR TITLE
Remove wc_enqueue_js() function

### DIFF
--- a/includes/Framework/Admin_Notice_Handler.php
+++ b/includes/Framework/Admin_Notice_Handler.php
@@ -307,10 +307,7 @@ class Admin_Notice_Handler {
 		} )( jQuery );
 		<?php
 		$javascript = ob_get_clean();
-		$handle     = 'wc-square-admin-notice-inline';
-		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-admin-notice-inline', $javascript );
 	}
 
 

--- a/includes/Framework/Admin_Notice_Handler.php
+++ b/includes/Framework/Admin_Notice_Handler.php
@@ -260,52 +260,57 @@ class Admin_Notice_Handler {
 
 		ob_start();
 		?>
+		( function( $ ) {
+			$( function() {
+				// Log dismissed notices
+				$( '.js-wc-plugin-framework-admin-notice' ).on( 'click.wp-dismiss-notice', '.notice-dismiss', function( e ) {
 
-		// Log dismissed notices
-		$( '.js-wc-plugin-framework-admin-notice' ).on( 'click.wp-dismiss-notice', '.notice-dismiss', function( e ) {
+					var $notice = $( this ).closest( '.js-wc-plugin-framework-admin-notice' );
 
-			var $notice = $( this ).closest( '.js-wc-plugin-framework-admin-notice' );
+					log_dismissed_notice(
+						$( $notice ).data( 'plugin-id' ),
+						$( $notice ).data( 'message-id' )
+					);
 
-			log_dismissed_notice(
-				$( $notice ).data( 'plugin-id' ),
-				$( $notice ).data( 'message-id' )
-			);
+				} );
 
-		} );
+				// Log and hide legacy notices
+				$( 'a.js-wc-plugin-framework-notice-dismiss' ).click( function( e ) {
 
-		// Log and hide legacy notices
-		$( 'a.js-wc-plugin-framework-notice-dismiss' ).click( function( e ) {
+					e.preventDefault();
 
-			e.preventDefault();
+					var $notice = $( this ).closest( '.js-wc-plugin-framework-admin-notice' );
 
-			var $notice = $( this ).closest( '.js-wc-plugin-framework-admin-notice' );
+					log_dismissed_notice(
+						$( $notice ).data( 'plugin-id' ),
+						$( $notice ).data( 'message-id' )
+					);
 
-			log_dismissed_notice(
-				$( $notice ).data( 'plugin-id' ),
-				$( $notice ).data( 'message-id' )
-			);
+					$( $notice ).fadeOut();
 
-			$( $notice ).fadeOut();
+				} );
 
-		} );
+				function log_dismissed_notice( pluginID, messageID ) {
 
-		function log_dismissed_notice( pluginID, messageID ) {
-
-			$.get(
-				'<?php echo esc_url( $ajax_url ); ?>',
-				{
-					action:    'wc_plugin_framework_' + pluginID + '_dismiss_notice',
-					messageid: messageID
+					$.get(
+						'<?php echo esc_url( $ajax_url ); ?>',
+						{
+							action:    'wc_plugin_framework_' + pluginID + '_dismiss_notice',
+							messageid: messageID
+						}
+					);
 				}
-			);
-		}
 
-		// move any delayed notices up into position .show();
-		$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
+				// move any delayed notices up into position .show();
+				$( '.js-wc-plugin-framework-admin-notice:hidden' ).insertAfter( '.js-wc-<?php echo esc_js( $plugin_slug ); ?>-admin-notice-placeholder' ).show();
+			} );
+		} )( jQuery );
 		<?php
 		$javascript = ob_get_clean();
-
-		wc_enqueue_js( $javascript );
+		$handle     = 'wc-square-admin-notice-inline';
+		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 	}
 
 

--- a/includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php
+++ b/includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php
@@ -210,7 +210,17 @@ class Payment_Gateway_Apple_Pay_Frontend {
 		 */
 		$args = apply_filters( 'sv_wc_apple_pay_product_handler_args', $args );
 
-		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Product_Handler(%s);', wp_json_encode( $args ) ) );
+		ob_start();
+		?>
+		( function() {
+			window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Product_Handler(<?php echo wp_json_encode( $args ); ?>);
+		} )();
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-apple-pay-product-inline';
+		wp_register_script( $handle, '', array( 'jquery', 'wc-square-apple-pay' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 
 		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'render_button' ) );
 	}
@@ -247,7 +257,17 @@ class Payment_Gateway_Apple_Pay_Frontend {
 		 */
 		$args = apply_filters( 'sv_wc_apple_pay_cart_handler_args', $args );
 
-		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Cart_Handler(%s);', wp_json_encode( $args ) ) );
+		ob_start();
+		?>
+		( function() {
+			window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Cart_Handler(<?php echo wp_json_encode( $args ); ?>);
+		} )();
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-apple-pay-cart-inline';
+		wp_register_script( $handle, '', array( 'jquery', 'wc-square-apple-pay' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 
 		add_action( 'woocommerce_proceed_to_checkout', array( $this, 'render_button' ) );
 	}
@@ -271,7 +291,17 @@ class Payment_Gateway_Apple_Pay_Frontend {
 		 */
 		$args = apply_filters( 'sv_wc_apple_pay_checkout_handler_args', array() );
 
-		wc_enqueue_js( sprintf( 'window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Checkout_Handler(%s);', wp_json_encode( $args ) ) );
+		ob_start();
+		?>
+		( function() {
+			window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Checkout_Handler(<?php echo wp_json_encode( $args ); ?>);
+		} )();
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-apple-pay-checkout-inline';
+		wp_register_script( $handle, '', array( 'jquery', 'wc-square-apple-pay' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 
 		if ( $this->get_plugin()->is_plugin_active( 'woocommerce-checkout-add-ons.php' ) ) {
 			add_action( 'woocommerce_review_order_before_payment', array( $this, 'render_button' ) );

--- a/includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php
+++ b/includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php
@@ -217,7 +217,7 @@ class Payment_Gateway_Apple_Pay_Frontend {
 		});
 		<?php
 		$javascript = ob_get_clean();
-		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-product-inline', $javascript, [ 'jquery', 'wc-square-apple-pay' ] );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-product-inline', $javascript, array( 'jquery', 'wc-square-apple-pay' ) );
 
 		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'render_button' ) );
 	}
@@ -261,7 +261,7 @@ class Payment_Gateway_Apple_Pay_Frontend {
 		});
 		<?php
 		$javascript = ob_get_clean();
-		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-cart-inline', $javascript, [ 'jquery', 'wc-square-apple-pay' ] );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-cart-inline', $javascript, array( 'jquery', 'wc-square-apple-pay' ) );
 
 		add_action( 'woocommerce_proceed_to_checkout', array( $this, 'render_button' ) );
 	}
@@ -292,7 +292,7 @@ class Payment_Gateway_Apple_Pay_Frontend {
 		});
 		<?php
 		$javascript = ob_get_clean();
-		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-checkout-inline', $javascript, [ 'jquery', 'wc-square-apple-pay' ] );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-checkout-inline', $javascript, array( 'jquery', 'wc-square-apple-pay' ) );
 
 		if ( $this->get_plugin()->is_plugin_active( 'woocommerce-checkout-add-ons.php' ) ) {
 			add_action( 'woocommerce_review_order_before_payment', array( $this, 'render_button' ) );

--- a/includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php
+++ b/includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php
@@ -212,15 +212,12 @@ class Payment_Gateway_Apple_Pay_Frontend {
 
 		ob_start();
 		?>
-		( function() {
+		jQuery(function($) {
 			window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Product_Handler(<?php echo wp_json_encode( $args ); ?>);
-		} )();
+		});
 		<?php
 		$javascript = ob_get_clean();
-		$handle     = 'wc-square-apple-pay-product-inline';
-		wp_register_script( $handle, '', array( 'jquery', 'wc-square-apple-pay' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-product-inline', $javascript, [ 'jquery', 'wc-square-apple-pay' ] );
 
 		add_action( 'woocommerce_before_add_to_cart_button', array( $this, 'render_button' ) );
 	}
@@ -259,15 +256,12 @@ class Payment_Gateway_Apple_Pay_Frontend {
 
 		ob_start();
 		?>
-		( function() {
+		jQuery(function($) {
 			window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Cart_Handler(<?php echo wp_json_encode( $args ); ?>);
-		} )();
+		});
 		<?php
 		$javascript = ob_get_clean();
-		$handle     = 'wc-square-apple-pay-cart-inline';
-		wp_register_script( $handle, '', array( 'jquery', 'wc-square-apple-pay' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-cart-inline', $javascript, [ 'jquery', 'wc-square-apple-pay' ] );
 
 		add_action( 'woocommerce_proceed_to_checkout', array( $this, 'render_button' ) );
 	}
@@ -293,15 +287,12 @@ class Payment_Gateway_Apple_Pay_Frontend {
 
 		ob_start();
 		?>
-		( function() {
+		jQuery(function($) {
 			window.sv_wc_apple_pay_handler = new Square_Apple_Pay_Checkout_Handler(<?php echo wp_json_encode( $args ); ?>);
-		} )();
+		});
 		<?php
 		$javascript = ob_get_clean();
-		$handle     = 'wc-square-apple-pay-checkout-inline';
-		wp_register_script( $handle, '', array( 'jquery', 'wc-square-apple-pay' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-apple-pay-checkout-inline', $javascript, [ 'jquery', 'wc-square-apple-pay' ] );
 
 		if ( $this->get_plugin()->is_plugin_active( 'woocommerce-checkout-add-ons.php' ) ) {
 			add_action( 'woocommerce_review_order_before_payment', array( $this, 'render_button' ) );

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -1423,10 +1423,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			} )( jQuery );
 			<?php
 			$javascript = ob_get_clean();
-			$handle     = 'wc-square-gateway-admin-csc';
-			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-			wp_enqueue_script( $handle );
-			wp_add_inline_script( $handle, $javascript );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gateway-admin-csc', $javascript );
 		}
 
 		// if transaction types are supported, show/hide the "charge virtual-only" setting
@@ -1453,10 +1450,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			} )( jQuery );
 			<?php
 			$javascript = ob_get_clean();
-			$handle     = 'wc-square-gateway-admin-transaction-type';
-			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-			wp_enqueue_script( $handle );
-			wp_add_inline_script( $handle, $javascript );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gateway-admin-transaction-type', $javascript );
 		}
 
 		// if there's more than one environment include the environment settings switcher code
@@ -1490,10 +1484,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			} )( jQuery );
 			<?php
 			$javascript = ob_get_clean();
-			$handle     = 'wc-square-gateway-admin-environment';
-			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-			wp_enqueue_script( $handle );
-			wp_add_inline_script( $handle, $javascript );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gateway-admin-environment', $javascript );
 		}
 
 		if ( ! empty( $this->shared_settings ) ) {
@@ -1522,10 +1513,7 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			} )( jQuery );
 			<?php
 			$javascript = ob_get_clean();
-			$handle     = 'wc-square-gateway-admin-inherit-settings';
-			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-			wp_enqueue_script( $handle );
-			wp_add_inline_script( $handle, $javascript );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gateway-admin-inherit-settings', $javascript );
 		}
 
 	}

--- a/includes/Framework/PaymentGateway/Payment_Gateway.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway.php
@@ -1406,21 +1406,27 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript to show/hide any shared settings fields as needed
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_csc' ).change( function() {
+			( function( $ ) {
+				$( function() {
+					$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_csc' ).change( function() {
 
-					var enabled = $( this ).is( ':checked' );
+						var enabled = $( this ).is( ':checked' );
 
-					if ( enabled ) {
-						$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_token_csc' ).closest( 'tr' ).show();
-					} else {
-						$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_token_csc' ).closest( 'tr' ).hide();
-					}
+						if ( enabled ) {
+							$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_token_csc' ).closest( 'tr' ).show();
+						} else {
+							$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_token_csc' ).closest( 'tr' ).hide();
+						}
 
-				} ).change();
+					} ).change();
+				} );
+			} )( jQuery );
 			<?php
-
-			wc_enqueue_js( ob_get_clean() );
-
+			$javascript = ob_get_clean();
+			$handle     = 'wc-square-gateway-admin-csc';
+			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+			wp_enqueue_script( $handle );
+			wp_add_inline_script( $handle, $javascript );
 		}
 
 		// if transaction types are supported, show/hide the "charge virtual-only" setting
@@ -1429,21 +1435,28 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_transaction_type' ).change( function() {
+			( function( $ ) {
+				$( function() {
+					$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_transaction_type' ).change( function() {
 
-					var transaction_type = $( this ).val();
-					var hidden_settings   = $( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_charge_virtual_orders, #woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_partial_capture, #woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_paid_capture' ).closest( 'tr' );
+						var transaction_type = $( this ).val();
+						var hidden_settings   = $( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_charge_virtual_orders, #woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_partial_capture, #woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_paid_capture' ).closest( 'tr' );
 
-					if ( '<?php echo esc_js( self::TRANSACTION_TYPE_AUTHORIZATION ); ?>' === transaction_type ) {
-						$( hidden_settings ).show();
-					} else {
-						$( hidden_settings ).hide();
-					}
+						if ( '<?php echo esc_js( self::TRANSACTION_TYPE_AUTHORIZATION ); ?>' === transaction_type ) {
+							$( hidden_settings ).show();
+						} else {
+							$( hidden_settings ).hide();
+						}
 
-				} ).change();
+					} ).change();
+				} );
+			} )( jQuery );
 			<?php
-
-			wc_enqueue_js( ob_get_clean() );
+			$javascript = ob_get_clean();
+			$handle     = 'wc-square-gateway-admin-transaction-type';
+			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+			wp_enqueue_script( $handle );
+			wp_add_inline_script( $handle, $javascript );
 		}
 
 		// if there's more than one environment include the environment settings switcher code
@@ -1452,29 +1465,35 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_environment' ).change( function() {
+			( function( $ ) {
+				$( function() {
+					$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_environment' ).change( function() {
 
-					// inherit settings from other gateway?
-					var inheritSettings = $( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_inherit_settings' ).is( ':checked' );
+						// inherit settings from other gateway?
+						var inheritSettings = $( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_inherit_settings' ).is( ':checked' );
 
-					var environment = $( this ).val();
+						var environment = $( this ).val();
 
-					// hide all environment-dependant fields
-					$( '.environment-field' ).closest( 'tr' ).hide();
+						// hide all environment-dependant fields
+						$( '.environment-field' ).closest( 'tr' ).hide();
 
-					// show the currently configured environment fields that are not also being hidden as any shared settings
-					var $environmentFields = $( '.' + environment + '-field' );
-					if ( inheritSettings ) {
-						$environmentFields = $environmentFields.not( '.shared-settings-field' );
-					}
+						// show the currently configured environment fields that are not also being hidden as any shared settings
+						var $environmentFields = $( '.' + environment + '-field' );
+						if ( inheritSettings ) {
+							$environmentFields = $environmentFields.not( '.shared-settings-field' );
+						}
 
-					$environmentFields.not( '.hidden' ).closest( 'tr' ).show();
+						$environmentFields.not( '.hidden' ).closest( 'tr' ).show();
 
-				} ).change();
+					} ).change();
+				} );
+			} )( jQuery );
 			<?php
-
-			wc_enqueue_js( ob_get_clean() );
-
+			$javascript = ob_get_clean();
+			$handle     = 'wc-square-gateway-admin-environment';
+			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+			wp_enqueue_script( $handle );
+			wp_add_inline_script( $handle, $javascript );
 		}
 
 		if ( ! empty( $this->shared_settings ) ) {
@@ -1482,25 +1501,31 @@ abstract class Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript to show/hide any shared settings fields as needed
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_inherit_settings' ).change( function() {
+			( function( $ ) {
+				$( function() {
+					$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_inherit_settings' ).change( function() {
 
-					var enabled = $( this ).is( ':checked' );
+						var enabled = $( this ).is( ':checked' );
 
-					if ( enabled ) {
-						$( '.shared-settings-field' ).closest( 'tr' ).hide();
-					} else {
-						// show the fields
-						$( '.shared-settings-field' ).closest( 'tr' ).show();
+						if ( enabled ) {
+							$( '.shared-settings-field' ).closest( 'tr' ).hide();
+						} else {
+							// show the fields
+							$( '.shared-settings-field' ).closest( 'tr' ).show();
 
-						// hide any that may not be available for the currently selected environment
-						$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_environment' ).change();
-					}
+							// hide any that may not be available for the currently selected environment
+							$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_environment' ).change();
+						}
 
-				} ).change();
+					} ).change();
+				} );
+			} )( jQuery );
 			<?php
-
-			wc_enqueue_js( ob_get_clean() );
-
+			$javascript = ob_get_clean();
+			$handle     = 'wc-square-gateway-admin-inherit-settings';
+			wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+			wp_enqueue_script( $handle );
+			wp_add_inline_script( $handle, $javascript );
 		}
 
 	}

--- a/includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php
@@ -868,14 +868,12 @@ class Payment_Gateway_Payment_Form {
 
 		ob_start();
 		?>
-		( function() {
+		jQuery(function($) {
 			window.wc_<?php echo esc_js( $this->get_gateway()->get_id() ); ?>_payment_form_handler = new WC_Square_Payment_Form_Handler( <?php echo wp_json_encode( $args ); ?> );
-		} )();
+		});
 		<?php
 		$javascript = ob_get_clean();
 		$handle     = 'wc-square-' . str_replace( '_', '-', $this->get_gateway()->get_id() ) . '-payment-form-inline';
-		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( $handle, $javascript, [ 'jquery', 'wc-square' ] );
 	}
 }

--- a/includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php
@@ -866,6 +866,16 @@ class Payment_Gateway_Payment_Form {
 		 */
 		$args = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_js_args', $args, $this );
 
-		wc_enqueue_js( sprintf( 'window.wc_%s_payment_form_handler = new WC_Square_Payment_Form_Handler( %s );', esc_js( $this->get_gateway()->get_id() ), wp_json_encode( $args ) ) );
+		ob_start();
+		?>
+		( function() {
+			window.wc_<?php echo esc_js( $this->get_gateway()->get_id() ); ?>_payment_form_handler = new WC_Square_Payment_Form_Handler( <?php echo wp_json_encode( $args ); ?> );
+		} )();
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-' . str_replace( '_', '-', $this->get_gateway()->get_id() ) . '-payment-form-inline';
+		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 	}
 }

--- a/includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php
@@ -874,6 +874,6 @@ class Payment_Gateway_Payment_Form {
 		<?php
 		$javascript = ob_get_clean();
 		$handle     = 'wc-square-' . str_replace( '_', '-', $this->get_gateway()->get_id() ) . '-payment-form-inline';
-		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( $handle, $javascript, [ 'jquery', 'wc-square' ] );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( $handle, $javascript, array( 'jquery', 'wc-square' ) );
 	}
 }

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -1281,7 +1281,17 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 		 */
 		$args = apply_filters( 'wc_' . $this->get_id() . '_payment_js_args', $args, $this );
 
-		wc_enqueue_js( sprintf( 'window.wc_%s_payment_handler = new WC_Square_Cash_App_Pay_Handler( %s );', esc_js( $this->get_id() ), wp_json_encode( $args ) ) );
+		ob_start();
+		?>
+		( function() {
+			window.wc_<?php echo esc_js( $this->get_id() ); ?>_payment_handler = new WC_Square_Cash_App_Pay_Handler( <?php echo wp_json_encode( $args ); ?> );
+		} )();
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-cash-app-pay-inline';
+		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 	}
 
 	/**

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -1287,15 +1287,12 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 
 		ob_start();
 		?>
-		( function() {
+		jQuery(function($) {
 			window.wc_<?php echo esc_js( $this->get_id() ); ?>_payment_handler = new WC_Square_Cash_App_Pay_Handler( <?php echo wp_json_encode( $args ); ?> );
-		} )();
+		});
 		<?php
 		$javascript = ob_get_clean();
-		$handle     = 'wc-square-cash-app-pay-inline';
-		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-cash-app-pay-inline', $javascript, [ 'jquery', 'wc-square-cash-app-pay' ] );
 	}
 
 	/**

--- a/includes/Gateway/Cash_App_Pay_Gateway.php
+++ b/includes/Gateway/Cash_App_Pay_Gateway.php
@@ -1292,7 +1292,7 @@ class Cash_App_Pay_Gateway extends Payment_Gateway {
 		});
 		<?php
 		$javascript = ob_get_clean();
-		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-cash-app-pay-inline', $javascript, [ 'jquery', 'wc-square-cash-app-pay' ] );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-cash-app-pay-inline', $javascript, array( 'jquery', 'wc-square-cash-app-pay' ) );
 	}
 
 	/**

--- a/includes/Gateway/Digital_Wallet.php
+++ b/includes/Gateway/Digital_Wallet.php
@@ -363,7 +363,7 @@ class Digital_Wallet {
 				} );
 			<?php
 			$javascript = ob_get_clean();
-			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-digital-wallet-inline', $javascript, [ 'jquery', 'wc-square-digital-wallet' ] );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-digital-wallet-inline', $javascript, array( 'jquery', 'wc-square-digital-wallet' ) );
 		} catch ( \Exception $e ) {
 			wp_dequeue_style( 'wc-square-digital-wallet' );
 			wp_dequeue_script( 'wc-square-digital-wallet' );

--- a/includes/Gateway/Digital_Wallet.php
+++ b/includes/Gateway/Digital_Wallet.php
@@ -358,15 +358,12 @@ class Digital_Wallet {
 
 			ob_start();
 			?>
-			( function() {
-				window.wc_square_digital_wallet_handler = new WC_Square_Digital_Wallet_Handler( <?php echo wp_json_encode( $args ); ?> );
-			} )();
+				jQuery(function($) { 
+					window.wc_square_digital_wallet_handler = new WC_Square_Digital_Wallet_Handler( <?php echo wp_json_encode( $args ); ?> );
+				} );
 			<?php
 			$javascript = ob_get_clean();
-			$handle     = 'wc-square-digital-wallet-inline';
-			wp_register_script( $handle, '', array( 'jquery', 'wc-square-digital-wallet' ), WC_SQUARE_PLUGIN_VERSION, true );
-			wp_enqueue_script( $handle );
-			wp_add_inline_script( $handle, $javascript );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-digital-wallet-inline', $javascript, [ 'jquery', 'wc-square-digital-wallet' ] );
 		} catch ( \Exception $e ) {
 			wp_dequeue_style( 'wc-square-digital-wallet' );
 			wp_dequeue_script( 'wc-square-digital-wallet' );

--- a/includes/Gateway/Digital_Wallet.php
+++ b/includes/Gateway/Digital_Wallet.php
@@ -356,7 +356,17 @@ class Digital_Wallet {
 				$this->get_localised_data()
 			);
 
-			wc_enqueue_js( sprintf( 'window.wc_square_digital_wallet_handler = new WC_Square_Digital_Wallet_Handler( %s );', wp_json_encode( $args ) ) );
+			ob_start();
+			?>
+			( function() {
+				window.wc_square_digital_wallet_handler = new WC_Square_Digital_Wallet_Handler( <?php echo wp_json_encode( $args ); ?> );
+			} )();
+			<?php
+			$javascript = ob_get_clean();
+			$handle     = 'wc-square-digital-wallet-inline';
+			wp_register_script( $handle, '', array( 'jquery', 'wc-square-digital-wallet' ), WC_SQUARE_PLUGIN_VERSION, true );
+			wp_enqueue_script( $handle );
+			wp_add_inline_script( $handle, $javascript );
 		} catch ( \Exception $e ) {
 			wp_dequeue_style( 'wc-square-digital-wallet' );
 			wp_dequeue_script( 'wc-square-digital-wallet' );

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -403,7 +403,7 @@ class Gift_Card extends Payment_Gateway {
 			});
 			<?php
 			$javascript = ob_get_clean();
-			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gift-card-inline', $javascript, [ 'jquery', 'wc-square-gift-card' ] );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gift-card-inline', $javascript, array( 'jquery', 'wc-square-gift-card' ) );
 		}
 
 		if ( is_checkout() || is_product() || has_block( 'woocommerce/single-product' ) ) {

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -398,15 +398,12 @@ class Gift_Card extends Payment_Gateway {
 
 			ob_start();
 			?>
-			( function() {
+			jQuery(function($) {
 				window.wc_square_gift_card_handler = new WC_Square_Gift_Card_Handler( <?php echo wp_json_encode( $args ); ?> );
-			} )();
+			});
 			<?php
 			$javascript = ob_get_clean();
-			$handle     = 'wc-square-gift-card-inline';
-			wp_register_script( $handle, '', array( 'jquery', 'wc-square-gift-card' ), WC_SQUARE_PLUGIN_VERSION, true );
-			wp_enqueue_script( $handle );
-			wp_add_inline_script( $handle, $javascript );
+			\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-gift-card-inline', $javascript, [ 'jquery', 'wc-square-gift-card' ] );
 		}
 
 		if ( is_checkout() || is_product() || has_block( 'woocommerce/single-product' ) ) {

--- a/includes/Gateway/Gift_Card.php
+++ b/includes/Gateway/Gift_Card.php
@@ -396,7 +396,17 @@ class Gift_Card extends Payment_Gateway {
 				true
 			);
 
-			wc_enqueue_js( sprintf( 'window.wc_square_gift_card_handler = new WC_Square_Gift_Card_Handler( %s );', wp_json_encode( $args ) ) );
+			ob_start();
+			?>
+			( function() {
+				window.wc_square_gift_card_handler = new WC_Square_Gift_Card_Handler( <?php echo wp_json_encode( $args ); ?> );
+			} )();
+			<?php
+			$javascript = ob_get_clean();
+			$handle     = 'wc-square-gift-card-inline';
+			wp_register_script( $handle, '', array( 'jquery', 'wc-square-gift-card' ), WC_SQUARE_PLUGIN_VERSION, true );
+			wp_enqueue_script( $handle );
+			wp_add_inline_script( $handle, $javascript );
 		}
 
 		if ( is_checkout() || is_product() || has_block( 'woocommerce/single-product' ) ) {

--- a/includes/Gateway/Payment_Form.php
+++ b/includes/Gateway/Payment_Form.php
@@ -304,18 +304,15 @@ class Payment_Form extends Payment_Gateway_Payment_Form {
 		 * @param Payment_Form $this payment form instance
 		 */
 		$args = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_js_args', $args, $this );
-
 		ob_start();
 		?>
-		( function() {
-			window.wc_<?php echo esc_js( $this->get_gateway()->get_id() ); ?>_payment_form_handler = new WC_Square_Payment_Form_Handler( <?php echo wp_json_encode( $args ); ?> );
-		} )();
+			jQuery(function($) { 
+				window.wc_<?php echo esc_js( $this->get_gateway()->get_id() ); ?>_payment_form_handler = new WC_Square_Payment_Form_Handler( <?php echo wp_json_encode( $args ); ?> );
+			});
 		<?php
 		$javascript = ob_get_clean();
 		$handle     = 'wc-square-' . str_replace( '_', '-', $this->get_gateway()->get_id() ) . '-payment-form-inline';
-		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( $handle, $javascript, [ 'jquery', 'wc-square' ] );
 	}
 
 

--- a/includes/Gateway/Payment_Form.php
+++ b/includes/Gateway/Payment_Form.php
@@ -312,7 +312,7 @@ class Payment_Form extends Payment_Gateway_Payment_Form {
 		<?php
 		$javascript = ob_get_clean();
 		$handle     = 'wc-square-' . str_replace( '_', '-', $this->get_gateway()->get_id() ) . '-payment-form-inline';
-		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( $handle, $javascript, [ 'jquery', 'wc-square' ] );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( $handle, $javascript, array( 'jquery', 'wc-square' ) );
 	}
 
 

--- a/includes/Gateway/Payment_Form.php
+++ b/includes/Gateway/Payment_Form.php
@@ -300,7 +300,17 @@ class Payment_Form extends Payment_Gateway_Payment_Form {
 		 */
 		$args = apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_js_args', $args, $this );
 
-		wc_enqueue_js( sprintf( 'window.wc_%s_payment_form_handler = new WC_Square_Payment_Form_Handler( %s );', esc_js( $this->get_gateway()->get_id() ), wp_json_encode( $args ) ) );
+		ob_start();
+		?>
+		( function() {
+			window.wc_<?php echo esc_js( $this->get_gateway()->get_id() ); ?>_payment_form_handler = new WC_Square_Payment_Form_Handler( <?php echo wp_json_encode( $args ); ?> );
+		} )();
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-' . str_replace( '_', '-', $this->get_gateway()->get_id() ) . '-payment-form-inline';
+		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 	}
 
 

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -247,13 +247,19 @@ class Products {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$selected = isset( $_GET['product_type'] ) && 'synced-with-square' === $_GET['product_type'] ? 'selected=\"selected\"' : '';
 
-		wc_enqueue_js(
-			"
-			jQuery( document ).ready( function( $ ) {
-				$( 'select#dropdown_product_type' ) . append( '<option value=\"synced-with-square\" ' + '" . $selected . "' + '>' + '" . $label . "' + '</option>' );
+		ob_start();
+		?>
+		( function( $ ) {
+			$( function() {
+				$( 'select#dropdown_product_type' ).append( '<option value="synced-with-square" <?php echo esc_js( $selected ); ?>><?php echo esc_js( $label ); ?></option>' );
 			} );
-			"
-		);
+		} )( jQuery );
+		<?php
+		$javascript = ob_get_clean();
+		$handle     = 'wc-square-products-sync-filter';
+		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
+		wp_enqueue_script( $handle );
+		wp_add_inline_script( $handle, $javascript );
 	}
 
 

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -243,15 +243,19 @@ class Products {
 
 		$label = esc_html__( 'Synced with Square', 'woocommerce-square' );
 
-		// Nonce check not required, checked against known string, read-only action.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$selected = isset( $_GET['product_type'] ) && 'synced-with-square' === $_GET['product_type'] ? 'selected=\"selected\"' : '';
-
 		ob_start();
 		?>
 		( function( $ ) {
 			$( function() {
-				$( 'select#dropdown_product_type' ).append( '<option value="synced-with-square" <?php echo esc_js( $selected ); ?>><?php echo esc_js( $label ); ?></option>' );
+				$( 'select#dropdown_product_type' ).append(
+					$( '<option>', {
+						value: 'synced-with-square',
+						text: '<?php echo esc_js( $label ); ?>',
+						<?php // Nonce check not required, checked against known string, read-only action. ?>
+						<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
+						selected: <?php echo isset( $_GET['product_type'] ) && 'synced-with-square' === $_GET['product_type'] ? 'true' : 'false'; ?>
+					} )
+				);
 			} );
 		} )( jQuery );
 		<?php

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -256,10 +256,7 @@ class Products {
 		} )( jQuery );
 		<?php
 		$javascript = ob_get_clean();
-		$handle     = 'wc-square-products-sync-filter';
-		wp_register_script( $handle, '', array( 'jquery' ), WC_SQUARE_PLUGIN_VERSION, true );
-		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, $javascript );
+		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-products-sync-filter', $javascript );
 	}
 
 

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -243,21 +243,17 @@ class Products {
 
 		$label = esc_html__( 'Synced with Square', 'woocommerce-square' );
 
+		// Nonce check not required, checked against known string, read-only action.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$selected = isset( $_GET['product_type'] ) && 'synced-with-square' === $_GET['product_type'] ? 'selected="selected"' : '';
+
 		ob_start();
 		?>
-		( function( $ ) {
-			$( function() {
-				$( 'select#dropdown_product_type' ).append(
-					$( '<option>', {
-						value: 'synced-with-square',
-						text: '<?php echo esc_js( $label ); ?>',
-						<?php // Nonce check not required, checked against known string, read-only action. ?>
-						<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
-						selected: <?php echo isset( $_GET['product_type'] ) && 'synced-with-square' === $_GET['product_type'] ? 'true' : 'false'; ?>
-					} )
-				);
-			} );
-		} )( jQuery );
+		jQuery( document ).ready( function( $ ) {
+			<?php // Not escaping as we know the value is not user-controlled and avoids issue with outputting `selected=""selected""` ?>
+			<?php // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+			$( 'select#dropdown_product_type' ).append( '<option value="synced-with-square" <?php echo $selected; ?>><?php echo esc_js( $label ); ?></option>' );
+		} );
 		<?php
 		$javascript = ob_get_clean();
 		\WooCommerce\Square\Utilities\Helper::enqueue_inline_script( 'wc-square-products-sync-filter', $javascript );

--- a/includes/Utilities/Helper.php
+++ b/includes/Utilities/Helper.php
@@ -88,11 +88,11 @@ class Helper {
 	 * @since 5.3.0
 	 * @param string      $script_handle  Script handle.
 	 * @param string      $javascript     Inline JavaScript code.
-	 * @param array       $dependencies   Optional. Script dependencies. Default [ 'jquery' ].
+	 * @param array       $dependencies   Optional. Script dependencies. Default array( 'jquery' ).
 	 * @param string|null $version        Optional. Script version. Default WC_Braintree::VERSION.
 	 * @param bool        $in_footer      Optional. Whether to enqueue in footer. Default true.
 	 */
-	public static function enqueue_inline_script( string $script_handle, string $javascript, array $dependencies = [ 'jquery' ], ?string $version = null, bool $in_footer = true ): void {
+	public static function enqueue_inline_script( string $script_handle, string $javascript, array $dependencies = array( 'jquery' ), ?string $version = null, bool $in_footer = true ): void {
 		$version = $version ?? WC_SQUARE_PLUGIN_VERSION;
 		wp_register_script( $script_handle, '', $dependencies, $version, $in_footer );
 		wp_enqueue_script( $script_handle );

--- a/includes/Utilities/Helper.php
+++ b/includes/Utilities/Helper.php
@@ -81,4 +81,21 @@ class Helper {
 
 		return defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
 	}
+
+	/**
+	 * Registers, enqueues, and adds an inline script (replaces repeated wp_register_script + wp_enqueue_script + wp_add_inline_script).
+	 *
+	 * @since 5.3.0
+	 * @param string      $script_handle  Script handle.
+	 * @param string      $javascript     Inline JavaScript code.
+	 * @param array       $dependencies   Optional. Script dependencies. Default [ 'jquery' ].
+	 * @param string|null $version        Optional. Script version. Default WC_Braintree::VERSION.
+	 * @param bool        $in_footer      Optional. Whether to enqueue in footer. Default true.
+	 */
+	public static function enqueue_inline_script( string $script_handle, string $javascript, array $dependencies = [ 'jquery' ], ?string $version = null, bool $in_footer = true ): void {
+		$version = $version ?? WC_SQUARE_PLUGIN_VERSION;
+		wp_register_script( $script_handle, '', $dependencies, $version, $in_footer );
+		wp_enqueue_script( $script_handle );
+		wp_add_inline_script( $script_handle, $javascript );
+	}
 }

--- a/includes/Utilities/Helper.php
+++ b/includes/Utilities/Helper.php
@@ -89,7 +89,7 @@ class Helper {
 	 * @param string      $script_handle  Script handle.
 	 * @param string      $javascript     Inline JavaScript code.
 	 * @param array       $dependencies   Optional. Script dependencies. Default array( 'jquery' ).
-	 * @param string|null $version        Optional. Script version. Default WC_Braintree::VERSION.
+	 * @param string|null $version        Optional. Script version. Default WC_SQUARE_PLUGIN_VERSION.
 	 * @param bool        $in_footer      Optional. Whether to enqueue in footer. Default true.
 	 */
 	public static function enqueue_inline_script( string $script_handle, string $javascript, array $dependencies = array( 'jquery' ), ?string $version = null, bool $in_footer = true ): void {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This PR updates the codebase to use WordPress core script enqueuing functions instead of the deprecated wc_enqueue_js helper, following WordPress coding standards and best practices.

Closes https://linear.app/a8c/issue/SQUARE-245/remove-wc-enqueue-js-function 

### Steps to test the changes in this Pull Request:
## 1. Products list – “Synced with Square” filter (Admin)

**File:** `includes/Handlers/Products.php`

**What’s affected:** The “Synced with Square” option is added to the product type dropdown on the admin Products list. Selecting it filters products by Square sync status.

**Steps to test:**
1. Go to **Products** in the admin.
2. Open the **product type** dropdown (e.g. “All products” / “Filter by type”).
3. Confirm **“Synced with Square”** appears as an option.
4. Select **“Synced with Square”**. The list should filter to show only products synced with Square (or behave as before).
5. In **DevTools → Console**, confirm no JavaScript errors on the Products list page.

---

## 2. Payment form handler – Credit card (Frontend)

**File:** `includes/Gateway/Payment_Form.php` (and `includes/Framework/PaymentGateway/Payment_Gateway_Payment_Form.php`)

**What’s affected:** Initialization of the credit card payment form (hosted fields) on checkout. The form handler is created with the correct gateway args.

**Steps to test:**
1. Ensure **Square** (credit card) is enabled and configured.
2. Add a product to the cart and go to **Checkout**.
3. Select **Square** (or the relevant card) as the payment method.
4. Confirm the **card fields** (number, expiry, CSC, etc.) load and are usable. Enter test card details and confirm validation/place order behaves as before.
5. In **DevTools → Console**, confirm no errors when the payment form loads or when placing an order.

---

## 3. Gift card (Frontend)

**File:** `includes/Gateway/Gift_Card.php`

**What’s affected:** Gift card handler init on checkout and product pages (apply gift card, balance, etc.).

**Steps to test:**
1. Ensure **Square Gift Card** is enabled.
2. On **Checkout** (or product page if applicable), confirm the **gift card** section/fields appear (e.g. apply gift card, balance).
3. Apply a gift card (or use the UI as before) and confirm the handler responds (balance update, validation, errors if invalid).
4. In **DevTools → Console**, confirm no errors when the gift card block loads or when applying a card.

---

## 4. Digital wallet (Frontend)

**File:** `includes/Gateway/Digital_Wallet.php`

**What’s affected:** Digital wallet handler init (e.g. Apple Pay / Google Pay via Square) on checkout or product.

**Steps to test:**
1. Ensure **Square Digital Wallet** (or the relevant wallet option) is enabled.
2. On **Checkout** or a **product page**, confirm the **digital wallet** button(s) (e.g. Apple Pay, Google Pay) appear.
3. Click the button (or simulate as far as your environment allows). The handler should initialize and attempt the wallet flow or show the expected error.
4. In **DevTools → Console**, confirm no errors when the page loads or when clicking the wallet button.

---

## 5. Cash App Pay (Frontend)

**File:** `includes/Gateway/Cash_App_Pay_Gateway.php`

**What’s affected:** Cash App Pay payment handler init on checkout.

**Steps to test:**
1. Ensure **Cash App Pay** is enabled for Square.
2. Add a product to the cart and go to **Checkout**.
3. Confirm the **Cash App Pay** option/button appears.
4. Click it and confirm the Cash App flow starts (or expected error in unsupported cases). Complete or cancel as applicable.
5. In **DevTools → Console**, confirm no errors when the checkout loads or when using Cash App Pay.

---

## 6. Gateway admin – CSC, Transaction type, Environment, Inherit settings (Admin)

**File:** `includes/Framework/PaymentGateway/Payment_Gateway.php`

**What’s affected:** Four inline scripts on Square gateway settings:
- **CSC:** Show/hide “Tokenization CSC” (or similar) when “Enable card security code” is toggled.
- **Transaction type:** Show/hide “Charge virtual-only”, “Partial capture”, “Paid capture” when transaction type (e.g. Authorization vs Charge) changes.
- **Environment:** Show/hide production vs sandbox fields when Environment dropdown changes.
- **Inherit settings:** Show/hide shared-settings fields when “Inherit settings” is toggled.

**Steps to test:**
1. Go to **WooCommerce → Settings → Payments** and open a **Square** gateway (e.g. Credit Card or main Square).
2. **CSC:** If the gateway has “Enable card security code” and “Tokenization CSC”, toggle **Enable card security code**. The tokenization CSC row should show/hide accordingly.
3. **Transaction type:** Change **Transaction type** (e.g. Authorization vs Charge). Rows for charge virtual-only, partial capture, paid capture should show/hide as designed.
4. **Environment:** If the gateway has **Environment** (Production/Sandbox), change it. Production-only and Sandbox-only fields should show/hide.
5. **Inherit settings:** If the gateway has **Inherit settings** (or shared settings), toggle it. Shared-settings rows should show/hide; if off, trigger environment change to hide fields that don’t apply.
6. In **DevTools → Console**, confirm no errors on load or when changing any of these options.

---

## 7. Apple Pay – Product, Cart, Checkout (Frontend)

**File:** `includes/Framework/PaymentGateway/ApplePay/Payment_Gateway_Apple_Pay_Frontend.php`

**What’s affected:** Apple Pay handler init in three contexts:
- **Product page** – Apple Pay button (e.g. “Buy with Apple Pay”).
- **Cart page** – Apple Pay on cart.
- **Checkout page** – Apple Pay on checkout.

**Steps to test:**
1. Ensure **Apple Pay** is enabled and configured for Square (and that the store supports Apple Pay).
2. **Product page:** Open a product. The **Apple Pay** button should appear where configured. Click it and confirm the Apple Pay sheet/flow starts (or expected error).
3. **Cart page:** Add a product to the cart and go to the **Cart**. The Apple Pay button should appear and behave the same way.
4. **Checkout page:** Go to **Checkout**. The Apple Pay button should appear and work (or show expected error if not available).
5. In **DevTools → Console**, confirm no errors on product, cart, or checkout when the Apple Pay button is present or clicked.

---

## 8. Admin notices – Dismiss (Admin)

**File:** `includes/Framework/Admin_Notice_Handler.php`

**What’s affected:** Dismissible Square admin notices. Clicking “Dismiss” (or the notice-dismiss control) logs the dismissal and fades out the notice. Legacy dismiss links are also handled.

**Steps to test:**
1. Trigger a **Square admin notice** (e.g. by disconnecting, misconfiguration, or any flow that shows a dismissible notice).
2. On the notice, click **Dismiss** (or the X). The notice should fade out and not reappear on reload (dismissal is logged).
3. If your setup has **legacy “Dismiss” links** on notices, click one and confirm the notice hides and no errors occur.
4. In **DevTools → Console**, confirm no errors when dismissing a notice.

---

## Quick checklist

| # | Area | Where | What to verify |
|---|------|--------|----------------|
| 1 | Synced with Square filter | Admin – Products list | Dropdown option appears; filter works; no console errors |
| 2 | Payment form (credit card) | Frontend – Checkout | Card fields load and submit; no errors |
| 3 | Gift card | Frontend – Checkout / Product | Gift card UI and apply flow work; no errors |
| 4 | Digital wallet | Frontend – Checkout / Product | Wallet button(s) appear and init; no errors |
| 5 | Cash App Pay | Frontend – Checkout | Cash App Pay option works; no errors |
| 6 | Gateway admin (CSC, Transaction type, Environment, Inherit) | Admin – Square gateway settings | Toggles/dropdowns show/hide correct rows; no errors |
| 7 | Apple Pay (Product, Cart, Checkout) | Frontend – Product, Cart, Checkout | Apple Pay button appears and works; no errors |
| 8 | Admin notice dismiss | Admin – any page with Square notice | Dismiss hides notice; no errors |

---

## Console

For each item above, keep **DevTools → Console** open and confirm there are no JavaScript errors when loading the page or when using the controls (dropdowns, toggles, payment buttons, dismiss, etc.).

### Changelog entry

> Dev - Replaced wc_enqueue_js with wp_add_inline_script according to the recommended WordPress core script patterns.
