### PR TITLE
Bump WooCommerce "tested up to" version 10.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Square ===
 Contributors: woocommerce, automattic
 Tags: credit card, square, woocommerce, inventory sync
-Requires at least: 6.7
+Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 5.2.0

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Version: 5.2.0
  * Plugin URI: https://woocommerce.com/products/square/
- * Requires at least: 6.7
+ * Requires at least: 6.8
  * Tested up to: 6.9
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
@@ -22,8 +22,8 @@
  * @copyright Copyright (c) 2019, Automattic, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
  *
- * WC requires at least: 10.3
- * WC tested up to: 10.5
+ * WC requires at least: 10.4
+ * WC tested up to: 10.6
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -60,10 +60,10 @@ class WooCommerce_Square_Loader {
 	const MINIMUM_PHP_VERSION = '7.4.0';
 
 	/** minimum WordPress version required by this plugin */
-	const MINIMUM_WP_VERSION = '6.7';
+	const MINIMUM_WP_VERSION = '6.8';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '10.3';
+	const MINIMUM_WC_VERSION = '10.4';
 
 	/**
 	 * SkyVerge plugin framework version used by this plugin


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://linear.app/a8c/issue/SQUARE-255/compatibility-testing-with-woo-106-beta

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR
2. All tests should be passed.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 10.6.
> Dev - Bump WooCommerce minimum supported version to 10.4.
> Dev - Bump Wordpress minimum supported version to 6.8.