### PR TITLE
Fix fulfillment type determination logic

### DIFF
--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -279,6 +279,7 @@ class Orders extends API\Request {
 		// Determine fulfillment type based on shipping method.
 		$shipping_methods        = $order->get_shipping_methods();
 		$has_non_pickup_shipping = false;
+		$shipment_method         = null;
 
 		foreach ( $shipping_methods as $shipping_method ) {
 			if ( ! $shipping_method instanceof \WC_Order_Item_Shipping ) {
@@ -287,6 +288,7 @@ class Orders extends API\Request {
 
 			if ( ! $this->is_local_pickup_method( $shipping_method ) ) {
 				$has_non_pickup_shipping = true;
+				$shipment_method         = $shipping_method;
 				break;
 			}
 		}
@@ -316,10 +318,9 @@ class Orders extends API\Request {
 
 			$shipment_details->setRecipient( $recipient );
 
-			// Add shipping method as carrier if available.
-			foreach ( $shipping_methods as $shipping_method ) {
-				$shipment_details->setCarrier( $shipping_method->get_method_title() );
-				break; // Use first shipping method.
+			// Use a non-pickup method title as carrier to avoid labeling shipment as local pickup.
+			if ( $shipment_method instanceof \WC_Order_Item_Shipping ) {
+				$shipment_details->setCarrier( $shipment_method->get_method_title() );
 			}
 
 			$fulfillment->setShipmentDetails( $shipment_details );
@@ -443,7 +444,9 @@ class Orders extends API\Request {
 				continue;
 			}
 
-			if ( $this->is_local_pickup_method( $item ) ) {
+			// Skip local pickup methods only when they have no cost, so that any
+			// non-zero pickup charge is still represented in the Square order.
+			if ( $this->is_local_pickup_method( $item ) && 0.0 === (float) $item->get_total() ) {
 				continue;
 			}
 
@@ -471,11 +474,6 @@ class Orders extends API\Request {
 			if ( ! $item instanceof \WC_Order_Item_Shipping ) {
 				continue;
 			}
-
-			if ( $this->is_local_pickup_method( $item ) ) {
-				continue;
-			}
-
 			$total = (float) $item->get_total();
 			if ( $total <= 0 ) {
 				continue;

--- a/includes/Gateway/API/Requests/Orders.php
+++ b/includes/Gateway/API/Requests/Orders.php
@@ -277,8 +277,22 @@ class Orders extends API\Request {
 		$fulfillment->setUid( wc_square()->get_idempotency_key( '', false ) );
 
 		// Determine fulfillment type based on shipping method.
-		$shipping_methods = $order->get_shipping_methods();
-		$fulfillment_type = empty( $shipping_methods ) ? FulfillmentType::PICKUP : FulfillmentType::SHIPMENT;
+		$shipping_methods        = $order->get_shipping_methods();
+		$has_non_pickup_shipping = false;
+
+		foreach ( $shipping_methods as $shipping_method ) {
+			if ( ! $shipping_method instanceof \WC_Order_Item_Shipping ) {
+				continue;
+			}
+
+			if ( ! $this->is_local_pickup_method( $shipping_method ) ) {
+				$has_non_pickup_shipping = true;
+				break;
+			}
+		}
+
+		// Treat orders as shipment only when a non-local pickup shipping rate is present.
+		$fulfillment_type = $has_non_pickup_shipping ? FulfillmentType::SHIPMENT : FulfillmentType::PICKUP;
 		$fulfillment->setType( $fulfillment_type );
 
 		// Add fulfillment details based on type.
@@ -429,6 +443,10 @@ class Orders extends API\Request {
 				continue;
 			}
 
+			if ( $this->is_local_pickup_method( $item ) ) {
+				continue;
+			}
+
 			$line_items[] = $item;
 		}
 
@@ -451,6 +469,10 @@ class Orders extends API\Request {
 
 		foreach ( $order->get_shipping_methods() as $item ) {
 			if ( ! $item instanceof \WC_Order_Item_Shipping ) {
+				continue;
+			}
+
+			if ( $this->is_local_pickup_method( $item ) ) {
 				continue;
 			}
 
@@ -499,6 +521,17 @@ class Orders extends API\Request {
 		}
 
 		return $service_charges;
+	}
+
+	/**
+	 * Determines whether a shipping method is WooCommerce local pickup.
+	 *
+	 * @param mixed $shipping_method Shipping method candidate.
+	 * @return bool
+	 */
+	protected function is_local_pickup_method( $shipping_method ) {
+		return $shipping_method instanceof \WC_Order_Item_Shipping
+			&& 'local_pickup' === $shipping_method->get_method_id();
 	}
 
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes Local Pickup orders being mapped to shipping semantics during Square order sync.

Changes:
1. Fulfillment type mapping now treats orders as `SHIPMENT` only when a non-`local_pickup` shipping method is present.
2. `local_pickup` methods are excluded from Square shipping line items.
3. `local_pickup` methods are excluded from Square shipping service charges.
4. Added a shared helper (`is_local_pickup_method`) so pickup detection logic is centralized and reused across all relevant paths.

This ensures Local Pickup orders are sent to Square as pickup orders, not shipment orders.
This also addresses the Local Pickup sync bug tracked in #465.
Closes #465  .

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Enable bidirectional order fulfillment sync in WooCommerce Square settings, then place an order using standard WooCommerce Local Pickup (`method_id: local_pickup`) with one or more line items.
1. Inspect the Square order created for that Woo order and verify fulfillment type is `PICKUP` (not `SHIPMENT`), and verify Local Pickup is not sent as a shipping line item/service charge.
1. Place a second order using a non-pickup shipping method (for example flat rate) and verify fulfillment type is `SHIPMENT` and shipping data is present as expected.
1. Repeat both order types with coupon/tax scenarios to confirm no regression in totals/itemization behavior.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Correct Local Pickup order sync mapping so Square receives pickup fulfillments and does not treat Local Pickup as shipping lines/service charges.
