### PR TITLE
Add SKU-based lookup for Inventory Synchronization

### DIFF
--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -1206,7 +1206,7 @@ class Product {
 			}
 
 			$objects = $data->getObjects();
-			if ( empty( $objects ) || ! $objects[0] instanceof \Square\Models\CatalogObject ) {
+			if ( ! is_array( $objects ) || empty( $objects ) || ! $objects[0] instanceof \Square\Models\CatalogObject ) {
 				return null;
 			}
 
@@ -1215,7 +1215,7 @@ class Product {
 				self::set_square_item_variation_id( $product_id, $variation_id );
 			}
 
-			return $variation_id ?: null;
+			return $variation_id ? $variation_id : null;
 		} catch ( \Exception $e ) {
 			wc_square()->log( 'SKU lookup for Square variation failed: ' . $e->getMessage(), array( 'sku' => $sku ) );
 			return null;

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -1169,6 +1169,61 @@ class Product {
 
 
 	/**
+	 * Looks up a Square catalog variation ID by SKU (e.g. when mapping was lost after timeout).
+	 * Optionally persists the mapping so future syncs don't need to look it up again.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string     $sku        WooCommerce product/variation SKU.
+	 * @param int|null   $product_id Optional. Product ID to save the mapping to when found.
+	 * @param bool       $persist    Optional. Whether to save the variation ID to the product when found. Default true.
+	 * @return string|null Square variation ID if found, null otherwise.
+	 */
+	public static function get_square_variation_id_by_sku( $sku, $product_id = null, $persist = true ) {
+
+		$sku = is_string( $sku ) ? trim( $sku ) : '';
+		if ( '' === $sku ) {
+			return null;
+		}
+
+		try {
+			$exact_query = new \Square\Models\CatalogQueryExact( 'sku', $sku );
+
+			$query = new \Square\Models\CatalogQuery();
+			$query->setExactQuery( $exact_query );
+
+			$response = wc_square()->get_api()->search_catalog_objects(
+				array(
+					'object_types' => array( 'ITEM_VARIATION' ),
+					'query'        => $query,
+					'limit'        => 1,
+				)
+			);
+
+			$data = $response->get_data();
+			if ( ! $data instanceof \Square\Models\SearchCatalogObjectsResponse ) {
+				return null;
+			}
+
+			$objects = $data->getObjects();
+			if ( empty( $objects ) || ! $objects[0] instanceof \Square\Models\CatalogObject ) {
+				return null;
+			}
+
+			$variation_id = $objects[0]->getId();
+			if ( $variation_id && $product_id && $persist ) {
+				self::set_square_item_variation_id( $product_id, $variation_id );
+			}
+
+			return $variation_id ?: null;
+		} catch ( \Exception $e ) {
+			wc_square()->log( 'SKU lookup for Square variation failed: ' . $e->getMessage(), array( 'sku' => $sku ) );
+			return null;
+		}
+	}
+
+
+	/**
 	 * Returns the Square item version (if known) for the given product.
 	 *
 	 * @since 2.0.0

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1133,10 +1133,8 @@ class Manual_Synchronization extends Stepped_Job {
 
 						$child_square_id = Product::get_square_item_variation_id( $child_id, false );
 						if ( ! $child_square_id && $child->get_sku() && $sku_lookups_this_step < self::MAX_SKU_LOOKUPS_PER_PUSH_STEP ) {
+							++$sku_lookups_this_step;
 							$child_square_id = Product::get_square_variation_id_by_sku( $child->get_sku(), $child_id, true );
-							if ( $child_square_id ) {
-								++$sku_lookups_this_step;
-							}
 						}
 						$inventory_change = Product::get_inventory_change_physical_count_type( $child );
 
@@ -1147,17 +1145,15 @@ class Manual_Synchronization extends Stepped_Job {
 				} else {
 					// Simple product: try SKU-based lookup if unmapped but synced (e.g. mapping lost after timeout).
 					if ( ! $square_variation_id && $product->get_sku() && $product->get_manage_stock() && $sku_lookups_this_step < self::MAX_SKU_LOOKUPS_PER_PUSH_STEP ) {
+						++$sku_lookups_this_step;
 						$square_variation_id = Product::get_square_variation_id_by_sku( $product->get_sku(), $product_id, true );
-						if ( $square_variation_id ) {
-							++$sku_lookups_this_step;
-						}
 					}
 
 					if ( $square_variation_id ) {
 
 						$inventory_change = Product::get_inventory_change_physical_count_type( $product );
 
-						if ( $inventory_change ) {
+						if ( $inventory_change && $product->get_manage_stock() ) {
 							$product_inventory_changes[] = $inventory_change;
 						}
 					}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -49,6 +49,9 @@ class Manual_Synchronization extends Stepped_Job {
 	/** @var int the limit for how many inventory changes can be made in a single request */
 	const BATCH_CHANGE_INVENTORY_LIMIT = 100;
 
+	/** @var int max SKU-based lookups per push_inventory step to avoid rate limits */
+	const MAX_SKU_LOOKUPS_PER_PUSH_STEP = 20;
+
 	/** @var int the limit for how many inventory counts can be requested per batch
 	 * Square paginates responses in page size of 100.
 	 * Consider some items can have more than one object returned with different states. */
@@ -1106,6 +1109,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$product_ids            = $this->get_attr( 'inventory_push_product_ids', array() );
 		$count                  = $this->get_attr( 'push_inventory_count', 0 );
+		$sku_lookups_this_step  = 0;
 		$inventory_changes      = array();
 		$inventory_change_count = 0;
 
@@ -1122,21 +1126,40 @@ class Manual_Synchronization extends Stepped_Job {
 
 					foreach ( $product->get_children() as $child_id ) {
 
-						$child            = wc_get_product( $child_id );
+						$child = wc_get_product( $child_id );
+						if ( ! $child instanceof \WC_Product || ! $child->get_manage_stock() ) {
+							continue;
+						}
+
+						$child_square_id = Product::get_square_item_variation_id( $child_id, false );
+						if ( ! $child_square_id && $child->get_sku() && $sku_lookups_this_step < self::MAX_SKU_LOOKUPS_PER_PUSH_STEP ) {
+							$child_square_id = Product::get_square_variation_id_by_sku( $child->get_sku(), $child_id, true );
+							if ( $child_square_id ) {
+								++$sku_lookups_this_step;
+							}
+						}
 						$inventory_change = Product::get_inventory_change_physical_count_type( $child );
 
-						if ( $child instanceof \WC_Product && $child->get_manage_stock() && $inventory_change ) {
-
+						if ( $inventory_change ) {
 							$product_inventory_changes[] = $inventory_change;
 						}
 					}
-				} elseif ( $square_variation_id ) {
+				} else {
+					// Simple product: try SKU-based lookup if unmapped but synced (e.g. mapping lost after timeout).
+					if ( ! $square_variation_id && $product->get_sku() && $product->get_manage_stock() && $sku_lookups_this_step < self::MAX_SKU_LOOKUPS_PER_PUSH_STEP ) {
+						$square_variation_id = Product::get_square_variation_id_by_sku( $product->get_sku(), $product_id, true );
+						if ( $square_variation_id ) {
+							++$sku_lookups_this_step;
+						}
+					}
 
-					$inventory_change = Product::get_inventory_change_physical_count_type( $product );
+					if ( $square_variation_id ) {
 
-					if ( $inventory_change && $product->get_manage_stock() ) {
+						$inventory_change = Product::get_inventory_change_physical_count_type( $product );
 
-						$product_inventory_changes[] = $inventory_change;
+						if ( $inventory_change ) {
+							$product_inventory_changes[] = $inventory_change;
+						}
 					}
 				}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When `push_inventory` runs, products/variations without a stored `_square_item_variation_id` mapping were previously skipped. If an earlier `upsert_new_products` step timed out (or failed) after Square created the item but before the plugin saved the mapping, those products stayed at 0 quantity in Square and never received a stock push.

This PR adds SKU-based fallback so `push_inventory` can recover in that case:

- A new method added **`Product::get_square_variation_id_by_sku()`**  
  Looks up a Square catalog variation by SKU via `SearchCatalogObjects` (exact query on `sku`). Optionally persists the mapping so later sync steps use the stored ID. Exceptions are caught and logged; the method returns `null` so sync continues.
- **`push_inventory` (Manual_Synchronization)**  
  - For **simple products**: if there is no stored Square variation ID but the product has a SKU and manages stock, attempts the new SKU lookup, persists the mapping when found, then builds and pushes the inventory change.
  - For **variable products**: same logic per child variation (no mapping → try SKU lookup → persist when found → push inventory).
  - **`MAX_SKU_LOOKUPS_PER_PUSH_STEP = 20`** limits how many SKU lookups run per `push_inventory` step to avoid rate limits; additional unmapped products are handled in later step runs.

> [!NOTE]
> The timeout that prevents mapping from being saved is intermittent (e.g. slow API, server limits), so this PR does not address that root cause. Instead, it targets the **incomplete-sync case**: when products already exist in Square but WooCommerce never received or stored the variation IDs (e.g. after a timeout). For those unmapped products, the plugin now attempts a **SKU-based lookup** during push_inventory—matching the approach suggested in the original issue—and persists the mapping when found so inventory can be pushed. This makes inventory push resilient to missed meta and looks promising for the reported scenario.

Closes https://linear.app/a8c/issue/SQUARE-264/push-inventory-should-attempt-sku-based-matching-for-unmapped-products.

## Steps to test the changes in this Pull Request

1. Set Woo as system of record
2. Inventory sync enabled
3. Create a new simple product with SKU and stock
4. Run manual sync so it upserts to Square.
5. In DB, delete the product’s `_square_item_variation_id` meta (simulate lost mapping).
6. Run sync again
7. Confirm the Square inventory for that product matches Woo after sync
8. Repeat with a variable product; remove only one variation’s `_square_item_variation_id`.
9. Run sync; confirm that variation’s inventory is pushed to Square after SKU lookup.
10. Confirm already-mapped products still push inventory as before (no behavior change).
11. Confirm products without SKU or that don’t manage stock are still skipped for push (no new behavior for them).

## Changelog entry

> Fix - Push inventory now attempts SKU-based lookup for synced products missing a Square variation ID