### PR TITLE
Fix: Clear stale Square category ID from all associated WooCommerce categories

### DIFF
--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -242,7 +242,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 				$response = wc_square()->get_api()->batch_retrieve_catalog_objects( $square_ids );
 
-				// swap the square ID into the array key for quick lookup
+				// Key by Square ID for lookup; handling duplicate mapping issue by storing all WC term IDs for each Square ID.
 				$mapped_category_audit = array();
 
 				foreach ( $mapped_categories as $mapped_category_id => $mapped_category ) {
@@ -261,7 +261,7 @@ class Manual_Synchronization extends Stepped_Job {
 						if ( isset( $mapped_category_audit[ $category->getId() ] ) ) {
 
 							$category_ids = $mapped_category_audit[ $category->getId() ];
-							foreach ( $category_ids as $category_id ) {
+							foreach ( (array) $category_ids as $category_id ) {
 								$map[ $category_id ]['square_version'] = $category->getVersion();
 							}
 							unset( $mapped_category_audit[ $category->getId() ] );

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -246,7 +246,7 @@ class Manual_Synchronization extends Stepped_Job {
 				$mapped_category_audit = array();
 
 				foreach ( $mapped_categories as $mapped_category_id => $mapped_category ) {
-					$mapped_category_audit[ $mapped_category['square_id'] ] = $mapped_category_id;
+					$mapped_category_audit[ $mapped_category['square_id'] ][] = $mapped_category_id;
 				}
 
 				if ( ! $response->get_data() instanceof BatchRetrieveCatalogObjectsResponse ) {
@@ -260,9 +260,10 @@ class Manual_Synchronization extends Stepped_Job {
 						// don't check for the name, it will get overwritten by the Woo value anyway
 						if ( isset( $mapped_category_audit[ $category->getId() ] ) ) {
 
-							$category_id = $mapped_category_audit[ $category->getId() ];
-
-							$map[ $category_id ]['square_version'] = $category->getVersion();
+							$category_ids = $mapped_category_audit[ $category->getId() ];
+							foreach ( $category_ids as $category_id ) {
+								$map[ $category_id ]['square_version'] = $category->getVersion();
+							}
 							unset( $mapped_category_audit[ $category->getId() ] );
 						}
 					}
@@ -271,7 +272,7 @@ class Manual_Synchronization extends Stepped_Job {
 				// any remaining categories were not found in Square and should have their local mapping data removed
 				if ( ! empty( $mapped_category_audit ) ) {
 
-					$outdated_category_ids = array_values( $mapped_category_audit );
+					$outdated_category_ids = array_merge( ...array_values( $mapped_category_audit ) );
 
 					foreach ( $outdated_category_ids as $outdated_category_id ) {
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When multiple WooCommerce product categories were mapped to the same Square category ID and that Square category was deleted or missing, `refresh_category_mappings()` only cleared the stale mapping for one WC category. The rest kept the invalid Square ID, causing manual sync to fail at `upsert_categories()`.

This change:
- Builds the category audit so **all** WC term IDs are stored per Square ID (array per key instead of a single value), so no mapping is overwritten.
- When a Square category is found in the API response, updates `square_version` in the map for **every** associated WC category.
- When a Square category is missing (stale), flattens the remaining audit entries and removes the stale mapping from **every** associated WC category, marking them unmapped so sync can create new Square categories and continue.

> [!NOTE]
> The plugin does not intentionally allow multiple WC categories per Square ID; this can occur when two WC categories share the same name and are matched to the same Square category across syncs, or from manual/DB edits. The fix makes cleanup resilient to that state.

Closes https://linear.app/a8c/issue/SQUARE-261/stale-category-mapping-not-fully-cleaned-up-when-two-woocommerce.

### Steps to test the changes in this Pull Request:
1. Set WooCommerce Square to use WooCommerce as the system of record and ensure at least two product categories exist and are mapped to Square (run a successful manual sync first if needed).
2. Simulate the bug: manually edit the `wc_square_category_map` option so two WC category IDs point to the same `square_id`.
3. Run manual sync (WooCommerce → Settings → Square → Sync).
4. Confirm sync completes without failing at category upsert, and that **both** WC categories no longer have the stale Square ID (check the map or Tools → Square category map test); both should be unmapped and eligible for new Square category creation on the next sync.

### Changelog entry

> Fix - Ensure stale category mappings are fully cleaned up when two WooCommerce categories share the same Square category ID.
