### PR TITLE
Release/5.3.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** WooCommerce Square Changelog ***
 
+= 5.3.1 - 2026-03-26 =
+* Fix - Improved reliability when customers change or remove an applied gift card at checkout.
+* Fix - Improved authorization handling for order-related requests in the payment flow.
+* Dev - Bump WooCommerce "tested up to" version 10.6.
+
 = 5.3.0 - 2026-03-05 =
 * Add - Initial support for Square Discount Codes (Coupons).
 * Fix - Set the "Synced with Square" taxonomy to private.

--- a/includes/Utilities/Order_Ajax_Authorization.php
+++ b/includes/Utilities/Order_Ajax_Authorization.php
@@ -15,14 +15,14 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Authorizes AJAX handlers that return order data during pay-for-order flows.
  *
- * @since x.x.x
+ * @since 5.3.1
  */
 final class Order_Ajax_Authorization {
 
 	/**
 	 * Generic error message for any failed pay-for-order authorization (avoid response differentiation).
 	 *
-	 * @since x.x.x
+	 * @since 5.3.1
 	 *
 	 * @return string
 	 */
@@ -33,7 +33,7 @@ final class Order_Ajax_Authorization {
 	/**
 	 * Order key from AJAX POST, or from the pay-for-order URL query string on full page requests.
 	 *
-	 * @since x.x.x
+	 * @since 5.3.1
 	 *
 	 * @return string
 	 */
@@ -52,7 +52,7 @@ final class Order_Ajax_Authorization {
 	/**
 	 * Order key for frontend scripts on the order-pay page.
 	 *
-	 * @since x.x.x
+	 * @since 5.3.1
 	 *
 	 * @return string
 	 */
@@ -71,7 +71,7 @@ final class Order_Ajax_Authorization {
 	/**
 	 * Whether the current request may load the given order in pay-for-order AJAX context.
 	 *
-	 * @since x.x.x
+	 * @since 5.3.1
 	 *
 	 * @param \WC_Order|false $order Order object or false.
 	 * @return bool
@@ -104,7 +104,7 @@ final class Order_Ajax_Authorization {
 	 * is active or `is_pay_for_order_page` is posted as true, returns the sanitized ID for the order being paid.
 	 * Used `is_authorized_for_pay_for_order()` to check if the order is authorized to be paid.
 	 *
-	 * @since x.x.x
+	 * @since 5.3.1
 	 *
 	 * @param int $order_id Order ID from POST or query.
 	 * @return int

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-square",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-square",
-      "version": "5.3.0",
+      "version": "5.3.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codeamp/block-components": "^0.0.1-beta.13",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/woocommerce/woocommerce-square.git"
   },
   "title": "WooCommerce Square",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "homepage": "https://woocommerce.com/products/woocommerce-square/",
   "scripts": {
     "build": "composer install --no-dev && npm run build:webpack && npm run makepot && npm run archive",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, square, woocommerce, inventory sync
 Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 5.3.0
+Stable tag: 5.3.1
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce Square ===
 Contributors: woocommerce, automattic
 Tags: credit card, square, woocommerce, inventory sync
-Requires at least: 6.8
+Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 7.4
 Stable tag: 5.3.1

--- a/readme.txt
+++ b/readme.txt
@@ -72,6 +72,11 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
+= 5.3.1 - 2026-03-26 =
+* Fix - Improved reliability when customers change or remove an applied gift card at checkout.
+* Fix - Improved authorization handling for order-related requests in the payment flow.
+* Dev - Bump WooCommerce "tested up to" version 10.6.
+
 = 5.3.0 - 2026-03-05 =
 * Add - Initial support for Square Discount Codes (Coupons).
 * Fix - Set the "Synced with Square" taxonomy to private.

--- a/tests/e2e/specs/d8.square-sor-multiple-variations.spec.js
+++ b/tests/e2e/specs/d8.square-sor-multiple-variations.spec.js
@@ -104,25 +104,25 @@ test( '[Square SOR] Import multiple variations products from Square @sync', asyn
 	await page.locator( 'li.variations_tab a' ).click();
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[0]"]' )
-	).toHaveValue( 'blue' );
+	).toHaveValue( 'red' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[0]"]' )
 	).toHaveValue( 'm' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[1]"]' )
-	).toHaveValue( 'blue' );
+	).toHaveValue( 'red' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[1]"]' )
 	).toHaveValue( 's' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[2]"]' )
-	).toHaveValue( 'red' );
+	).toHaveValue( 'blue' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[2]"]' )
 	).toHaveValue( 'm' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[3]"]' )
-	).toHaveValue( 'red' );
+	).toHaveValue( 'blue' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[3]"]' )
 	).toHaveValue( 's' );
@@ -153,7 +153,7 @@ test( '[Square SOR] Import multiple variations products from Square @sync', asyn
 	await page.locator( 'li.variations_tab a' ).click();
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[0]"]' )
-	).toHaveValue( 'blue' );
+	).toHaveValue( 'red' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[0]"]' )
 	).toHaveValue( 'm' );
@@ -162,7 +162,7 @@ test( '[Square SOR] Import multiple variations products from Square @sync', asyn
 	).toHaveValue( 'Cotton' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[1]"]' )
-	).toHaveValue( 'blue' );
+	).toHaveValue( 'red' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[1]"]' )
 	).toHaveValue( 's' );
@@ -171,7 +171,7 @@ test( '[Square SOR] Import multiple variations products from Square @sync', asyn
 	).toHaveValue( 'Cotton' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[2]"]' )
-	).toHaveValue( 'red' );
+	).toHaveValue( 'blue' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[2]"]' )
 	).toHaveValue( 'm' );
@@ -180,7 +180,7 @@ test( '[Square SOR] Import multiple variations products from Square @sync', asyn
 	).toHaveValue( 'Cotton' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_color[3]"]' )
-	).toHaveValue( 'red' );
+	).toHaveValue( 'blue' );
 	await expect(
 		page.locator( 'select[name="attribute_pa_size[3]"]' )
 	).toHaveValue( 's' );

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -4,7 +4,7 @@
  * Requires Plugins: woocommerce
  * Version: 5.3.1
  * Plugin URI: https://woocommerce.com/products/square/
- * Requires at least: 6.8
+ * Requires at least: 6.7
  * Tested up to: 6.9
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
@@ -22,7 +22,7 @@
  * @copyright Copyright (c) 2019, Automattic, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
  *
- * WC requires at least: 10.4
+ * WC requires at least: 10.3
  * WC tested up to: 10.6
  */
 
@@ -60,10 +60,10 @@ class WooCommerce_Square_Loader {
 	const MINIMUM_PHP_VERSION = '7.4.0';
 
 	/** minimum WordPress version required by this plugin */
-	const MINIMUM_WP_VERSION = '6.8';
+	const MINIMUM_WP_VERSION = '6.7';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '10.4';
+	const MINIMUM_WC_VERSION = '10.3';
 
 	/**
 	 * SkyVerge plugin framework version used by this plugin

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce Square
  * Requires Plugins: woocommerce
- * Version: 5.3.0
+ * Version: 5.3.1
  * Plugin URI: https://woocommerce.com/products/square/
  * Requires at least: 6.8
  * Tested up to: 6.9
@@ -29,7 +29,7 @@
 defined( 'ABSPATH' ) || exit;
 
 if ( ! defined( 'WC_SQUARE_PLUGIN_VERSION' ) ) {
-	define( 'WC_SQUARE_PLUGIN_VERSION', '5.3.0' ); // WRCS: DEFINED_VERSION.
+	define( 'WC_SQUARE_PLUGIN_VERSION', '5.3.1' ); // WRCS: DEFINED_VERSION.
 }
 
 if ( ! defined( 'WC_SQUARE_PLUGIN_URL' ) ) {


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Version bump and release prep for the 5.3.1

> [!NOTE]
> E2E tests changes are not related to changes we are shipping in this release, it needed due to recent Square account credentials changes on GH action.

Closes https://linear.app/a8c/issue/SQUARE-288/release-version-531

### Steps to test the changes in this Pull Request:
Verify that all file changes looks accurate and expected tests are passing.


### Changelog entry
N/A