### PR TITLE
Skip Error Throws for Stale Square Catalog Errors

### DIFF
--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -53,7 +53,7 @@ class Gateway extends Payment_Gateway_Direct {
 	/**
 	 * Error code used to indicate coupon/redemption failures that should fail checkout.
 	 *
-	 * @since 5.3.1
+	 * @since 5.3.2
 	 */
 	const COUPON_REDEMPTION_ERROR_CODE = 9001;
 

--- a/includes/Gateway.php
+++ b/includes/Gateway.php
@@ -50,6 +50,13 @@ use WooCommerce\Square\Utilities\Performance_Logger;
  */
 class Gateway extends Payment_Gateway_Direct {
 
+	/**
+	 * Error code used to indicate coupon/redemption failures that should fail checkout.
+	 *
+	 * @since 5.3.1
+	 */
+	const COUPON_REDEMPTION_ERROR_CODE = 9001;
+
 
 	/** @var Gateway\API API base instance */
 	private $api;
@@ -511,7 +518,8 @@ class Gateway extends Payment_Gateway_Direct {
 										/* translators: %s: error message from Square */
 										__( 'The coupon could not be applied (e.g. redemption limit reached or code expired). Please remove it and try again, or use a different payment method. Error: %s', 'woocommerce-square' ),
 										$error_message
-									)
+									),
+									self::COUPON_REDEMPTION_ERROR_CODE
 								);
 							}
 
@@ -520,7 +528,8 @@ class Gateway extends Payment_Gateway_Direct {
 									$this->get_plugin()->log( sprintf( 'Square: Create redemption returned no id for discount code %1$s on order #%2$s', $square_discount_code_id, $order->get_id() ), $this->get_id() );
 								}
 								throw new \Exception(
-									__( 'The coupon could not be applied. Please remove it and try again, or use a different payment method.', 'woocommerce-square' )
+									__( 'The coupon could not be applied. Please remove it and try again, or use a different payment method.', 'woocommerce-square' ),
+									self::COUPON_REDEMPTION_ERROR_CODE
 								);
 							}
 
@@ -576,8 +585,12 @@ class Gateway extends Payment_Gateway_Direct {
 				if ( $this->debug_log() ) {
 					$this->get_plugin()->log( $exception->getMessage(), $this->get_id() );
 				}
-				// Re-throw so the transaction fails and the customer sees the error (e.g. redemption failure).
-				throw $exception;
+
+				// Only fail the transaction for coupon/redemption errors.
+				if ( self::COUPON_REDEMPTION_ERROR_CODE === $exception->getCode() ) {
+					// Re-throw so the transaction fails and the customer sees the error.
+					throw $exception;
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

- Introduce a dedicated `COUPON_REDEMPTION_ERROR_CODE` constant on the `Gateway` class to tag coupon/redemption-related exceptions that should fail checkout.
- Update the coupon redemption error paths in `do_transaction()` to throw exceptions with this explicit error code when Square discount redemptions fail (e.g. redemption limit, expired code, missing redemption ID).
- Narrow the outer `do_transaction()` catch block to only re-throw exceptions when their code matches `COUPON_REDEMPTION_ERROR_CODE`, logging and swallowing other `create_order()`/catalog-related exceptions so checkout can proceed as in pre-5.3.0 behavior.

Closes https://linear.app/a8c/issue/SQUARE-276/regression-v530-throw-dollarexception-in-do-transaction-breaks.

Closes https://linear.app/a8c/issue/SQUARE-277/regression-in-530-checkout-fails-with-value-too-low-base-price-money

For SQUARE-277, I was able to reproduce the issue using a paid plugin. While investigating a fix, I discovered that these third-party plugins add discounts as line items rather than proper “discount” items - which doesn’t align with the Square checkout flow. A potential fix would be to convert those line items into Discounts, but that carries a high risk of regression.

After digging deeper, I found the root cause: we started surfacing (i.e. `throw`-ing) these errors with the Coupon Code release, and the errors themselves are legitimate. However, this PR - which filters the thrown exceptions - also resolves this issue. I tested against it and confirmed SQUARE-277 is fixed: the line items are rejected by Square, but the order no longer fails, which matches the behavior we had prior to the Coupon Code release. So I’d recommend keeping that approach as-is.

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Configure a store where a Square coupon/discount code is valid and successfully redeemable, then place an order using that code and confirm checkout still succeeds and the coupon is applied correctly.
2. Configure a store with a Square coupon/discount that cannot be redeemed (e.g. exhausted redemption limit or expired) and confirm checkout fails with the expected coupon error message (and not a generic payment decline).
3. Configure a product with stale Square catalog IDs (e.g. via disconnect/reconnect or Square-side deletion), attempt checkout with and without coupons, and confirm checkout now completes successfully while the catalog NOT_FOUND error is logged instead of being surfaced as a payment decline.
4. Also confirm the issue SQUARE-277 is also fixed.

### Changelog entry

> Fix - Prevent stale Square catalog IDs from breaking checkout while still surfacing genuine coupon redemption failures as checkout errors.
