### PR TITLE
Fix debug mode admin notice link pointing to wrong settings page

### DIFF
--- a/includes/Framework/PaymentGateway/Payment_Gateway_Plugin.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Plugin.php
@@ -653,14 +653,18 @@ abstract class Payment_Gateway_Plugin extends Plugin {
 
 			if ( $gateway->is_enabled() && $gateway->is_production_environment() && 'off' !== $debug_mode ) {
 
-				$is_square_settings = $this->is_plugin_settings();
+				// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce not required, read-only check.
+				$is_square_settings_tab = isset( $_GET['page'], $_GET['tab'] )
+					&& 'wc-settings' === $_GET['page']
+					&& $this->get_id() === $_GET['tab'];
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 				$message = sprintf(
 					/* translators: Placeholders: %1$s - payment gateway name, %2$s - opening <a> tag, %3$s - closing </a> tag */
 					esc_html__( 'Heads up! %1$s is currently configured to log transaction data for debugging purposes. If you are not experiencing any problems with payment processing, we recommend %2$sturning off Debug Mode%3$s', 'woocommerce-square' ),
 					$gateway->get_method_title(),
-					! $is_square_settings ? '<a href="' . esc_url( $this->get_settings_url() ) . '">' : '',
-					! $is_square_settings ? ' &raquo;</a>' : ''
+					! $is_square_settings_tab ? '<a href="' . esc_url( $this->get_settings_url() ) . '">' : '',
+					! $is_square_settings_tab ? ' &raquo;</a>' : ''
 				);
 
 				$this->get_admin_notice_handler()->add_admin_notice(

--- a/includes/Framework/PaymentGateway/Payment_Gateway_Plugin.php
+++ b/includes/Framework/PaymentGateway/Payment_Gateway_Plugin.php
@@ -653,14 +653,14 @@ abstract class Payment_Gateway_Plugin extends Plugin {
 
 			if ( $gateway->is_enabled() && $gateway->is_production_environment() && 'off' !== $debug_mode ) {
 
-				$is_gateway_settings = $this->is_payment_gateway_configuration_page( $gateway->get_id() );
+				$is_square_settings = $this->is_plugin_settings();
 
 				$message = sprintf(
 					/* translators: Placeholders: %1$s - payment gateway name, %2$s - opening <a> tag, %3$s - closing </a> tag */
 					esc_html__( 'Heads up! %1$s is currently configured to log transaction data for debugging purposes. If you are not experiencing any problems with payment processing, we recommend %2$sturning off Debug Mode%3$s', 'woocommerce-square' ),
 					$gateway->get_method_title(),
-					! $is_gateway_settings ? '<a href="' . esc_url( $this->get_payment_gateway_configuration_url( $gateway->get_id() ) ) . '">' : '',
-					! $is_gateway_settings ? ' &raquo;</a>' : ''
+					! $is_square_settings ? '<a href="' . esc_url( $this->get_settings_url() ) . '">' : '',
+					! $is_square_settings ? ' &raquo;</a>' : ''
 				);
 
 				$this->get_admin_notice_handler()->add_admin_notice(


### PR DESCRIPTION
## Summary
- The "turning off Debug Mode" link in the admin notice was pointing to the Credit Card payment settings page (`admin.php?page=wc-settings&tab=checkout&section=square_credit_card`) instead of the Square connection settings page (`admin.php?page=wc-settings&tab=square`) where the debug toggle actually lives.
- Updated `add_debug_setting_notices()` to use `$this->get_settings_url()` and `$this->is_plugin_settings()` which correctly resolve to the Square settings tab.
- Likely a leftover from when debug mode was migrated during the NUX update (v4.7.0).

Fixes SQUARE-296.

## Test plan
- [ ] Enable debug mode on the Square connection settings page (`WooCommerce > Settings > Square`)
- [ ] Switch to production environment with a gateway enabled
- [ ] Verify the admin notice "turning off Debug Mode" link now points to `admin.php?page=wc-settings&tab=square`
- [ ] Verify the link is not shown when already on the Square settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)