### PR TITLE
fix: add null guards for getItemOptionData()->getValues() calls

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -641,7 +641,7 @@ class API extends Base {
 			$option_name                              = $this->get_item_option_name_from_catalog_object( $object );
 			$options_data[ $object->getId() ]['name'] = $option_name;
 
-			$option_values_object = $object->getItemOptionData()->getValues();
+			$option_values_object = $object->getItemOptionData() ? $object->getItemOptionData()->getValues() : array();
 			$option_values        = array();
 			$option_values_ids    = array();
 
@@ -680,7 +680,7 @@ class API extends Base {
 			$option   = $response->get_data()->getObject();
 
 			// Filter out the existing option values from the attribute values.
-			$square_existing_option_objects = $option->getItemOptionData()->getValues();
+			$square_existing_option_objects = $option->getItemOptionData() ? $option->getItemOptionData()->getValues() : array();
 			$options_value_data             = $square_existing_option_objects;
 
 			$square_existing_option_values = array();
@@ -726,7 +726,7 @@ class API extends Base {
 			$response = $this->retrieve_catalog_object( $option_id );
 			$option   = $response->get_data()->getObject();
 
-			$option_values_object = $option->getItemOptionData()->getValues();
+			$option_values_object = $option->getItemOptionData() ? $option->getItemOptionData()->getValues() : array();
 			$option_value_ids     = array();
 			$option_values        = array();
 

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -382,7 +382,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						$option_id = $option->getId();
 
 						// Get the Square ID of the attribute value.
-						$updated_option_values = $option->getItemOptionData()->getValues();
+						$updated_option_values = $option->getItemOptionData() ? $option->getItemOptionData()->getValues() : array();
 						foreach ( $updated_option_values as $option_value ) {
 							if ( $option_value->getItemOptionValueData()->getName() === $attribute_value ) {
 								$option_value_id = $option_value->getId();


### PR DESCRIPTION
## Summary

Three locations call `getItemOptionData()->getValues()` on Square `CatalogObject` instances without checking whether `getItemOptionData()` returns null. The Square SDK types this return as `?CatalogItemOption` — explicitly nullable.

If Square returns an `ITEM_OPTION` object with null `item_option_data`:
- **PHP 7**: uncatchable Fatal Error
- **PHP 8**: throws `\Error`, which is not caught by `catch (\Exception)` in `Stepped_Job::do_next_step()`

Either way, the entire Action Scheduler job crashes with no recovery path.

## Fix

Applied the same null guard pattern already used in `Product_Import.php` (lines 789 and 894):

```php
$option_values_object = $object->getItemOptionData() ? $object->getItemOptionData()->getValues() : array();
```

### Locations fixed

| File | Method | Line |
|------|--------|------|
| `includes/API.php` | `retrieve_options_data()` | 644 |
| `includes/API.php` | `create_options_and_values()` | 683 |
| `includes/API.php` | `create_options_and_values()` | 729 |
| `includes/Handlers/Product/Woo_SOR.php` | `update_catalog_variation()` | 385 |

## Test plan

- [ ] Verify sync completes successfully with a normal catalog (no regression)
- [ ] Verify sync handles catalogs with malformed ITEM_OPTION objects (null `item_option_data`) without crashing
- [ ] Verify the sync continues processing remaining objects after encountering a null option

Fixes SQUARE-292.

### Changelog entry
> Fix - Syncs no longer crash when encountering certain malformed items in your Square catalog.