### PR TITLE
Add admin notice to inform merchants if a successful product sync has not occurred in a while.

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -415,7 +415,7 @@ class Admin {
 		 *
 		 * @since x.x.x
 		 *
-		 * @param int $threshold_seconds The threshold time in seconds. Default is 24 hours.
+		 * @param int $threshold_seconds The threshold time in seconds. Default is 24 hours, or 48 hours when the sync interval is 24 hours.
 		 * @param int $sync_interval     The sync interval in seconds.
 		 */
 		$threshold_seconds = apply_filters( 'wc_square_sync_status_notice_threshold_seconds', $threshold_seconds, $sync_interval );
@@ -438,7 +438,7 @@ class Admin {
 		}
 
 		// Bail if synced products count is 0.
-		if ( 0 === $synced_products_count ) {
+		if ( 0 === (int) $synced_products_count ) {
 			return;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -106,6 +106,9 @@ class Admin {
 				$this->load_scripts_styles( $hook );
 			}
 		);
+
+		// Show warning notice for the user to manually trigger a sync if it has been a while since the last successful sync.
+		add_action( 'admin_notices', array( $this, 'maybe_show_sync_status_notice' ) );
 	}
 
 
@@ -367,5 +370,99 @@ class Admin {
 	protected function get_plugin() {
 
 		return $this->plugin;
+	}
+
+	/**
+	 * Maybe show a warning notice for the user to manually trigger a sync if it has been a while since the last successful sync.
+	 *
+	 * If the following conditions are met, show the notice:
+	 * - The connection is established.
+	 * - The location is set.
+	 * - The product sync is enabled.
+	 * - The last synced at is set and is before the threshold time (default is 48 hours).
+	 * - The synced products count is greater than 0 (at least one product is synced with Square).
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function maybe_show_sync_status_notice() {
+		// Bail if the user does not have the manage_woocommerce capability.
+		if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return;
+		}
+
+		// Bail if the connection is not established, the location is not set, or the product sync is not enabled.
+		$is_connected            = wc_square()->get_settings_handler()->is_connected();
+		$location_id             = wc_square()->get_settings_handler()->get_location_id();
+		$is_product_sync_enabled = wc_square()->get_settings_handler()->is_product_sync_enabled();
+		if ( ! $is_connected || ! $location_id || ! $is_product_sync_enabled ) {
+			return;
+		}
+
+		// Bail if the last synced at is not set.
+		$last_synced_at = wc_square()->get_sync_handler()->get_last_synced_at();
+		if ( ! $last_synced_at ) {
+			return;
+		}
+
+		$threshold_seconds = 48 * HOUR_IN_SECONDS;
+
+		/**
+		 * Filters the threshold time for the sync status notice.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param int $threshold_seconds The threshold time in seconds. Default is 48 hours.
+		 */
+		$threshold_seconds = apply_filters( 'wc_square_sync_status_notice_threshold_seconds', $threshold_seconds );
+
+		// Get the synced products count.
+		$synced_products_count_key = 'wc_square_synced_products_count_' . $location_id;
+		$synced_products_count     = get_transient( $synced_products_count_key );
+
+		if ( false === $synced_products_count ) {
+			$synced_products_count = count( Product::get_products_synced_with_square() );
+
+			// Set the transient for the synced products count.
+			set_transient( $synced_products_count_key, $synced_products_count, $threshold_seconds );
+		}
+
+		// Bail if synced products count is 0.
+		if ( 0 === $synced_products_count ) {
+			return;
+		}
+
+		$threshold_time = time() - $threshold_seconds;
+
+		// Bail if the last synced at is after the threshold time.
+		if ( $last_synced_at > $threshold_time ) {
+			return;
+		}
+
+		// Show the notice if the last synced at is before the threshold time.
+		?>
+		<div class="notice notice-warning is-dismissible">
+			<p>
+				<?php
+				echo wp_kses(
+					sprintf(
+						/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag, %3$s - <a> tag, %4$s - </a> tag */
+						__( 'It has been a while since the last successful sync. Please manually trigger a sync from the %1$supdate page%2$s, or clear the ongoing sync from the %3$stools page%4$s if it is stuck, to ensure that your products are up to date.', 'woocommerce-square' ),
+						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square&section=update' ) ) . '">',
+						'</a>',
+						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-status&tab=tools' ) ) . '">',
+						'</a>'
+					),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				);
+				?>
+			</p>
+		</div>
+		<?php
 	}
 }

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -419,6 +419,12 @@ class Admin {
 		 * @param int $sync_interval     The sync interval in seconds.
 		 */
 		$threshold_seconds = apply_filters( 'wc_square_sync_status_notice_threshold_seconds', $threshold_seconds, $sync_interval );
+		$threshold_time    = time() - $threshold_seconds;
+
+		// Bail if the last synced at is after the threshold time.
+		if ( $last_synced_at > $threshold_time ) {
+			return;
+		}
 
 		// Get the synced products count.
 		$synced_products_count_key = 'wc_square_synced_products_count_' . $location_id;
@@ -433,13 +439,6 @@ class Admin {
 
 		// Bail if synced products count is 0.
 		if ( 0 === $synced_products_count ) {
-			return;
-		}
-
-		$threshold_time = time() - $threshold_seconds;
-
-		// Bail if the last synced at is after the threshold time.
-		if ( $last_synced_at > $threshold_time ) {
 			return;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -379,7 +379,7 @@ class Admin {
 	 * - The connection is established.
 	 * - The location is set.
 	 * - The product sync is enabled.
-	 * - The last synced at is set and is before the threshold time (default is 48 hours).
+	 * - The last synced at is set and is before the threshold time (default is 24 hours, 48 hours if the sync interval is 24 hours).
 	 * - The synced products count is greater than 0 (at least one product is synced with Square).
 	 *
 	 * @since x.x.x
@@ -406,16 +406,19 @@ class Admin {
 			return;
 		}
 
-		$threshold_seconds = 48 * HOUR_IN_SECONDS;
+		// The threshold time is 24 hours by default, 48 hours if the sync interval is 24 hours.
+		$sync_interval     = wc_square()->get_settings_handler()->get_sync_interval();
+		$threshold_seconds = $sync_interval >= 24 * HOUR_IN_SECONDS ? 48 * HOUR_IN_SECONDS : 24 * HOUR_IN_SECONDS;
 
 		/**
 		 * Filters the threshold time for the sync status notice.
 		 *
 		 * @since x.x.x
 		 *
-		 * @param int $threshold_seconds The threshold time in seconds. Default is 48 hours.
+		 * @param int $threshold_seconds The threshold time in seconds. Default is 24 hours.
+		 * @param int $sync_interval     The sync interval in seconds.
 		 */
-		$threshold_seconds = apply_filters( 'wc_square_sync_status_notice_threshold_seconds', $threshold_seconds );
+		$threshold_seconds = apply_filters( 'wc_square_sync_status_notice_threshold_seconds', $threshold_seconds, $sync_interval );
 
 		// Get the synced products count.
 		$synced_products_count_key = 'wc_square_synced_products_count_' . $location_id;

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -216,8 +216,8 @@ class Background_Job extends Background_Job_Handler {
 
 		Records::set_record(
 			array(
-				'type'    => 'alert',
-				'message' => 'Sync failed. Please try again',
+				'type'    => 'failed',
+				'message' => __( 'Sync failed. Please try again', 'woocommerce-square' ),
 			)
 		);
 

--- a/includes/Sync/Records/Record.php
+++ b/includes/Sync/Records/Record.php
@@ -206,6 +206,7 @@ class Record {
 			'notice'   => __( 'Notice', 'woocommerce-square' ),
 			'alert'    => __( 'Alert', 'woocommerce-square' ),
 			'resolved' => __( 'Resolved', 'woocommerce-square' ),
+			'failed'   => __( 'Failed', 'woocommerce-square' ),
 		);
 	}
 

--- a/src/css/admin/wc-square-admin.scss
+++ b/src/css/admin/wc-square-admin.scss
@@ -42,6 +42,7 @@
 					padding: 6px 10px;
 				}
 
+				&.failed span,
 				&.alert span {
 					background: #EBA3A3;
 					color: #761919;


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
This pull request introduces a new admin warning notice to alert users when a product sync with Square hasn't occurred in a while (in last 24 hours or 48 hours if sync interval is 24 hours), and improves the handling and display of sync failure statuses in both backend logic and admin UI.

<img width="2007" height="101" alt="image" src="https://github.com/user-attachments/assets/264a5dec-f1fb-435e-aa71-23c1b842c097" />


Closes https://linear.app/a8c/issue/SQUARE-299/square-sync-admin-facing-sync-status-and-stale-sync-warning

### Steps to test the changes in this Pull Request:
1. Update the `wc_square_last_synced_at` option value to a timestamp older than 24 hours.
2. Visit the WP Admin dashboard and ensure you see a notice about the product sync.
3. Manually run the sync, wait for it to complete, and ensure the notice disappears once the sync completes successfully.
4. Simulate a sync failure by manually throwing an exception.
5. Ensure that the sync record is added as failed instead of alert.
<img width="882" height="135" alt="image" src="https://github.com/user-attachments/assets/d442596a-c40b-42b6-baa4-b658127b8fc5" />


### Changelog entry
> Add - Admin notice to inform merchants if a successful product sync has not occurred in a while.