### PR TITLE
Add SKU-based existence check before creating new Square catalog items

### DIFF
--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -23,10 +23,14 @@
 
 namespace WooCommerce\Square\Sync;
 
+use Automattic\WooCommerce\Enums\ProductType;
 use Square\Models\BatchRetrieveInventoryCountsResponse;
 use Square\Models\BatchUpsertCatalogObjectsResponse;
 use Square\Models\BatchRetrieveCatalogObjectsResponse;
 use Square\Models\CatalogObject;
+use Square\Models\CatalogObjectType;
+use Square\Models\CatalogQuery;
+use Square\Models\CatalogQuerySet;
 use Square\Models\SearchCatalogObjectsResponse;
 use Square\Models\CatalogInfoResponse;
 use Square\ApiHelper;
@@ -716,6 +720,172 @@ class Manual_Synchronization extends Stepped_Job {
 		}
 	}
 
+	/**
+	 * Links products to existing Square items by SKUs.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $product_ids The IDs of the WooCommerce products to link.
+	 * @return array The IDs of the linked products.
+	 */
+	protected function link_products_to_existing_square_items( $product_ids ) {
+		$linked_product_ids       = array();
+		$product_skus             = array();
+		$existing_catalog_objects = array();
+
+		foreach ( $product_ids as $product_id ) {
+			$product = wc_get_product( $product_id );
+			if ( ! $product ) {
+				continue;
+			}
+
+			if ( ! empty( $product->get_sku() ) ) {
+				$product_skus[] = $product->get_sku();
+			}
+
+			if ( $product->is_type( 'variable' ) && $product->has_child() ) {
+				foreach ( $product->get_children() as $variation_id ) {
+					$variation = wc_get_product( $variation_id );
+
+					if ( $variation instanceof \WC_Product && ! empty( $variation->get_sku() ) ) {
+						$product_skus[] = $variation->get_sku();
+					}
+				}
+			}
+		}
+
+		// Remove duplicates if any.
+		$product_skus = array_unique( $product_skus );
+
+		if ( empty( $product_skus ) ) {
+			return $linked_product_ids;
+		}
+
+		// Set query has limit of 250 items.
+		foreach ( array_chunk( $product_skus, 250 ) as $batched_skus ) {
+			$existing_catalog_objects = array_merge( $existing_catalog_objects, $this->find_existing_square_items_by_skus( $batched_skus ) );
+		}
+
+		// If no existing catalog objects found, return.
+		if ( empty( $existing_catalog_objects ) ) {
+			return $linked_product_ids;
+		}
+
+		// Link products to existing catalog objects.
+		foreach ( $existing_catalog_objects as $remote_catalog_item ) {
+			if ( ! $remote_catalog_item instanceof CatalogObject ) {
+				continue;
+			}
+
+			if ( is_array( $remote_catalog_item->getItemData()->getVariations() ) ) {
+				$product_id = null;
+				foreach ( $remote_catalog_item->getItemData()->getVariations() as $catalog_item_variation ) {
+					$variation_data = $catalog_item_variation->getItemVariationData();
+					if ( ! $variation_data || ! $variation_data->getSku() || empty( $variation_data->getSku() ) ) {
+						continue;
+					}
+
+					$local_product_id = wc_get_product_id_by_sku( $variation_data->getSku() );
+					if ( ! $local_product_id ) {
+						continue;
+					}
+
+					$local_product = wc_get_product( $local_product_id );
+					if ( ! $local_product ) {
+						continue;
+					}
+
+					Product::update_square_meta(
+						$local_product,
+						array(
+							'item_variation_id'      => $catalog_item_variation->getId(),
+							'item_variation_version' => $catalog_item_variation->getVersion(),
+						)
+					);
+
+					$product_id = $local_product->is_type( ProductType::VARIATION ) ? $local_product->get_parent_id() : $local_product->get_id();
+				}
+
+				// Update the parent product if it exists.
+				if ( $product_id ) {
+					$product = wc_get_product( $product_id );
+					if ( $product ) {
+						Product::update_square_meta(
+							$product,
+							array(
+								'item_id'       => $remote_catalog_item->getId(),
+								'item_version'  => $remote_catalog_item->getVersion(),
+								'item_image_id' => Product::get_catalog_item_thumbnail_id( $remote_catalog_item ),
+							)
+						);
+					}
+				}
+
+				$linked_product_ids[] = $product_id;
+			}
+		}
+
+		return $linked_product_ids;
+	}
+
+	/**
+	 * Finds existing Square items by SKUs.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $product_skus The SKUs of the WooCommerce products to find.
+	 * @return array The IDs of the existing Square items.
+	 */
+	protected function find_existing_square_items_by_skus( $product_skus ) {
+		$existing_items = array();
+
+		$query     = new CatalogQuery();
+		$set_query = new CatalogQuerySet( 'sku', $product_skus );
+		$query->setSetQuery( $set_query );
+
+		try {
+			$response = wc_square()->get_api()->search_catalog_objects(
+				array(
+					'object_types'            => array( 'ITEM_VARIATION' ),
+					'query'                   => $query,
+					'include_related_objects' => true,
+				)
+			);
+
+			$search_response = $response->get_data();
+
+			if ( ! $search_response instanceof SearchCatalogObjectsResponse ) {
+				return array();
+			}
+
+			$related_objects = $search_response->getRelatedObjects();
+			if ( empty( $related_objects ) || ! is_array( $related_objects ) ) {
+				// No related objects found.
+				return array();
+			}
+
+			foreach ( $related_objects as $object ) {
+				if (
+					$object instanceof CatalogObject
+					&& $object->getType() === CatalogObjectType::ITEM
+					&& $object->getIsDeleted() === false
+				) {
+					$existing_items[] = $object;
+				}
+			}
+
+			return $existing_items;
+		} catch ( \Exception $exception ) {
+			wc_square()->log(
+				sprintf(
+					'Failed to find existing Square items by SKUs: %s',
+					$exception->getMessage()
+				)
+			);
+		}
+
+		return array();
+	}
 
 	/**
 	 * @throws \Exception
@@ -743,6 +913,33 @@ class Manual_Synchronization extends Stepped_Job {
 			$product_ids = $product_ids_batch;
 		} else {
 			$this->set_attr( 'upsert_new_product_ids', array() );
+		}
+
+		// SKU guard: check for existing Square items before creating new ones.
+		// Link products to existing Square items by SKUs, to prevent creating duplicate items.
+		$linked_product_ids = $this->link_products_to_existing_square_items( $product_ids );
+
+		// Remove linked products from the upsert batch — they already exist in Square.
+		if ( ! empty( $linked_product_ids ) ) {
+			$product_ids = array_values( array_diff( $product_ids, $linked_product_ids ) );
+
+			// Linked products count as processed and need inventory push.
+			$processed_product_ids      = array_merge( $linked_product_ids, $processed_product_ids );
+			$inventory_push_product_ids = array_merge( $linked_product_ids, $inventory_push_product_ids );
+			$this->set_attr( 'processed_product_ids', $processed_product_ids );
+			$this->set_attr( 'inventory_push_product_ids', $inventory_push_product_ids );
+
+			// Clear retry idempotency key if the batch changed — the key is bound to the
+			// original request body and would cause Square to reject a modified batch.
+			if ( ! empty( $retry_idempotency_key ) ) {
+				$this->set_attr( 'upsert_retry_idempotency_key', null );
+				$this->set_attr( 'upsert_retry_product_ids', array() );
+			}
+
+			// If all products were linked to existing items, no upsert needed, return early.
+			if ( empty( $product_ids ) ) {
+				return;
+			}
 		}
 
 		$catalog_objects = array();

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -761,6 +761,7 @@ class Manual_Synchronization extends Stepped_Job {
 		}
 
 		// Set query has limit of 250 items.
+		$sku_to_object_id_map = array();
 		foreach ( array_chunk( $product_skus, 250 ) as $batched_skus ) {
 			foreach ( $this->find_existing_square_items_by_skus( $batched_skus ) as $existing_catalog_object ) {
 				if ( ! $existing_catalog_object instanceof CatalogObject ) {
@@ -771,6 +772,37 @@ class Manual_Synchronization extends Stepped_Job {
 					continue;
 				}
 				$existing_catalog_objects[ $remote_catalog_object_id ] = $existing_catalog_object;
+
+				// Check for Multiple Square items with the same SKU.
+				$item_data = $existing_catalog_object->getItemData();
+				if ( $item_data && is_array( $item_data->getVariations() ) ) {
+					foreach ( $item_data->getVariations() as $variation ) {
+						if ( ! $variation->getItemVariationData()->getSku() ) {
+							continue;
+						}
+
+						$sku = $variation->getItemVariationData()->getSku();
+						if ( isset( $sku_to_object_id_map[ $sku ] ) && ! empty( $sku_to_object_id_map[ $sku ] ) ) {
+							unset( $existing_catalog_objects[ $sku_to_object_id_map[ $sku ] ] );
+							unset( $existing_catalog_objects[ $remote_catalog_object_id ] );
+							Records::set_record(
+								array(
+									'type'    => 'alert',
+									'message' => sprintf(
+										/* translators: %1$s - SKU, %2$s - Square Item 1, %3$s - Square Item 2. */
+										__( 'Multiple Square items share the same SKU: %1$s. Square Item IDs: %2$s, %3$s', 'woocommerce-square' ),
+										$sku,
+										$sku_to_object_id_map[ $sku ],
+										$remote_catalog_object_id
+									),
+								)
+							);
+							continue;
+						}
+
+						$sku_to_object_id_map[ $sku ] = $remote_catalog_object_id;
+					}
+				}
 			}
 		}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -777,11 +777,12 @@ class Manual_Synchronization extends Stepped_Job {
 				$item_data = $existing_catalog_object->getItemData();
 				if ( $item_data && is_array( $item_data->getVariations() ) ) {
 					foreach ( $item_data->getVariations() as $variation ) {
-						if ( ! $variation->getItemVariationData()->getSku() ) {
+						$variation_data = $variation->getItemVariationData();
+						if ( ! $variation_data || empty( $variation_data->getSku() ) ) {
 							continue;
 						}
 
-						$sku = $variation->getItemVariationData()->getSku();
+						$sku = $variation_data->getSku();
 						if ( isset( $sku_to_object_id_map[ $sku ] ) && ! empty( $sku_to_object_id_map[ $sku ] ) ) {
 							unset( $existing_catalog_objects[ $sku_to_object_id_map[ $sku ] ] );
 							unset( $existing_catalog_objects[ $remote_catalog_object_id ] );

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -23,7 +23,6 @@
 
 namespace WooCommerce\Square\Sync;
 
-use Automattic\WooCommerce\Enums\ProductType;
 use Square\Models\BatchRetrieveInventoryCountsResponse;
 use Square\Models\BatchUpsertCatalogObjectsResponse;
 use Square\Models\BatchRetrieveCatalogObjectsResponse;
@@ -763,7 +762,16 @@ class Manual_Synchronization extends Stepped_Job {
 
 		// Set query has limit of 250 items.
 		foreach ( array_chunk( $product_skus, 250 ) as $batched_skus ) {
-			$existing_catalog_objects = array_merge( $existing_catalog_objects, $this->find_existing_square_items_by_skus( $batched_skus ) );
+			foreach ( $this->find_existing_square_items_by_skus( $batched_skus ) as $existing_catalog_object ) {
+				if ( ! $existing_catalog_object instanceof CatalogObject ) {
+					continue;
+				}
+				$remote_catalog_object_id = $existing_catalog_object->getId();
+				if ( empty( $remote_catalog_object_id ) ) {
+					continue;
+				}
+				$existing_catalog_objects[ $remote_catalog_object_id ] = $existing_catalog_object;
+			}
 		}
 
 		// If no existing catalog objects found, return.
@@ -803,7 +811,7 @@ class Manual_Synchronization extends Stepped_Job {
 						)
 					);
 
-					$product_id = $local_product->is_type( ProductType::VARIATION ) ? $local_product->get_parent_id() : $local_product->get_id();
+					$product_id = $local_product->is_type( 'variation' ) ? $local_product->get_parent_id() : $local_product->get_id();
 				}
 
 				// Update the parent product if it exists.
@@ -819,9 +827,9 @@ class Manual_Synchronization extends Stepped_Job {
 							)
 						);
 					}
-				}
 
-				$linked_product_ids[] = $product_id;
+					$linked_product_ids[] = $product_id;
+				}
 			}
 		}
 
@@ -834,7 +842,7 @@ class Manual_Synchronization extends Stepped_Job {
 	 * @since x.x.x
 	 *
 	 * @param array $product_skus The SKUs of the WooCommerce products to find.
-	 * @return array The IDs of the existing Square items.
+	 * @return CatalogObject[] The existing Square ITEM catalog objects.
 	 */
 	protected function find_existing_square_items_by_skus( $product_skus ) {
 		$existing_items = array();
@@ -938,6 +946,10 @@ class Manual_Synchronization extends Stepped_Job {
 
 			// If all products were linked to existing items, no upsert needed, return early.
 			if ( empty( $product_ids ) ) {
+				$upsert_new_product_ids = $this->get_attr( 'upsert_new_product_ids', array() );
+				if ( empty( $upsert_new_product_ids ) ) {
+					$this->complete_step( 'upsert_new_products' );
+				}
 				return;
 			}
 		}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -781,10 +781,6 @@ class Manual_Synchronization extends Stepped_Job {
 
 		// Link products to existing catalog objects.
 		foreach ( $existing_catalog_objects as $remote_catalog_item ) {
-			if ( ! $remote_catalog_item instanceof CatalogObject ) {
-				continue;
-			}
-
 			if ( is_array( $remote_catalog_item->getItemData()->getVariations() ) ) {
 				$product_id = null;
 				foreach ( $remote_catalog_item->getItemData()->getVariations() as $catalog_item_variation ) {
@@ -892,6 +888,7 @@ class Manual_Synchronization extends Stepped_Job {
 			);
 		}
 
+		// Return empty array to indicate no existing items found, even if an exception was thrown, log failure and continue.
 		return array();
 	}
 
@@ -929,6 +926,10 @@ class Manual_Synchronization extends Stepped_Job {
 
 		// Remove linked products from the upsert batch — they already exist in Square.
 		if ( ! empty( $linked_product_ids ) ) {
+			// Log the number of products linked to existing Square items.
+			wc_square()->log( '[SKU Guard] Linked ' . count( $linked_product_ids ) . ' products to existing Square items - skipping upsert for these products.' );
+
+			// Remove linked products from the upsert batch.
 			$product_ids = array_values( array_diff( $product_ids, $linked_product_ids ) );
 
 			// Linked products count as processed and need inventory push.

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -785,11 +785,12 @@ class Manual_Synchronization extends Stepped_Job {
 				continue;
 			}
 
-			if ( is_array( $remote_catalog_item->getItemData()->getVariations() ) ) {
+			$item_data = $remote_catalog_item->getItemData();
+			if ( $item_data && is_array( $item_data->getVariations() ) ) {
 				$product_id = null;
 				foreach ( $remote_catalog_item->getItemData()->getVariations() as $catalog_item_variation ) {
 					$variation_data = $catalog_item_variation->getItemVariationData();
-					if ( ! $variation_data || ! $variation_data->getSku() || empty( $variation_data->getSku() ) ) {
+					if ( ! $variation_data || empty( $variation_data->getSku() ) ) {
 						continue;
 					}
 
@@ -876,7 +877,7 @@ class Manual_Synchronization extends Stepped_Job {
 				if (
 					$object instanceof CatalogObject
 					&& $object->getType() === CatalogObjectType::ITEM
-					&& $object->getIsDeleted() === false
+					&& ! $object->getIsDeleted()
 				) {
 					$existing_items[] = $object;
 				}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
As reported in https://linear.app/a8c/issue/SQUARE-290/timeout-during-search-matched-products-causes-duplicate-square-catalog, currently, the timeout during search_matched_products causes duplicate Square catalog items on sync retry

This PR follows the defensive fix here, basically it adds sku-based  existence check before creating new Square catalog items in the `upsert_new_products()` to prevent duplicates. (This PR follow the approach taken in https://github.com/woocommerce/woocommerce-square/pull/483)

>[!NOTE]
> The issue also mentions timeouts and other concerns as well. This PR does not address those timeouts and instead focuses on preventing existing items from being pushed again.

Closes https://linear.app/a8c/issue/SQUARE-290/timeout-during-search-matched-products-causes-duplicate-square-catalog

### Steps to test the changes in this Pull Request:
SOR: WooCommerce

1. There is no easy way to test this, but we can simulate the situation described in the issue with a minor code change.
2. Check out the `trunk` branch.
3. Comment out these two lines:
https://github.com/woocommerce/woocommerce-square/blob/46e9e168fb8838ae3817499e8a63c51c0ceed6e8/includes/Sync/Manual_Synchronization.php#L1722-L1723
4. Add a new product and sync it with Square.
5. Delete the Square-related metadata from the `postmeta` table for that product (`_square_*`).
6. Go to the product edit screen and click “Update.”
7. Go to the Square dashboard and verify that a duplicate product is created.
8. Check out this PR branch. Follow steps 3–6 and verify that no duplicate product is created on the Square side.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Fix - Add SKU-based existence check before creating new Square catalog items to prevent duplicates.