### PR TITLE
SQUARE-300: Skip SKU-based product matching for Square variations with no SKU

### DIFF
--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -640,7 +640,13 @@ class Manual_Synchronization extends Stepped_Job {
 
 					foreach ( $catalog_object->getItemData()->getVariations() as $catalog_variation ) {
 
-						$product_id = wc_get_product_id_by_sku( $catalog_variation->getItemVariationData()->getSku() );
+						$sku = $catalog_variation->getItemVariationData()->getSku();
+
+						if ( empty( $sku ) ) {
+							continue;
+						}
+
+						$product_id = wc_get_product_id_by_sku( $sku );
 
 						$product = wc_get_product( $product_id );
 
@@ -1292,11 +1298,21 @@ class Manual_Synchronization extends Stepped_Job {
 				$missing_variations        = array();
 				$woo_product_variations    = $maybe_parent_product->get_children();
 				$square_product_variations = $object->getItemData()->getVariations();
-				$square_variation_ids      = array_map(
-					function ( $square_product_variation ) {
-						return wc_get_product_id_by_sku( $square_product_variation->getItemVariationData()->getSku() );
-					},
-					$square_product_variations
+				$square_variation_ids      = array_values(
+					array_filter(
+						array_map(
+							function ( $square_product_variation ) {
+								$sku = $square_product_variation->getItemVariationData()->getSku();
+
+								if ( empty( $sku ) ) {
+									return null;
+								}
+
+								return wc_get_product_id_by_sku( $sku );
+							},
+							$square_product_variations
+						)
+					)
 				);
 
 				foreach ( $woo_product_variations as $woo_product_variation_id ) {
@@ -1314,7 +1330,13 @@ class Manual_Synchronization extends Stepped_Job {
 
 			foreach ( $object->getItemData()->getVariations() as $variation ) {
 
-				$found_product_id = wc_get_product_id_by_sku( $variation->getItemVariationData()->getSku() );
+				$sku = $variation->getItemVariationData()->getSku();
+
+				if ( empty( $sku ) ) {
+					continue;
+				}
+
+				$found_product_id = wc_get_product_id_by_sku( $sku );
 
 				// bail if this product has already been processed
 				if ( in_array( $found_product_id, $processed_product_ids, false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

During `Manual_Synchronization`, the plugin calls `wc_get_product_id_by_sku()` with the SKU from each Square catalog variation - but with no guard against empty or null values. `wc_get_product_id_by_sku('')` queries `wc_product_meta_lookup` for `sku = ''`, which returns the first WooCommerce product with a blank SKU - an entirely unrelated product. That product then receives a `_square_item_id` mapping, and on every subsequent interval poll its name, data, and image are silently overwritten with data from the wrong Square catalog object.

This PR adds empty-SKU guards at all three affected call sites in `Manual_Synchronization.php`.

If no variation in a Square item carries a SKU, the sync correctly falls through to ID-based matching via `_square_item_id`. If there is no existing ID mapping either, the item is left unmatched - the intended behaviour per the ticket.

Closes https://linear.app/a8c/issue/SQUARE-300/wc-get-product-id-by-sku-matches-unrelated-products-when-square.

### Steps to test the changes in this Pull Request:

1. In the Square Sandbox Dashboard, create a catalog item with two variations: one with a SKU (e.g. `test-sku-001`) and one with a blank SKU field (e.g. a shipping fee item with variable pricing).
2. In WooCommerce, ensure at least one product exists with no SKU set on either the parent or its variations.
3. Trigger a manual sync: **WooCommerce → Square → Sync → Import products from Square**.
4. Confirm the blank-SKU WooCommerce product has **not** received a `_square_item_id` meta value, run the command in terminal or manually confirm from DB:
   ```
   wp post meta get <blank_sku_post_id> _square_item_id
   ```
   Expected: empty / not found.
5. Confirm the product whose SKU matches `test-sku-001` **has** been correctly mapped:
   ```
   wp post meta get <matched_post_id> _square_item_id
   ```
   Expected: the Square item ID.
6. Run a second sync and verify the blank-SKU WooCommerce product's name and data have not been overwritten.

### Changelog entry

> Fix - Skip SKU-based product matching for Square variations with no SKU to prevent unrelated WooCommerce products from being overwritten during sync.