### PR TITLE
SQUARE-306 - Fix button misalignment in import products modal for WP 7.0

### DIFF
--- a/src/new-user-experience/styles/index.scss
+++ b/src/new-user-experience/styles/index.scss
@@ -35,7 +35,11 @@
 
 .import-modal-cover button.button-primary {
 	float: right;
-	font-size: 16px;
+
+	&:hover,
+	&:focus {
+		color: #fff;
+	}
 }
 
 .import-modal-cover button.is-secondary {


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

In WP 7.0, the import products modal displayed misaligned buttons. The root cause was a `font-size: 16px` override applied only to the primary button (`.import-modal-cover button.button-primary`) but not the secondary button. This caused a height discrepancy between the two buttons when rendered with WP 7.0's updated `components-button` styles.

This PR removes the `font-size: 16px` override so both buttons inherit the same font size from `components-button`, making them visually consistent.

Closes https://linear.app/a8c/issue/SQUARE-306/button-misaligned-with-wp-70-new-admin-screen.

<img width="836" height="380" alt="image" src="https://github.com/user-attachments/assets/8ec4e0ca-f943-4047-bd22-3ab3e661f485" />

### Steps to test the changes in this Pull Request:

1. Install WordPress 7.0 RC
1. Go to **WooCommerce > Settings > Square** (General tab)
1. Click the **Import Products** button
1. Confirm the Cancel and Import Products buttons in the modal are correctly aligned
2. Make sure it looks good in WP <v7.0 too

### Changelog entry

> Fix - Correct button alignment in the Import Products modal on WP 7.0.

Closes #492