### PR TITLE
Respect `user_has_cap` filters in `pay-for-order` check

### DIFF
--- a/includes/Utilities/Order_Ajax_Authorization.php
+++ b/includes/Utilities/Order_Ajax_Authorization.php
@@ -99,23 +99,11 @@ final class Order_Ajax_Authorization {
 			return true;
 		}
 
-		// Respect the WordPress capability system. Temporarily expose the already-validated order
-		// key via $_GET['key'] so that user_has_cap filters (e.g. the BusinessBloomer
-		// pay-for-order-without-login pattern) can grant pay_for_order in AJAX context where
-		// $_GET['key'] is absent from the request URL.
-		$key_injected = false;
-		if ( ! isset( $_GET['key'] ) && $order_key ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$_GET['key']  = $order_key; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$key_injected = true;
-		}
-
-		$can_pay = current_user_can( 'pay_for_order', $order->get_id() );
-
-		if ( $key_injected ) {
-			unset( $_GET['key'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-
-		return $can_pay;
+		// Respect the WordPress capability system. Allows site-level user_has_cap filters
+		// to grant pay_for_order (e.g. a snippet that authorises guests via the order key).
+		// Note: AJAX requests do not include $_GET['key']; filters that verify the order key
+		// should read it from $_POST['order_key'] instead, which is always present here.
+		return current_user_can( 'pay_for_order', $order->get_id() );
 	}
 
 	/**

--- a/includes/Utilities/Order_Ajax_Authorization.php
+++ b/includes/Utilities/Order_Ajax_Authorization.php
@@ -89,12 +89,33 @@ final class Order_Ajax_Authorization {
 
 		$order_customer_id = (int) $order->get_user_id();
 
-		// Guest orders (`user_id` 0) only need a valid key. Orders with a customer account require the current user to be that customer.
-		if ( ! $order_customer_id || get_current_user_id() === $order_customer_id ) {
+		// Guest orders (user_id 0) only need a valid key.
+		if ( ! $order_customer_id ) {
 			return true;
 		}
 
-		return false;
+		// Logged-in order owner.
+		if ( get_current_user_id() === $order_customer_id ) {
+			return true;
+		}
+
+		// Respect the WordPress capability system. Temporarily expose the already-validated order
+		// key via $_GET['key'] so that user_has_cap filters (e.g. the BusinessBloomer
+		// pay-for-order-without-login pattern) can grant pay_for_order in AJAX context where
+		// $_GET['key'] is absent from the request URL.
+		$key_injected = false;
+		if ( ! isset( $_GET['key'] ) && $order_key ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$_GET['key']  = $order_key; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$key_injected = true;
+		}
+
+		$can_pay = current_user_can( 'pay_for_order', $order->get_id() );
+
+		if ( $key_injected ) {
+			unset( $_GET['key'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		return $can_pay;
 	}
 
 	/**
@@ -102,7 +123,7 @@ final class Order_Ajax_Authorization {
 	 *
 	 * On normal checkout AJAX, a forged `order_id` must be ignored (returns 0). When the pay-for-order endpoint
 	 * is active or `is_pay_for_order_page` is posted as true, returns the sanitized ID for the order being paid.
-	 * Used `is_authorized_for_pay_for_order()` to check if the order is authorized to be paid.
+	 * Uses `is_authorized_for_pay_for_order()` to check if the order is authorized to be paid.
 	 *
 	 * @since 5.3.1
 	 *

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,6 +28,12 @@
 		<exclude name="WooCommerce.Commenting.CommentTags.LicenseTag" />
 	</rule>
 
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array" value="pay_for_order"/>
+		</properties>
+	</rule>
+
 	<rule ref="WordPress.Security.EscapeOutput">
 		<properties>
 			<property name="customAutoEscapedFunctions" type="array" value="wc_price"/>


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When a merchant uses a `user_has_cap` filter to allow guests to access order-pay URLs via the order key, the guest can see the Square payment form but receives _"An error occurred, please try again or try an alternate form of payment."_ on submission.

**Root cause:** The `user_has_cap` filter fires correctly at page load (when `$_GET['key']` is in the URL), but the AJAX POST request that runs `is_authorized_for_pay_for_order()` does not include `$_GET['key']`, so the filter never grants `pay_for_order` during the AJAX call. Square's check then compares `get_current_user_id()` (0) against `order->get_user_id()` (non-zero) and returns false.

**Fix:** After the order key has already been validated by `$order->key_is_valid()`, call `current_user_can('pay_for_order', $order->get_id())` directly. This delegates to the WordPress capability system cleanly without mutating superglobals. Since AJAX requests don't include `$_GET['key']`, filters that verify the order key should read it from `$_POST['order_key']` instead, which our AJAX handlers always include. Also fixes a minor docblock grammar in `trusted_line_items_order_id()`.

Closes https://linear.app/a8c/issue/SQUARE-309/order-ajax-authorization-blocks-guests-on-customer-assigned-orders.

### Steps to test the changes in this Pull Request:

**Setup:** Add the following mu-plugin to enable the guest pay flow:

```php
// wp-content/mu-plugins/test-pay-without-login.php
add_filter( 'user_has_cap', function( $allcaps, $caps, $args ) {
    if ( ! isset( $caps[0] ) || 'pay_for_order' !== $caps[0] ) {
        return $allcaps;
    }
    // Page load: $_GET['key']; AJAX POST: $_POST['order_key']
    $key = $_GET['key'] ?? $_POST['order_key'] ?? '';
    if ( ! $key ) { return $allcaps; }
    $order = wc_get_order( $args[2] ?? null );
    if ( $order && $order->key_is_valid( $key ) ) {
        $allcaps['pay_for_order'] = true;
    }
    return $allcaps;
}, 9999, 3 );
add_filter( 'woocommerce_order_email_verification_required', '__return_false', 9999 );
```

**Test cases:**

1. **The fix:** Create an order assigned to a registered customer. Open the order-pay URL as a guest (logged out). With the mu-plugin active, the Square payment form should load and payment should complete successfully - no "An error occurred" message.

2. **No filter - blocked:** With the mu-plugin removed/disabled, open the same order-pay URL as a guest. You should see "Please log in to your account below to continue to the payment form." (WooCommerce page-level block - correct).

3. **Wrong key - blocked:** Open the order-pay URL with a tampered key (`?key=wrong`). You should see "Sorry, this order is invalid and cannot be paid for.".

4. **Logged-in owner - passes:** Log in as the customer who owns the order. Navigate to their order-pay URL (mu-plugin may be on or off). Payment form loads and completes successfully.

5. **True guest order (user_id=0) - passes:** Create an order with no customer (`customer_id=0`). Open its order-pay URL while logged out. Payment form loads and completes successfully.

### Changelog entry

> Fix - Allow extending the “Pay for Order” functionality via the WordPress capability system.
