### PR TITLE
SQUARE-303 - Compatibility testing with Woo 10.8 Beta 1

### DIFF
--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -22,8 +22,8 @@
  * @copyright Copyright (c) 2019, Automattic, Inc.
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
  *
- * WC requires at least: 10.5
- * WC tested up to: 10.7
+ * WC requires at least: 10.6
+ * WC tested up to: 10.8
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -63,7 +63,7 @@ class WooCommerce_Square_Loader {
 	const MINIMUM_WP_VERSION = '6.8';
 
 	/** minimum WooCommerce version required by this plugin */
-	const MINIMUM_WC_VERSION = '10.5';
+	const MINIMUM_WC_VERSION = '10.6';
 
 	/**
 	 * SkyVerge plugin framework version used by this plugin


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://linear.app/a8c/issue/SQUARE-303/compatibility-testing-with-woo-108-beta-1

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR
2. All tests should be passed.

### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev - Bump WooCommerce "tested up to" version 10.8.
> Dev - Bump WooCommerce minimum supported version to 10.6.
