### PR TITLE
fix(SQUARE-318): remove stale actionscheduler DELETE block from Plugin.php

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -998,11 +998,6 @@ class Plugin extends Payment_Gateway_Plugin {
 			return;
 		}
 
-		// Remove all OLD scheduled actions to cleanup DB.
-		// TODO: Remove this in next release.
-		global $wpdb;
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = 'wc_square_init_payment_token_migration'" );
-
 		if ( false === as_has_scheduled_action( 'wc_square_init_payment_token_migration_v2' ) ) {
 			as_enqueue_async_action( 'wc_square_init_payment_token_migration_v2', array( 'page' => 1 ) );
 		}


### PR DESCRIPTION
## Summary

Removes the stale `actionscheduler` DELETE block that was introduced in PR #68 (February 2024, v4.5.1).

## Background

The deleted code was a one-time cleanup targeting sites upgrading from <3.7.1 to 4.5.0, which introduced the `wc_square_init_payment_token_migration` hook. A `TODO: Remove this in next release` comment marked it for deletion, but it survived 15+ months and multiple major version bumps (4.5 → 5.3).

**Removed block (`includes/Plugin.php` ~line 1001):**
```php
// Remove all OLD scheduled actions to cleanup DB.
// TODO: Remove this in next release.
global $wpdb;
$wpdb->query( "DELETE FROM {$wpdb->prefix}actionscheduler_actions WHERE hook = 'wc_square_init_payment_token_migration'" );
```

## What Changed

- **`includes/Plugin.php`** — deleted 5 lines (comment + `global $wpdb` declaration + `$wpdb->query()` call + blank line)

## Risk

None. Sites on <3.7.1 are well outside any migration window. The v2 migration hook (`wc_square_init_payment_token_migration_v2`) is unaffected — that scheduling logic remains intact in `schedule_token_migration_job()`.

## Testing

1. Confirm `schedule_token_migration_job()` still schedules the v2 action correctly on a fresh site.
2. Confirm no PHP errors or warnings on activation.
3. Search codebase: `wc_square_init_payment_token_migration` (without `_v2`) should no longer appear in any live code paths — only in the v2 registration at line 149 (`add_action( 'wc_square_init_payment_token_migration', '__return_false' )`).

---
*Identified during the May 2026 TAM review of WooCommerce Square v5.3.3. Implemented by Hermes (SQUARE-318).*

### Changelog entry

> Update – Removed stale Action Scheduler DELETE hook from Plugin.php.
