### PR TITLE
SQUARE-278: [UI Update] 1 - Establish New Settings Tab Shell & Remove Legacy Menu

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -88,16 +88,19 @@ class Admin {
 	 */
 	private function add_hooks() {
 
-		// add the settings page.
-		add_filter(
-			'woocommerce_get_settings_pages',
-			function ( $pages ) {
-
-				$pages[] = new Admin\Settings_Page( $this->get_plugin()->get_settings_handler() );
-
-				return $pages;
-			}
-		);
+		if ( $this->get_plugin()->is_modern_settings_path_active() ) {
+			// Modern path: hub under WooCommerce > Settings > Payments > Square.
+			Admin\Payments_Square_Hub::init();
+		} else {
+			// Legacy path: top-level WooCommerce > Settings > Square tab.
+			add_filter(
+				'woocommerce_get_settings_pages',
+				function ( $pages ) {
+					$pages[] = new Admin\Settings_Page( $this->get_plugin()->get_settings_handler() );
+					return $pages;
+				}
+			);
+		}
 
 		// load admin scripts.
 		add_action(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -169,7 +169,10 @@ class Admin {
 					),
 				)
 			);
-		} elseif ( $this->get_plugin()->is_plugin_settings() ) {
+		} elseif ( $this->get_plugin()->is_plugin_settings() && ! Admin\Payments_Square_Hub::is_square_payments_hub() ) {
+			// Legacy settings scripts must not load on the modern hub page; the SDK
+			// renders its own assets and these legacy bundles depend on jQuery markup
+			// that no longer exists.
 			wp_enqueue_style(
 				'wc-square-admin',
 				$this->get_plugin()->get_plugin_url() . '/build/assets/admin/wc-square-admin.css',

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -30,10 +30,13 @@ use WooCommerce\Square\Plugin;
 /**
  * Registers the Square settings hub under WooCommerce > Settings > Payments > Square.
  *
- * When the modern-settings path is active, this class:
- *   - Extends the WooCommerce Payments/Checkout settings tab to include a Square section.
- *   - Provides get_settings_ui_page() so the SDK renders the 4-tab Square hub.
- *   - Redirects the legacy ?tab=square URL to the new hub location.
+ * When the modern-settings path is active, this class registers the Square hub under
+ * WooCommerce > Settings > Payments > Square and redirects legacy Square URLs to the hub.
+ *
+ * Two registration paths depending on WC version:
+ *   - WC 11.0+ (PR #65975): registers Square_Settings_Section via SettingsSectionRegistry.
+ *   - WC 10.9: replaces WC_Settings_Payment_Gateways with a subclass that provides
+ *     get_settings_ui_page() returning Square_Modern_Settings_Page.
  *
  * @since x.x.x
  */
@@ -56,11 +59,44 @@ class Payments_Square_Hub {
 	/**
 	 * Initialises hooks. Only called when the modern-settings path is active.
 	 *
+	 * On WC 11.0+ (after WooCommerce Core PR #65975, which adds get_settings_ui_page() to
+	 * SettingsSection), Square registers via SettingsSectionRegistry so WC Core resolves the
+	 * hub natively without a WC_Settings_Payment_Gateways subclass. On WC 10.9 the subclass
+	 * path is used as a fallback.
+	 *
 	 * @since x.x.x
 	 */
 	public static function init(): void {
-		add_filter( 'woocommerce_get_settings_pages', array( self::class, 'add_square_hub_to_checkout_page' ), 20 );
+		if ( self::can_use_registry_path() ) {
+			add_action( 'woocommerce_settings_sections_registration', array( self::class, 'register_settings_section' ) );
+		} else {
+			add_filter( 'woocommerce_get_settings_pages', array( self::class, 'add_square_hub_to_checkout_page' ), 20 );
+		}
 		add_action( 'admin_init', array( self::class, 'redirect_legacy_square_settings_tab' ) );
+	}
+
+	/**
+	 * Returns true when WC 11.0+ native registry support is available.
+	 *
+	 * The presence of SettingsSection::get_settings_ui_page() is the indicator: that method
+	 * was added in WooCommerce Core PR #65975 (milestone 11.0.0) together with the
+	 * SettingsSectionUIPageProviderInterface that makes the registry resolve native pages.
+	 *
+	 * @since x.x.x
+	 */
+	private static function can_use_registry_path(): bool {
+		return method_exists( '\Automattic\WooCommerce\Admin\Settings\SettingsSection', 'get_settings_ui_page' );
+	}
+
+	/**
+	 * Registers the Square hub section via SettingsSectionRegistry (WC 11.0+ path).
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry $registry Registry instance.
+	 */
+	public static function register_settings_section( \Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry $registry ): void {
+		$registry->register( new Square_Settings_Section() );
 	}
 
 	/**

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -92,6 +92,10 @@ class Payments_Square_Hub {
 	/**
 	 * Removes all hooks registered by the original WC_Settings_Payment_Gateways instance.
 	 *
+	 * Priorities (20, 30, PHP_INT_MAX) and method names are coupled to WC_Settings_Payment_Gateways
+	 * internals as of WooCommerce 10.8. If WC changes them, remove_* calls silently no-op and
+	 * duplicate hooks may fire. Verify against WC_Settings_Payment_Gateways when upgrading WC.
+	 *
 	 * @since x.x.x
 	 *
 	 * @param \WC_Settings_Payment_Gateways $page Original checkout settings page.

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * WooCommerce Square
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@woocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade WooCommerce Square to newer
+ * versions in the future. If you wish to customize WooCommerce Square for your
+ * needs please refer to https://docs.woocommerce.com/document/woocommerce-square/
+ *
+ * @author    WooCommerce
+ * @copyright Copyright: (c) 2019, Automattic, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
+ */
+
+namespace WooCommerce\Square\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+use WooCommerce\Square\Plugin;
+
+/**
+ * Registers the Square settings hub under WooCommerce > Settings > Payments > Square.
+ *
+ * When the modern-settings path is active, this class:
+ *   - Extends the WooCommerce Payments/Checkout settings tab to include a Square section.
+ *   - Provides get_modern_settings_page() so the SDK renders the 4-tab Square hub.
+ *   - Redirects the legacy ?tab=square URL to the new hub location.
+ *
+ * @since x.x.x
+ */
+class Payments_Square_Hub {
+
+	/** WC Payments/Checkout tab name. */
+	const CHECKOUT_TAB = 'checkout';
+
+	/** Section ID for the Square hub within the Checkout tab. */
+	const SECTION = 'square'; // matches Plugin::PLUGIN_ID
+
+	/** Query arg used to identify the active sub-tab within the Square hub. */
+	const TAB_ARG = 'square-tab';
+
+	const TAB_GENERAL               = 'general';
+	const TAB_PAYMENT_METHODS       = 'payment-methods';
+	const TAB_PAYMENTS_TRANSACTIONS = 'payments-transactions';
+	const TAB_SYNCHRONIZE           = 'synchronize';
+
+	/**
+	 * Initialises hooks. Only called when the modern-settings path is active.
+	 *
+	 * @since x.x.x
+	 */
+	public static function init(): void {
+		add_filter( 'woocommerce_get_settings_pages', array( self::class, 'add_square_hub_to_checkout_page' ), 20 );
+		add_action( 'admin_init', array( self::class, 'redirect_legacy_square_settings_tab' ) );
+	}
+
+	/**
+	 * Replaces the WC Payments settings page instance with a Square-hub-aware subclass.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $pages Settings pages returned by the woocommerce_get_settings_pages filter.
+	 * @return array
+	 */
+	public static function add_square_hub_to_checkout_page( array $pages ): array {
+		if ( ! class_exists( 'WC_Settings_Payment_Gateways' ) ) {
+			return $pages;
+		}
+
+		foreach ( $pages as $index => $page ) {
+			if ( ! ( $page instanceof \WC_Settings_Payment_Gateways ) ) {
+				continue;
+			}
+
+			self::remove_checkout_page_hooks( $page );
+			$pages[ $index ] = self::create_checkout_page_with_square_hub();
+			break;
+		}
+
+		return $pages;
+	}
+
+	/**
+	 * Removes all hooks registered by the original WC_Settings_Payment_Gateways instance.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WC_Settings_Payment_Gateways $page Original checkout settings page.
+	 */
+	private static function remove_checkout_page_hooks( \WC_Settings_Payment_Gateways $page ): void {
+		remove_filter( 'woocommerce_settings_tabs_array', array( $page, 'add_settings_page' ), 20 );
+		remove_action( 'woocommerce_sections_' . $page->id, array( $page, 'output_sections' ) );
+		remove_action( 'woocommerce_settings_' . $page->id, array( $page, 'output' ) );
+		remove_action( 'woocommerce_settings_save_' . $page->id, array( $page, 'save' ) );
+		remove_action( 'woocommerce_admin_field_add_settings_slot', array( $page, 'add_settings_slot' ) );
+		remove_filter( 'admin_body_class', array( $page, 'add_modern_settings_body_class' ) );
+		remove_filter( 'admin_body_class', array( $page, 'add_body_classes' ), 30 );
+		remove_action( 'admin_head', array( $page, 'hide_help_tabs' ) );
+		remove_action( 'in_admin_header', array( $page, 'suppress_admin_notices' ), PHP_INT_MAX );
+		remove_filter( 'woocommerce_admin_features', array( $page, 'suppress_store_alerts' ), PHP_INT_MAX );
+	}
+
+	/**
+	 * Creates a WC_Settings_Payment_Gateways subclass that adds the Square hub section.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WC_Settings_Payment_Gateways
+	 */
+	private static function create_checkout_page_with_square_hub(): \WC_Settings_Payment_Gateways {
+		return new class() extends \WC_Settings_Payment_Gateways {
+
+			/**
+			 * {@inheritDoc}
+			 *
+			 * Appends the Square section to the standard Payments/Checkout sections.
+			 */
+			public function get_sections(): array {
+				$sections = parent::get_sections();
+				$sections[ Payments_Square_Hub::SECTION ] = __( 'Square', 'woocommerce-square' );
+				return $sections;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 *
+			 * Returns the Square modern settings adapter when the Square section is active.
+			 */
+			public function get_modern_settings_page(): ?\Automattic\WooCommerce\Admin\Settings\ModernSettingsPageInterface {
+				if ( ! $this->is_square_section() ) {
+					return null;
+				}
+
+				return new Square_Modern_Settings_Page( $this );
+			}
+
+			/**
+			 * Returns true when ?tab=checkout&section=square is active.
+			 */
+			private function is_square_section(): bool {
+				global $current_tab, $current_section;
+
+				return Payments_Square_Hub::CHECKOUT_TAB === $current_tab
+					&& Payments_Square_Hub::SECTION === $current_section;
+			}
+		};
+	}
+
+	/**
+	 * Redirects legacy ?tab=square URLs to the hub at ?tab=checkout&section=square.
+	 *
+	 * @since x.x.x
+	 */
+	public static function redirect_legacy_square_settings_tab(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['page'], $_GET['tab'] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( 'wc-settings' !== $_GET['page'] || Plugin::PLUGIN_ID !== $_GET['tab'] ) {
+			return;
+		}
+
+		wp_safe_redirect( self::get_hub_url() );
+		exit;
+	}
+
+	/**
+	 * Returns the URL for the Square hub (or a specific sub-tab).
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $tab Optional sub-tab ID. Defaults to the General tab.
+	 * @return string
+	 */
+	public static function get_hub_url( string $tab = '' ): string {
+		$params = array(
+			'page'    => 'wc-settings',
+			'tab'     => self::CHECKOUT_TAB,
+			'section' => self::SECTION,
+		);
+
+		if ( '' !== $tab ) {
+			$params[ self::TAB_ARG ] = $tab;
+		}
+
+		// nosemgrep audit.php.wp.security.xss.query-arg
+		return add_query_arg( $params, admin_url( 'admin.php' ) );
+	}
+
+	/**
+	 * Returns the currently active sub-tab within the Square hub.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string One of the TAB_* constants. Defaults to TAB_GENERAL.
+	 */
+	public static function get_active_tab(): string {
+		$valid = array(
+			self::TAB_GENERAL,
+			self::TAB_PAYMENT_METHODS,
+			self::TAB_PAYMENTS_TRANSACTIONS,
+			self::TAB_SYNCHRONIZE,
+		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$tab = isset( $_GET[ self::TAB_ARG ] ) ? sanitize_key( wp_unslash( $_GET[ self::TAB_ARG ] ) ) : self::TAB_GENERAL;
+
+		return in_array( $tab, $valid, true ) ? $tab : self::TAB_GENERAL;
+	}
+
+	/**
+	 * Returns true when currently viewing the Square payments hub.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public static function is_square_payments_hub(): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return isset( $_GET['page'], $_GET['tab'], $_GET['section'] )
+			&& 'wc-settings' === $_GET['page']
+			&& self::CHECKOUT_TAB === $_GET['tab']
+			&& self::SECTION === $_GET['section'];
+	}
+}

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -155,24 +155,43 @@ class Payments_Square_Hub {
 		};
 	}
 
+	/** Gateway section IDs that should redirect to the Square hub. */
+	const LEGACY_GATEWAY_SECTIONS = array(
+		'square_credit_card',
+		'square_cash_app_pay',
+		'gift_cards_pay',
+	);
+
 	/**
-	 * Redirects legacy ?tab=square URLs to the hub at ?tab=checkout&section=square.
+	 * Redirects legacy Square URLs to the hub at ?tab=checkout&section=square.
+	 *
+	 * Handles two cases:
+	 *   - ?tab=square (old dedicated Square tab)
+	 *   - ?tab=checkout&section=<gateway_id> (payments-list deep-links for Square gateways)
 	 *
 	 * @since x.x.x
 	 */
 	public static function redirect_legacy_square_settings_tab(): void {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET['page'], $_GET['tab'] ) ) {
+		if ( ! isset( $_GET['page'], $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] ) {
 			return;
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( 'wc-settings' !== $_GET['page'] || Plugin::PLUGIN_ID !== $_GET['tab'] ) {
-			return;
+		$tab = sanitize_key( wp_unslash( $_GET['tab'] ) );
+
+		if ( Plugin::PLUGIN_ID === $tab ) {
+			wp_safe_redirect( self::get_hub_url() );
+			exit;
 		}
 
-		wp_safe_redirect( self::get_hub_url() );
-		exit;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$section = isset( $_GET['section'] ) ? sanitize_key( wp_unslash( $_GET['section'] ) ) : '';
+
+		if ( self::CHECKOUT_TAB === $tab && in_array( $section, self::LEGACY_GATEWAY_SECTIONS, true ) ) {
+			wp_safe_redirect( self::get_hub_url() );
+			exit;
+		}
 	}
 
 	/**

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -30,13 +30,9 @@ use WooCommerce\Square\Plugin;
 /**
  * Registers the Square settings hub under WooCommerce > Settings > Payments > Square.
  *
- * When the modern-settings path is active, this class registers the Square hub under
- * WooCommerce > Settings > Payments > Square and redirects legacy Square URLs to the hub.
- *
- * Two registration paths depending on WC version:
- *   - WC 11.0+ (PR #65975): registers Square_Settings_Section via SettingsSectionRegistry.
- *   - WC 10.9: replaces WC_Settings_Payment_Gateways with a subclass that provides
- *     get_settings_ui_page() returning Square_Modern_Settings_Page.
+ * When the modern-settings path is active (WC 11.0+), registers Square_Settings_Section
+ * via SettingsSectionRegistry so WC Core resolves the 4-tab hub natively. On older WC
+ * or when the feature flag is off, the legacy Settings_Page.php path is used instead.
  *
  * @since x.x.x
  */
@@ -59,37 +55,15 @@ class Payments_Square_Hub {
 	/**
 	 * Initialises hooks. Only called when the modern-settings path is active.
 	 *
-	 * On WC 11.0+ (after WooCommerce Core PR #65975, which adds get_settings_ui_page() to
-	 * SettingsSection), Square registers via SettingsSectionRegistry so WC Core resolves the
-	 * hub natively without a WC_Settings_Payment_Gateways subclass. On WC 10.9 the subclass
-	 * path is used as a fallback.
-	 *
 	 * @since x.x.x
 	 */
 	public static function init(): void {
-		if ( self::can_use_registry_path() ) {
-			add_action( 'woocommerce_settings_sections_registration', array( self::class, 'register_settings_section' ) );
-		} else {
-			add_filter( 'woocommerce_get_settings_pages', array( self::class, 'add_square_hub_to_checkout_page' ), 20 );
-		}
+		add_action( 'woocommerce_settings_sections_registration', array( self::class, 'register_settings_section' ) );
 		add_action( 'admin_init', array( self::class, 'redirect_legacy_square_settings_tab' ) );
 	}
 
 	/**
-	 * Returns true when WC 11.0+ native registry support is available.
-	 *
-	 * The presence of SettingsSection::get_settings_ui_page() is the indicator: that method
-	 * was added in WooCommerce Core PR #65975 (milestone 11.0.0) together with the
-	 * SettingsSectionUIPageProviderInterface that makes the registry resolve native pages.
-	 *
-	 * @since x.x.x
-	 */
-	private static function can_use_registry_path(): bool {
-		return method_exists( '\Automattic\WooCommerce\Admin\Settings\SettingsSection', 'get_settings_ui_page' );
-	}
-
-	/**
-	 * Registers the Square hub section via SettingsSectionRegistry (WC 11.0+ path).
+	 * Registers the Square hub section via SettingsSectionRegistry.
 	 *
 	 * @since x.x.x
 	 *
@@ -97,104 +71,6 @@ class Payments_Square_Hub {
 	 */
 	public static function register_settings_section( \Automattic\WooCommerce\Admin\Settings\SettingsSectionRegistry $registry ): void {
 		$registry->register( new Square_Settings_Section() );
-	}
-
-	/**
-	 * Replaces the WC Payments settings page instance with a Square-hub-aware subclass.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param array $pages Settings pages returned by the woocommerce_get_settings_pages filter.
-	 * @return array
-	 */
-	public static function add_square_hub_to_checkout_page( array $pages ): array {
-		if ( ! class_exists( 'WC_Settings_Payment_Gateways' ) ) {
-			return $pages;
-		}
-
-		foreach ( $pages as $index => $page ) {
-			if ( ! ( $page instanceof \WC_Settings_Payment_Gateways ) ) {
-				continue;
-			}
-
-			self::remove_checkout_page_hooks( $page );
-			$pages[ $index ] = self::create_checkout_page_with_square_hub();
-			break;
-		}
-
-		return $pages;
-	}
-
-	/**
-	 * Removes all hooks registered by the original WC_Settings_Payment_Gateways instance.
-	 *
-	 * Priorities (20, 30, PHP_INT_MAX) and method names are coupled to WC_Settings_Payment_Gateways
-	 * internals as of WooCommerce 10.8. If WC changes them, remove_* calls silently no-op and
-	 * duplicate hooks may fire. Verify against WC_Settings_Payment_Gateways when upgrading WC.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param \WC_Settings_Payment_Gateways $page Original checkout settings page.
-	 */
-	private static function remove_checkout_page_hooks( \WC_Settings_Payment_Gateways $page ): void {
-		remove_filter( 'woocommerce_settings_tabs_array', array( $page, 'add_settings_page' ), 20 );
-		remove_action( 'woocommerce_sections_' . $page->get_id(), array( $page, 'output_sections' ) );
-		remove_action( 'woocommerce_settings_' . $page->get_id(), array( $page, 'output' ) );
-		remove_action( 'woocommerce_settings_save_' . $page->get_id(), array( $page, 'save' ) );
-		remove_action( 'woocommerce_admin_field_add_settings_slot', array( $page, 'add_settings_slot' ) );
-		// WC <10.9 uses add_modern_settings_body_class; WC 10.9+ renamed it to
-		// add_settings_ui_body_class. Remove both so we cover the supported range.
-		remove_filter( 'admin_body_class', array( $page, 'add_modern_settings_body_class' ) );
-		remove_filter( 'admin_body_class', array( $page, 'add_settings_ui_body_class' ) );
-		remove_filter( 'admin_body_class', array( $page, 'add_body_classes' ), 30 );
-		remove_action( 'admin_head', array( $page, 'hide_help_tabs' ) );
-		remove_action( 'in_admin_header', array( $page, 'suppress_admin_notices' ), PHP_INT_MAX );
-		remove_filter( 'woocommerce_admin_features', array( $page, 'suppress_store_alerts' ), PHP_INT_MAX );
-	}
-
-	/**
-	 * Creates a WC_Settings_Payment_Gateways subclass that adds the Square hub section.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return \WC_Settings_Payment_Gateways
-	 */
-	private static function create_checkout_page_with_square_hub(): \WC_Settings_Payment_Gateways {
-		return new class() extends \WC_Settings_Payment_Gateways {
-
-			/**
-			 * {@inheritDoc}
-			 *
-			 * Appends the Square section to the standard Payments/Checkout sections.
-			 */
-			public function get_sections(): array {
-				return parent::get_sections() + array( Payments_Square_Hub::SECTION => __( 'Square', 'woocommerce-square' ) );
-			}
-
-			/**
-			 * {@inheritDoc}
-			 *
-			 * Returns the Square settings UI adapter when the Square section is active.
-			 * WC 10.9+ calls this method to opt a settings page into the SDK renderer.
-			 */
-			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
-				if ( ! $this->is_square_section() ) {
-					return null;
-				}
-
-				return new Square_Modern_Settings_Page( $this );
-			}
-
-			/**
-			 * Returns true when ?tab=checkout&section=square is active.
-			 */
-			private function is_square_section(): bool {
-				global $current_tab, $current_section;
-
-				return Payments_Square_Hub::CHECKOUT_TAB === $current_tab
-					&& Payments_Square_Hub::SECTION === $current_section;
-			}
-		};
 	}
 
 	/** Gateway section IDs that should redirect to the Square hub. */

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -98,9 +98,9 @@ class Payments_Square_Hub {
 	 */
 	private static function remove_checkout_page_hooks( \WC_Settings_Payment_Gateways $page ): void {
 		remove_filter( 'woocommerce_settings_tabs_array', array( $page, 'add_settings_page' ), 20 );
-		remove_action( 'woocommerce_sections_' . $page->id, array( $page, 'output_sections' ) );
-		remove_action( 'woocommerce_settings_' . $page->id, array( $page, 'output' ) );
-		remove_action( 'woocommerce_settings_save_' . $page->id, array( $page, 'save' ) );
+		remove_action( 'woocommerce_sections_' . $page->get_id(), array( $page, 'output_sections' ) );
+		remove_action( 'woocommerce_settings_' . $page->get_id(), array( $page, 'output' ) );
+		remove_action( 'woocommerce_settings_save_' . $page->get_id(), array( $page, 'save' ) );
 		remove_action( 'woocommerce_admin_field_add_settings_slot', array( $page, 'add_settings_slot' ) );
 		remove_filter( 'admin_body_class', array( $page, 'add_modern_settings_body_class' ) );
 		remove_filter( 'admin_body_class', array( $page, 'add_body_classes' ), 30 );

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -135,9 +135,10 @@ class Payments_Square_Hub {
 			/**
 			 * {@inheritDoc}
 			 *
-			 * Returns the Square modern settings adapter when the Square section is active.
+			 * Returns the Square settings UI adapter when the Square section is active.
+			 * WC 10.9+ calls this method to opt a settings page into the SDK renderer.
 			 */
-			public function get_modern_settings_page(): ?\Automattic\WooCommerce\Admin\Settings\ModernSettingsPageInterface {
+			public function get_settings_ui_page(): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
 				if ( ! $this->is_square_section() ) {
 					return null;
 				}

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -125,9 +125,7 @@ class Payments_Square_Hub {
 			 * Appends the Square section to the standard Payments/Checkout sections.
 			 */
 			public function get_sections(): array {
-				$sections = parent::get_sections();
-				$sections[ Payments_Square_Hub::SECTION ] = __( 'Square', 'woocommerce-square' );
-				return $sections;
+				return parent::get_sections() + array( Payments_Square_Hub::SECTION => __( 'Square', 'woocommerce-square' ) );
 			}
 
 			/**
@@ -246,10 +244,11 @@ class Payments_Square_Hub {
 	 * @return bool
 	 */
 	public static function is_square_payments_hub(): bool {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		return isset( $_GET['page'], $_GET['tab'], $_GET['section'] )
 			&& 'wc-settings' === $_GET['page']
 			&& self::CHECKOUT_TAB === $_GET['tab']
 			&& self::SECTION === $_GET['section'];
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 }

--- a/includes/Admin/Payments_Square_Hub.php
+++ b/includes/Admin/Payments_Square_Hub.php
@@ -32,7 +32,7 @@ use WooCommerce\Square\Plugin;
  *
  * When the modern-settings path is active, this class:
  *   - Extends the WooCommerce Payments/Checkout settings tab to include a Square section.
- *   - Provides get_modern_settings_page() so the SDK renders the 4-tab Square hub.
+ *   - Provides get_settings_ui_page() so the SDK renders the 4-tab Square hub.
  *   - Redirects the legacy ?tab=square URL to the new hub location.
  *
  * @since x.x.x
@@ -106,7 +106,10 @@ class Payments_Square_Hub {
 		remove_action( 'woocommerce_settings_' . $page->get_id(), array( $page, 'output' ) );
 		remove_action( 'woocommerce_settings_save_' . $page->get_id(), array( $page, 'save' ) );
 		remove_action( 'woocommerce_admin_field_add_settings_slot', array( $page, 'add_settings_slot' ) );
+		// WC <10.9 uses add_modern_settings_body_class; WC 10.9+ renamed it to
+		// add_settings_ui_body_class. Remove both so we cover the supported range.
 		remove_filter( 'admin_body_class', array( $page, 'add_modern_settings_body_class' ) );
+		remove_filter( 'admin_body_class', array( $page, 'add_settings_ui_body_class' ) );
 		remove_filter( 'admin_body_class', array( $page, 'add_body_classes' ), 30 );
 		remove_action( 'admin_head', array( $page, 'hide_help_tabs' ) );
 		remove_action( 'in_admin_header', array( $page, 'suppress_admin_notices' ), PHP_INT_MAX );

--- a/includes/Admin/Square_Modern_Settings_Page.php
+++ b/includes/Admin/Square_Modern_Settings_Page.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * WooCommerce Square
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@woocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade WooCommerce Square to newer
+ * versions in the future. If you wish to customize WooCommerce Square for your
+ * needs please refer to https://docs.woocommerce.com/document/woocommerce-square/
+ *
+ * @author    WooCommerce
+ * @copyright Copyright: (c) 2019, Automattic, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
+ */
+
+namespace WooCommerce\Square\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' ) ) {
+
+	/**
+	 * Adapts the Square settings for the WooCommerce modern-settings SDK.
+	 *
+	 * Provides the schema used by the SDK to render the 4-tab Square hub:
+	 *   General | Payment Methods | Payments & Transactions | Synchronize Square
+	 *
+	 * Tickets 2-5 add field groups to each tab. This Ticket 1 implementation
+	 * registers the shell with empty groups so the tab structure is navigable.
+	 *
+	 * @since x.x.x
+	 */
+	class Square_Modern_Settings_Page extends \Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter {
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Returns the WooCommerce Payments/Checkout tab ID so the SDK scopes
+		 * this adapter to ?tab=checkout&section=square.
+		 */
+		public function get_page_id(): string {
+			return Payments_Square_Hub::CHECKOUT_TAB;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Returns the schema for the Square hub. The groups array is intentionally
+		 * empty in Ticket 1; field groups are added in Tickets 2–5.
+		 *
+		 * @param string $section WC section ID (unused; Square sub-tab is read from
+		 *                        the square-tab query arg instead).
+		 */
+		public function get_schema( string $section ): array {
+			return array(
+				'id'      => $this->get_page_id(),
+				'title'   => __( 'Square', 'woocommerce-square' ),
+				'section' => Payments_Square_Hub::SECTION,
+				'shell'   => array(
+					'title'             => __( 'Square', 'woocommerce-square' ),
+					'sectionNavigation' => $this->get_square_tab_navigation(),
+				),
+				'groups'  => array(),
+				'save'    => array( 'adapter' => $this->get_save_adapter( $section ) ),
+			);
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Enqueues the Square settings JS bundle which calls registerSettingsExtension.
+		 *
+		 * @param string $section Unused for Ticket 1 (no fields yet).
+		 */
+		public function get_script_handles( string $section ): array {
+			return array( 'woocommerce-square-settings-js' );
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Returns 'none' for Ticket 1 since no fields are present yet.
+		 * Subsequent tickets switch applicable groups to 'custom' with
+		 * the square/save handler routing to the existing REST endpoints.
+		 *
+		 * @param string $section Unused.
+		 */
+		public function get_save_adapter( string $section ): string {
+			return 'none';
+		}
+
+		/**
+		 * Builds the sectionNavigation array for the 4 Square hub sub-tabs.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return array<int, array{id: string, label: string, href: string, active: bool}>
+		 */
+		private function get_square_tab_navigation(): array {
+			$active_tab = Payments_Square_Hub::get_active_tab();
+			$base_url   = Payments_Square_Hub::get_hub_url();
+
+			$tabs = array(
+				Payments_Square_Hub::TAB_GENERAL               => __( 'General', 'woocommerce-square' ),
+				Payments_Square_Hub::TAB_PAYMENT_METHODS       => __( 'Payment Methods', 'woocommerce-square' ),
+				Payments_Square_Hub::TAB_PAYMENTS_TRANSACTIONS => __( 'Payments & Transactions', 'woocommerce-square' ),
+				Payments_Square_Hub::TAB_SYNCHRONIZE           => __( 'Synchronize Square', 'woocommerce-square' ),
+			);
+
+			$nav = array();
+			foreach ( $tabs as $id => $label ) {
+				$nav[] = array(
+					'id'     => $id,
+					'label'  => $label,
+					'href'   => add_query_arg( Payments_Square_Hub::TAB_ARG, $id, $base_url ),
+					'active' => $active_tab === $id,
+				);
+			}
+
+			return $nav;
+		}
+	}
+}

--- a/includes/Admin/Square_Modern_Settings_Page.php
+++ b/includes/Admin/Square_Modern_Settings_Page.php
@@ -43,11 +43,11 @@ if ( class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAda
 		/**
 		 * {@inheritDoc}
 		 *
-		 * Returns the WooCommerce Payments/Checkout tab ID so the SDK scopes
-		 * this adapter to ?tab=checkout&section=square.
+		 * Returns 'square' so the schema id matches the JS registerSettingsExtension
+		 * scope.page value. Must NOT return the WC tab id ('checkout').
 		 */
 		public function get_page_id(): string {
-			return Payments_Square_Hub::CHECKOUT_TAB;
+			return Payments_Square_Hub::SECTION;
 		}
 
 		/**
@@ -76,12 +76,13 @@ if ( class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAda
 		/**
 		 * {@inheritDoc}
 		 *
-		 * Enqueues the Square settings JS bundle which calls registerSettingsExtension.
+		 * No JS bundle in Ticket 1 (empty shell, no fields). Ticket 2 adds the
+		 * woocommerce-square-settings handle once the webpack bundle exists.
 		 *
-		 * @param string $section Unused for Ticket 1 (no fields yet).
+		 * @param string $section Unused.
 		 */
 		public function get_script_handles( string $section ): array {
-			return array( 'woocommerce-square-settings-js' );
+			return array();
 		}
 
 		/**

--- a/includes/Admin/Square_Modern_Settings_Page.php
+++ b/includes/Admin/Square_Modern_Settings_Page.php
@@ -54,7 +54,7 @@ if ( class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAda
 		 * {@inheritDoc}
 		 *
 		 * Returns the schema for the Square hub. The groups array is intentionally
-		 * empty in Ticket 1; field groups are added in Tickets 2–5.
+		 * empty in Ticket 1; field groups are added in Tickets 2-5.
 		 *
 		 * @param string $section WC section ID (unused; Square sub-tab is read from
 		 *                        the square-tab query arg instead).

--- a/includes/Admin/Square_Modern_Settings_Page.php
+++ b/includes/Admin/Square_Modern_Settings_Page.php
@@ -110,10 +110,10 @@ if ( class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAda
 			$base_url   = Payments_Square_Hub::get_hub_url();
 
 			$tabs = array(
-				Payments_Square_Hub::TAB_GENERAL               => __( 'General', 'woocommerce-square' ),
-				Payments_Square_Hub::TAB_PAYMENT_METHODS       => __( 'Payment Methods', 'woocommerce-square' ),
+				Payments_Square_Hub::TAB_GENERAL         => __( 'General', 'woocommerce-square' ),
+				Payments_Square_Hub::TAB_PAYMENT_METHODS => __( 'Payment Methods', 'woocommerce-square' ),
 				Payments_Square_Hub::TAB_PAYMENTS_TRANSACTIONS => __( 'Payments & Transactions', 'woocommerce-square' ),
-				Payments_Square_Hub::TAB_SYNCHRONIZE           => __( 'Synchronize Square', 'woocommerce-square' ),
+				Payments_Square_Hub::TAB_SYNCHRONIZE     => __( 'Synchronize Square', 'woocommerce-square' ),
 			);
 
 			$nav = array();

--- a/includes/Admin/Square_Settings_Section.php
+++ b/includes/Admin/Square_Settings_Section.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * WooCommerce Square
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@woocommerce.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade WooCommerce Square to newer
+ * versions in the future. If you wish to customize WooCommerce Square for your
+ * needs please refer to https://docs.woocommerce.com/document/woocommerce-square/
+ *
+ * @author    WooCommerce
+ * @copyright Copyright: (c) 2019, Automattic, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0 or later
+ */
+
+namespace WooCommerce\Square\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+if ( class_exists( '\Automattic\WooCommerce\Admin\Settings\SettingsSection' ) ) {
+
+	/**
+	 * Registers the Square hub as a native settings section (WC 11.0+).
+	 *
+	 * Returned from SettingsSectionRegistry when get_settings_ui_page() is available
+	 * (WooCommerce Core PR #65975, milestone 11.0.0). On WC 10.9 the subclass path in
+	 * Payments_Square_Hub is used instead and this class is never instantiated.
+	 *
+	 * @since x.x.x
+	 */
+	class Square_Settings_Section extends \Automattic\WooCommerce\Admin\Settings\SettingsSection {
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_parent_page_id(): string {
+			return Payments_Square_Hub::CHECKOUT_TAB;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_id(): string {
+			return Payments_Square_Hub::SECTION;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		public function get_label(): string {
+			return __( 'Square', 'woocommerce-square' );
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Not used on the native path — schema is provided by Square_Modern_Settings_Page.
+		 */
+		public function get_settings( \WC_Settings_Page $parent_page ): array {
+			return array();
+		}
+
+		/**
+		 * {@inheritDoc}
+		 *
+		 * Returns the Square hub adapter so WC Core uses it directly instead of the
+		 * legacy RegisteredSettingsSectionAdapter / from_legacy_settings() path.
+		 */
+		public function get_settings_ui_page( \WC_Settings_Page $parent_page ): ?\Automattic\WooCommerce\Admin\Settings\SettingsUIPageInterface {
+			return new Square_Modern_Settings_Page( $parent_page );
+		}
+	}
+}

--- a/includes/Emails/WC_Square_Sync_Completed.php
+++ b/includes/Emails/WC_Square_Sync_Completed.php
@@ -113,7 +113,7 @@ class WC_Square_Sync_Completed extends Emails\Base_Email {
 			if ( true === $html ) {
 				$square       = wc_square();
 				$settings_url = $square->get_settings_url();
-				$records_url  = add_query_arg( array( 'section' => 'update' ), $settings_url );
+				$records_url  = $square->get_sync_records_url();
 
 				if ( $square->get_settings_handler()->is_debug_enabled() ) {
 					$action = sprintf(

--- a/includes/Handlers/Products.php
+++ b/includes/Handlers/Products.php
@@ -751,7 +751,7 @@ class Products {
 								esc_html__( 'The product catalog visibility has been set to "hidden", as a matching product could not be found in Square on %1$s at %2$s. %3$sCheck sync records%4$s.', 'woocommerce-square' ),
 								date_i18n( wc_date_format(), $record->get_timestamp() ),
 								date_i18n( wc_time_format(), $record->get_timestamp() ),
-								'<a href="' . esc_url( add_query_arg( array( 'section' => 'update' ), wc_square()->get_settings_url() ) ) . '">',
+								'<a href="' . esc_url( wc_square()->get_sync_records_url() ) . '">',
 								'</a>'
 							)
 						);

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -395,7 +395,7 @@ class Plugin extends Payment_Gateway_Plugin {
 						'<strong>',
 						count( Product::get_products_synced_with_square() ),
 						'</strong>',
-						'<a href="' . esc_url( add_query_arg( 'section', 'update', $this->get_settings_url() ) ) . '">',
+						'<a href="' . esc_url( $this->get_sync_records_url() ) . '">',
 						'</a>'
 					);
 
@@ -924,6 +924,35 @@ class Plugin extends Payment_Gateway_Plugin {
 		);
 
 		// All usage of this return value has been escaped late.
+		// nosemgrep audit.php.wp.security.xss.query-arg
+		return add_query_arg( $params, admin_url( 'admin.php' ) );
+	}
+
+	/**
+	 * Gets the URL of the sync records / "Update from Square" screen.
+	 *
+	 * On the legacy path this is ?tab=square&section=update.
+	 * On the modern path this is the Synchronize sub-tab of the Square hub.
+	 *
+	 * Using a dedicated helper avoids callers appending section=update to
+	 * get_settings_url(), which on the modern path overwrites section=square
+	 * and lands the user on the wrong WC settings section.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	public function get_sync_records_url(): string {
+		if ( $this->is_modern_settings_path_active() ) {
+			return Admin\Payments_Square_Hub::get_hub_url( Admin\Payments_Square_Hub::TAB_SYNCHRONIZE );
+		}
+
+		$params = array(
+			'page'    => 'wc-settings',
+			'tab'     => self::PLUGIN_ID,
+			'section' => 'update',
+		);
+
 		// nosemgrep audit.php.wp.security.xss.query-arg
 		return add_query_arg( $params, admin_url( 'admin.php' ) );
 	}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -698,10 +698,23 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * @return bool
 	 */
 	public function is_modern_settings_path_active(): bool {
-		return class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
-			&& class_exists( '\Automattic\WooCommerce\Admin\Features\Features' )
-			&& \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'modern-settings' )
-			&& ! apply_filters( 'square_disable_modern_settings', false );
+		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
+			|| ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' )
+			|| ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'modern-settings' ) ) {
+			return false;
+		}
+
+		/**
+		 * Filters whether to disable the Square modern settings path.
+		 *
+		 * Return true to force Square to render with the legacy settings page
+		 * regardless of the modern-settings feature flag.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param bool $disabled Whether to disable the modern settings path. Default false.
+		 */
+		return ! (bool) apply_filters( 'square_disable_modern_settings', false );
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -689,8 +689,8 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * Determines if the modern settings path is active.
 	 *
 	 * All three gates must be true:
-	 *   1. The WooCommerce modern-settings SDK class is present.
-	 *   2. The modern-settings feature flag is enabled.
+	 *   1. WooCommerce 11.0+ native registry support is present (SettingsSection::get_settings_ui_page).
+	 *   2. The settings-ui feature flag is enabled.
 	 *   3. The wc_square_is_modern_settings_active escape-hatch filter is not overridden to false.
 	 *
 	 * @since x.x.x
@@ -698,18 +698,15 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * @return bool
 	 */
 	public function is_modern_settings_path_active(): bool {
-		// Both flags are checked for cross-version compat:
-		// - WC <10.9 registered the feature as 'modern-settings'.
-		// - WC 10.9+ renamed it to 'settings-ui' (WC core now gates on 'settings-ui').
-		// Features::is_enabled() reads from `woocommerce_admin_features`; FeaturesUtil
-		// only covers FeaturesController features and always returns false for these.
-		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
+		// Requires WC 11.0+ (WooCommerce Core PR #65975). The presence of
+		// SettingsSection::get_settings_ui_page() is the precise version indicator.
+		if ( ! method_exists( '\Automattic\WooCommerce\Admin\Settings\SettingsSection', 'get_settings_ui_page' )
 			|| ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) ) {
 			return false;
 		}
 
 		$features = \Automattic\WooCommerce\Admin\Features\Features::class;
-		if ( ! $features::is_enabled( 'settings-ui' ) && ! $features::is_enabled( 'modern-settings' ) ) {
+		if ( ! $features::is_enabled( 'settings-ui' ) ) {
 			return false;
 		}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -698,14 +698,18 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * @return bool
 	 */
 	public function is_modern_settings_path_active(): bool {
-		// `modern-settings` is a WooCommerce admin JS feature (registered via the
-		// `woocommerce_admin_features` filter), not a PHP FeaturesController feature.
-		// FeaturesUtil::feature_is_enabled() only covers FeaturesController-registered
-		// features and will always return false for this flag. Features::is_enabled()
-		// reads from `woocommerce_admin_features` and is the correct check here.
+		// Both flags are checked for cross-version compat:
+		// - WC <10.9 registered the feature as 'modern-settings'.
+		// - WC 10.9+ renamed it to 'settings-ui' (WC core now gates on 'settings-ui').
+		// Features::is_enabled() reads from `woocommerce_admin_features`; FeaturesUtil
+		// only covers FeaturesController features and always returns false for these.
 		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
-			|| ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' )
-			|| ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'modern-settings' ) ) {
+			|| ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' ) ) {
+			return false;
+		}
+
+		$features = \Automattic\WooCommerce\Admin\Features\Features::class;
+		if ( ! $features::is_enabled( 'settings-ui' ) && ! $features::is_enabled( 'modern-settings' ) ) {
 			return false;
 		}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -691,7 +691,7 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * All three gates must be true:
 	 *   1. The WooCommerce modern-settings SDK class is present.
 	 *   2. The modern-settings feature flag is enabled.
-	 *   3. The square_disable_modern_settings escape-hatch filter is not applied.
+	 *   3. The wc_square_is_modern_settings_active escape-hatch filter is not overridden to false.
 	 *
 	 * @since x.x.x
 	 *
@@ -714,16 +714,16 @@ class Plugin extends Payment_Gateway_Plugin {
 		}
 
 		/**
-		 * Filters whether to disable the Square modern settings path.
+		 * Filters whether the Square modern settings path is active.
 		 *
-		 * Return true to force Square to render with the legacy settings page
+		 * Return false to force Square to render with the legacy settings page
 		 * regardless of the modern-settings feature flag.
 		 *
 		 * @since x.x.x
 		 *
-		 * @param bool $disabled Whether to disable the modern settings path. Default false.
+		 * @param bool $active Whether the modern settings path is active. Default true.
 		 */
-		return ! (bool) apply_filters( 'square_disable_modern_settings', false );
+		return (bool) apply_filters( 'wc_square_is_modern_settings_active', true );
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -698,9 +698,14 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * @return bool
 	 */
 	public function is_modern_settings_path_active(): bool {
+		// `modern-settings` is a WooCommerce admin JS feature (registered via the
+		// `woocommerce_admin_features` filter), not a PHP FeaturesController feature.
+		// FeaturesUtil::feature_is_enabled() only covers FeaturesController-registered
+		// features and will always return false for this flag. Features::is_enabled()
+		// reads from `woocommerce_admin_features` and is the correct check here.
 		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
-			|| ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' )
-			|| ! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'modern-settings' ) ) {
+			|| ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' )
+			|| ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'modern-settings' ) ) {
 			return false;
 		}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -699,8 +699,8 @@ class Plugin extends Payment_Gateway_Plugin {
 	 */
 	public function is_modern_settings_path_active(): bool {
 		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
-			|| ! class_exists( '\Automattic\WooCommerce\Admin\Features\Features' )
-			|| ! \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'modern-settings' ) ) {
+			|| ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' )
+			|| ! \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'modern-settings' ) ) {
 			return false;
 		}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -678,8 +678,30 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * @return bool
 	 */
 	public function is_plugin_settings() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce note required, read-only check.
-		return parent::is_plugin_settings() || ( isset( $_GET['page'], $_GET['tab'] ) && 'wc-settings' === $_GET['page'] && self::PLUGIN_ID === $_GET['tab'] );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce not required, read-only check.
+		$is_legacy_settings = isset( $_GET['page'], $_GET['tab'] ) && 'wc-settings' === $_GET['page'] && self::PLUGIN_ID === $_GET['tab'];
+		$is_hub_settings    = $this->is_modern_settings_path_active() && Admin\Payments_Square_Hub::is_square_payments_hub();
+
+		return parent::is_plugin_settings() || $is_legacy_settings || $is_hub_settings;
+	}
+
+	/**
+	 * Determines if the modern settings path is active.
+	 *
+	 * All three gates must be true:
+	 *   1. The WooCommerce modern-settings SDK class is present.
+	 *   2. The modern-settings feature flag is enabled.
+	 *   3. The square_disable_modern_settings escape-hatch filter is not applied.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public function is_modern_settings_path_active(): bool {
+		return class_exists( '\Automattic\WooCommerce\Admin\Settings\LegacySettingsPageAdapter' )
+			&& class_exists( '\Automattic\WooCommerce\Admin\Features\Features' )
+			&& \Automattic\WooCommerce\Admin\Features\Features::is_enabled( 'modern-settings' )
+			&& ! apply_filters( 'square_disable_modern_settings', false );
 	}
 
 	/**
@@ -869,6 +891,10 @@ class Plugin extends Payment_Gateway_Plugin {
 	 * @return string
 	 */
 	public function get_settings_url( $gateway_id = null ) {
+
+		if ( $this->is_modern_settings_path_active() ) {
+			return Admin\Payments_Square_Hub::get_hub_url();
+		}
 
 		$params = array(
 			'page' => 'wc-settings',


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable? Foundational Playwright smoke tests (modern hub loads / legacy loads flag-off / escape-hatch forces legacy) are deferred to https://linear.app/a8c/issue/SQUARE-286/update-ui-9-end-to-end-qa-settings-migration-and-integration.
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/SQUARE-278/ui-update-1-establish-new-settings-tab-shell-and-remove-legacy-menu.

This is **Ticket 1** of the Square settings redesign series. It establishes the hub shell and routing infrastructure that Tickets 2-5 build on. No settings fields are added here; only the tab structure, gating logic, and legacy redirects.

<img width="1938" height="750" alt="image" src="https://github.com/user-attachments/assets/e3410709-58cb-4b4c-85f0-8977ad36d55c" />

#### WooCommerce 11.0 requirement

The modern path requires **WooCommerce 11.0** (WC Core PR [#65975](https://github.com/woocommerce/woocommerce/pull/65975)), which adds `SettingsSection::get_settings_ui_page()`, the native registry hook Square uses to slot its hub into WooCommerce > Settings > Payments > Square.

The gate in `Plugin::is_modern_settings_path_active()` checks two things:
1. `method_exists(SettingsSection, 'get_settings_ui_page')` - WC 11.0 presence check
2. `Features::is_enabled('settings-ui')` - feature flag

On WC < 11.0 or when the flag is off, `Settings_Page.php` (legacy top-level Square tab) is used unchanged.

#### Note on `Features::is_enabled` vs `FeaturesUtil`

`FeaturesUtil::feature_is_enabled()` delegates to `FeaturesController`, which only covers features registered in `FeaturesController::get_feature_definitions()`. The `settings-ui` flag is a **WooCommerce admin JS feature** and lives in the `woocommerce_admin_features` filter system (same one that populates `window.wcAdminFeatures`), not in `FeaturesController`. Using `FeaturesUtil` for it always returns `false`. `Features::is_enabled()` is the correct check. A comment in `Plugin.php` documents this distinction.

### Steps to test the changes in this Pull Request:

**Environment:** WooCommerce 11.0 dev build (use the zip from dmallory, WC Core PR #65975 branch, until Beta 1 ships on July 13).

**Setup - two mu-plugin files are needed. Drop them into `wp-content/mu-plugins/`:**
- [modern-settings-flag.php](https://gist.github.com/faisal-alvi/09a5996522d214c86d2d019155821d12) - enables `settings-ui` feature flag
- [square-disable-modern-settings.php](https://gist.github.com/faisal-alvi/6a3cef28b42fa1b02b81e18bf756f879) - escape hatch, forces Square back to legacy even when the flag is on

---

**Modern path (WC 11.0 zip + flag on, escape hatch off):**

1. Add `modern-settings-flag.php` to `mu-plugins/`. Verify in browser console: `window.wcAdminFeatures['settings-ui']` is `true`.
2. Navigate to **WooCommerce > Settings > Payments > Square** and confirm the hub renders with 4 sub-tabs: General, Payment Methods, Payments & Transactions, Synchronize Square. The top-level **Square** tab should be gone from the main nav.
3. Click each sub-tab and confirm the active state updates correctly in the URL (`?square-tab=...`) and the tab highlight.
4. Navigate to `?page=wc-settings&tab=square` (legacy URL) and confirm it redirects to the hub.
5. Navigate to `?page=wc-settings&tab=checkout&section=square_credit_card` and confirm redirect to hub.

**Legacy path (flag off or WC < 11.0):**

6. Remove `modern-settings-flag.php`. Confirm the top-level **WooCommerce > Settings > Square** tab reappears and is fully functional.

**Escape hatch (flag on, Square forced to legacy):**

7. Re-add `modern-settings-flag.php`. Add `square-disable-modern-settings.php` to `mu-plugins/`. Confirm `window.wcAdminFeatures['settings-ui']` is still `true` in the console, but Square falls back to the legacy top-level tab and the hub does not appear.

### Changelog entry

> Add - Introduce Square settings hub under WooCommerce > Settings > Payments > Square via WC 11.0 native registry, with full fallback to the legacy settings tab on older WooCommerce or when the flag is off.