### PR TITLE
Always use temp IDs for new Square catalog objects

### DIFF
--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -273,7 +273,8 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 		self::update_variation( $product, $catalog_object );
 
 		if ( ! $catalog_object->getId() ) {
-			$catalog_object->setId( self::get_square_item_variation_id( $product ) );
+			// Use a temp ID so stale stored variation IDs do not cause Square to reject the batch.
+			$catalog_object->setId( '#item_variation_' . $product->get_id() );
 		}
 
 		if ( ! $catalog_object->getVersion() ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1000,8 +1000,12 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$catalog_objects = array();
 		foreach ( $product_ids as $product_id ) {
-			$catalog_item   = new \Square\Models\CatalogItem();
-			$catalog_object = new CatalogObject( 'ITEM', Product::get_square_item_id( $product_id ) );
+			$catalog_item = new \Square\Models\CatalogItem();
+			// Always use a Square temp ID (prefixed with '#') regardless of any stored Square ID.
+			// Stored IDs may be stale (e.g. catalog wiped on the Square side) and would cause Square
+			// to reject the entire batch with INVALID_VALUE. Square maps temp IDs to new permanent IDs
+			// in the response, which are written back to WC postmeta by upsert_catalog_objects().
+			$catalog_object = new CatalogObject( 'ITEM', '#item_' . $product_id );
 			$catalog_object->setItemData( $catalog_item );
 			$catalog_objects[ $product_id ] = $catalog_object;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/SQUARE-143/feature-request-square-if-product-has-an-issue-skip-the-product.
Closes https://linear.app/a8c/issue/SQUARE-133/question-square-sync-failing-due-to-orphaned-square-object-ids (similar)

When `upsert_new_products` builds `CatalogObject` instances to send to Square via `batchUpsertCatalogObjects`, it previously passed the stored Square item/variation IDs from WC postmeta. If those IDs refer to catalog objects that no longer exist in Square (e.g. catalog wiped by support, sandbox reset), Square rejects the **entire batch** with `INVALID_VALUE`, blocking all other valid products in the same sync.

Related Slack Threads:
- [Thread 1](https://fueled.slack.com/archives/C01TYRCJ1QD/p1779111192416559?thread_ts=1775556489.891209&amp;cid=C01TYRCJ1QD)
- [Thread 2](https://fueled.slack.com/archives/C01UCQGPBDJ/p1779112263947779)

**Fix:** Always use Square's temp ID convention (`#item_{product_id}` / `#item_variation_{product_id}`) for new catalog objects. Square treats `#`-prefixed IDs as "create new", assigns permanent IDs, and returns them in the `idMappings` response. The existing `upsert_catalog_objects()` handler already parses both `#item_` and `#item_variation_` prefixes and writes the new permanent IDs back to WC postmeta - no additional write-back code needed.

Also, the logs from SQUARE-133 (a separate merchant ticket with identical symptoms) confirm this exact failure path: on the first sync attempt, `upsert_new_products` sent a permanent stale ID `QBY346ZPDA7SJNEIRZRFEIOJ` to Square and received `INVALID_VALUE`, rejecting the entire batch of 25 products. On the retry, the same 25 products were sent using `#item_` temp IDs and succeeded. The fix removes the dependency on `clear_square_meta` running cleanly by always using temp IDs in `upsert_new_products`, making the outcome the same regardless of what state the stored meta is in.

### Steps to test the changes in this Pull Request:

1. On a product synced with Square, manually set a stale/fake Square item ID: `_square_item_id` = `"STALE_FAKE_ID"` and `_square_item_variation_id` = `"STALE_FAKE_VAR_ID"`
2. Ensure WooCommerce is set as the Source of Record (Settings -> Square -> Sync)
3. Trigger a manual sync (WooCommerce -> Square Settings -> Update tab -> Sync now)
4. After sync completes, confirm the postmeta now holds a real permanent Square ID (not the stale value): check for `_square_item_id` in DB.

**Expected (after fix):** sync succeeds and new permanent IDs are written back to postmeta.
**Before fix:** Square rejects the batch with `INVALID_VALUE` and the sync fails entirely.

### Changelog entry

> Fix – Square product syncs no longer fail entirely when one item has an outdated catalog ID.