### PR TITLE
SQUARE-323: push inventory per batch during new product creation

### DIFF
--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1380,31 +1380,7 @@ class Manual_Synchronization extends Stepped_Job {
 				continue;
 			}
 
-			$product_inventory_changes = array();
-
-			if ( $product->is_type( 'variable' ) && $product->has_child() ) {
-
-				foreach ( $product->get_children() as $child_id ) {
-
-					$child = wc_get_product( $child_id );
-					if ( ! $child instanceof \WC_Product || ! $child->get_manage_stock() ) {
-						continue;
-					}
-
-					$inventory_change = Product::get_inventory_change_physical_count_type( $child );
-					if ( $inventory_change ) {
-						$product_inventory_changes[] = $inventory_change;
-					}
-				}
-			} else {
-
-				if ( $product->get_manage_stock() ) {
-					$inventory_change = Product::get_inventory_change_physical_count_type( $product );
-					if ( $inventory_change ) {
-						$product_inventory_changes[] = $inventory_change;
-					}
-				}
-			}
+			$product_inventory_changes = $this->get_product_inventory_changes( $product );
 
 			if ( ! empty( $product_inventory_changes ) ) {
 				$inventory_changes[ $product_id ] = $product_inventory_changes;
@@ -1446,6 +1422,53 @@ class Manual_Synchronization extends Stepped_Job {
 		);
 
 		return $failed_ids;
+	}
+
+
+	/**
+	 * Builds inventory change objects for a single product.
+	 *
+	 * Handles both variable and simple products. For variable products it iterates
+	 * each child variation; for simple products it acts on the product itself.
+	 * Only products with stock management enabled produce inventory changes.
+	 *
+	 * Note: this method does not perform SKU-based Square ID lookups. It assumes
+	 * Square variation IDs are already stored in WC postmeta, which is guaranteed
+	 * for products that have just been upserted via upsert_catalog_objects().
+	 * The deferred push_inventory() step handles its own SKU lookups separately.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WC_Product $product WooCommerce product object.
+	 * @return \Square\Models\InventoryChange[] Inventory change objects for the product.
+	 */
+	private function get_product_inventory_changes( \WC_Product $product ): array {
+
+		$changes = array();
+
+		if ( $product->is_type( 'variable' ) && $product->has_child() ) {
+
+			foreach ( $product->get_children() as $child_id ) {
+
+				$child = wc_get_product( $child_id );
+				if ( ! $child instanceof \WC_Product || ! $child->get_manage_stock() ) {
+					continue;
+				}
+
+				$change = Product::get_inventory_change_physical_count_type( $child );
+				if ( $change ) {
+					$changes[] = $change;
+				}
+			}
+		} elseif ( $product->get_manage_stock() ) {
+
+			$change = Product::get_inventory_change_physical_count_type( $product );
+			if ( $change ) {
+				$changes[] = $change;
+			}
+		}
+
+		return $changes;
 	}
 
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1396,14 +1396,18 @@ class Manual_Synchronization extends Stepped_Job {
 		// Chunk by the batch limit in case the set of products has many variations.
 		$chunks = array_chunk( $all_changes, self::BATCH_CHANGE_INVENTORY_LIMIT );
 
-		foreach ( $chunks as $chunk ) {
+		$total_chunks = count( $chunks );
+
+		foreach ( $chunks as $chunk_index => $chunk ) {
 			try {
 				$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $chunk ) ) . '_inline_inventory_' . $this->get_attr( 'id' ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 				wc_square()->get_api()->batch_change_inventory( $idempotency_key, $chunk );
 			} catch ( \Exception $e ) {
 				wc_square()->log(
 					sprintf(
-						'Inline inventory push failed for %d products during upsert_new_products: %s. These will be retried by the push_inventory step.',
+						'Inline inventory push failed on chunk %d of %d for %d products during upsert_new_products: %s. These will be retried by the push_inventory step.',
+						$chunk_index + 1,
+						$total_chunks,
 						count( $inventory_changes ),
 						$e->getMessage()
 					)

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1391,7 +1391,6 @@ class Manual_Synchronization extends Stepped_Job {
 			return array();
 		}
 
-		$failed_ids  = array();
 		$all_changes = array_merge( ...array_values( $inventory_changes ) );
 
 		// Chunk by the batch limit in case the set of products has many variations.
@@ -1421,7 +1420,7 @@ class Manual_Synchronization extends Stepped_Job {
 			)
 		);
 
-		return $failed_ids;
+		return array();
 	}
 
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1008,8 +1008,16 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$result = $this->upsert_catalog_objects( $catalog_objects, true );
 
-		// newly upserted IDs should get their inventory pushed
-		$inventory_push_product_ids = array_merge( $result['processed'], $inventory_push_product_ids );
+		// Push inventory inline immediately after each upsert batch when inventory sync is enabled.
+		// This ensures products don't sit in Square with zero inventory if the sync fails before
+		// the deferred push_inventory step runs. Only IDs whose inline push failed are queued for
+		// the deferred step - successful pushes are not re-queued to avoid double-counting.
+		if ( wc_square()->get_settings_handler()->is_inventory_sync_enabled() && ! empty( $result['processed'] ) ) {
+			$failed_inventory_ids       = $this->push_inventory_for_products( $result['processed'] );
+			$inventory_push_product_ids = array_merge( $failed_inventory_ids, $inventory_push_product_ids );
+		} else {
+			$inventory_push_product_ids = array_merge( $result['processed'], $inventory_push_product_ids );
+		}
 		$this->set_attr( 'inventory_push_product_ids', $inventory_push_product_ids );
 
 		// update the processed list
@@ -1345,6 +1353,99 @@ class Manual_Synchronization extends Stepped_Job {
 				}
 			}
 		}
+	}
+
+
+	/**
+	 * Pushes WooCommerce inventory to Square for a specific set of product IDs.
+	 *
+	 * Called inline after each upsert_new_products batch so that newly created Square catalog
+	 * objects receive correct stock quantities immediately, rather than waiting for the deferred
+	 * push_inventory step. If the API call fails the exception is caught, the failure is logged,
+	 * and the affected product IDs are returned so the caller can queue them for the deferred step.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int[] $product_ids WooCommerce product IDs to push inventory for.
+	 * @return int[] Product IDs for which the inventory push failed.
+	 */
+	private function push_inventory_for_products( array $product_ids ): array {
+
+		$inventory_changes = array();
+
+		foreach ( $product_ids as $product_id ) {
+
+			$product = wc_get_product( $product_id );
+			if ( ! $product instanceof \WC_Product ) {
+				continue;
+			}
+
+			$product_inventory_changes = array();
+
+			if ( $product->is_type( 'variable' ) && $product->has_child() ) {
+
+				foreach ( $product->get_children() as $child_id ) {
+
+					$child = wc_get_product( $child_id );
+					if ( ! $child instanceof \WC_Product || ! $child->get_manage_stock() ) {
+						continue;
+					}
+
+					$inventory_change = Product::get_inventory_change_physical_count_type( $child );
+					if ( $inventory_change ) {
+						$product_inventory_changes[] = $inventory_change;
+					}
+				}
+			} else {
+
+				if ( $product->get_manage_stock() ) {
+					$inventory_change = Product::get_inventory_change_physical_count_type( $product );
+					if ( $inventory_change ) {
+						$product_inventory_changes[] = $inventory_change;
+					}
+				}
+			}
+
+			if ( ! empty( $product_inventory_changes ) ) {
+				$inventory_changes[ $product_id ] = $product_inventory_changes;
+			}
+		}
+
+		if ( empty( $inventory_changes ) ) {
+			return array();
+		}
+
+		$failed_ids  = array();
+		$all_changes = array_merge( ...array_values( $inventory_changes ) );
+
+		// Chunk by the batch limit in case the set of products has many variations.
+		$chunks = array_chunk( $all_changes, self::BATCH_CHANGE_INVENTORY_LIMIT );
+
+		foreach ( $chunks as $chunk ) {
+			try {
+				$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $chunk ) ) . '_inline_inventory_' . $this->get_attr( 'id' ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				wc_square()->get_api()->batch_change_inventory( $idempotency_key, $chunk );
+			} catch ( \Exception $e ) {
+				wc_square()->log(
+					sprintf(
+						'Inline inventory push failed for %d products during upsert_new_products: %s. These will be retried by the push_inventory step.',
+						count( $inventory_changes ),
+						$e->getMessage()
+					)
+				);
+				// Return all product IDs so the deferred push_inventory step retries them.
+				return array_keys( $inventory_changes );
+			}
+		}
+
+		wc_square()->log(
+			sprintf(
+				'Pushed inventory inline for %d newly upserted products.',
+				count( $inventory_changes )
+			)
+		);
+
+		return $failed_ids;
 	}
 
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -975,9 +975,16 @@ class Manual_Synchronization extends Stepped_Job {
 			// Remove linked products from the upsert batch.
 			$product_ids = array_values( array_diff( $product_ids, $linked_product_ids ) );
 
-			// Linked products count as processed and need inventory push.
-			$processed_product_ids      = array_merge( $linked_product_ids, $processed_product_ids );
-			$inventory_push_product_ids = array_merge( $linked_product_ids, $inventory_push_product_ids );
+			// Linked products count as processed. Push their inventory inline when inventory sync
+			// is enabled - Square IDs are fresh in postmeta at this point. Only failed IDs are
+			// queued for the deferred step.
+			$processed_product_ids = array_merge( $linked_product_ids, $processed_product_ids );
+			if ( wc_square()->get_settings_handler()->is_inventory_sync_enabled() ) {
+				$failed_linked_ids          = $this->push_inventory_for_products( $linked_product_ids );
+				$inventory_push_product_ids = array_merge( $failed_linked_ids, $inventory_push_product_ids );
+			} else {
+				$inventory_push_product_ids = array_merge( $linked_product_ids, $inventory_push_product_ids );
+			}
 			$this->set_attr( 'processed_product_ids', $processed_product_ids );
 			$this->set_attr( 'inventory_push_product_ids', $inventory_push_product_ids );
 


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/SQUARE-323/push-inventory-per-batch-during-new-product-creation-instead-of

When running a manual sync with Woo as the System of Record, `upsert_new_products` creates new Square catalog items in batches of 25. Until now, inventory was pushed to Square in a separate `push_inventory` step that only runs after all batches complete. On large catalogs this creates a wide failure window - for example, if the sync for 6,000 products (240 batches of 25) times out or errors at batch 150, every product already created in Square sits at 0 inventory with no automated recovery path.

This fix pushes inventory to Square inline, immediately after each `upsert_catalog_objects` call succeeds. A new private helper method `push_inventory_for_products()` handles the API call, using a shared `get_product_inventory_changes()` helper that builds the inventory change objects for a product. If the inline push fails, the affected IDs are queued into `inventory_push_product_ids` so the existing deferred `push_inventory` step picks them up as a safety net. Products whose inline push succeeds are not queued - so there is no double-push.

One edge case worth noting: `push_inventory_for_products` chunks inventory changes in groups of 100 (the Square API limit per `batchChangeInventory` call). If a product batch produces more than 100 changes (e.g. a variable product with many variations), it takes multiple chunks. If chunk 1 succeeds but chunk 2 fails, the method returns all product IDs in that batch as failed - so the deferred `push_inventory` step will re-push the products from chunk 1 as well. This is intentional: it keeps the failure handling simple and the worst case is a repeat push of the same stock counts to Square, which is harmless.

The deferred `push_inventory` step is completely unchanged and still runs at the end of the pipeline. For a clean sync it simply finds an empty queue and completes immediately. For a sync that partially fails mid-way, it handles any IDs that the inline push could not cover.

Behaviour is unchanged when inventory sync is disabled in settings - the existing code path is taken and all processed IDs go into `inventory_push_product_ids` as before.

**Note on batch size - why it was not reduced and still kept at 25**

Reducing the batch size was considered as part of this work. The argument was that smaller batches mean less inventory exposure per crash. However, the inline push already reduces the worst-case exposure to at most one in-flight batch regardless of its size - so going from 25 to, for example, 15 would make almost no practical difference to the failure window.

The downside is more meaningful: the batch size controls how many WC products are processed per AJAX step call. Dropping to 15 increases round-trips by 67% for every sync. For a 6,000-product merchant that is roughly 160 extra AJAX requests, each carrying full PHP and DB overhead, which adds up to a noticeably longer total sync time.

The batch size is already filterable via the `wc_square_sync_max_objects_per_upsert` filter, so any merchant or environment that needs smaller batches can tune it without a code change. If future data from large-catalog merchants shows 25 is regularly causing AJAX timeouts, that is a good reason to revisit the default in a separate ticket. It is not the right change to bundle here.

### Steps to test the changes in this Pull Request:

**Scenario 1 - reproduce the original issue on trunk**

1. Activate the plugin in the `trunk` branch.
2. Set System of Record to WooCommerce and enable inventory sync in Square settings.
3. Create two simple products with stock management enabled and a stock quantity > 0. Enable "Sync with Square" on each. It would be great if only these 2 products are set as Sync with Square for easy and quicker testing.
4. Make sure neither product exists in Square yet (no `_square_item_id` stored in WC postmeta).
5. In `includes/Sync/Manual_Synchronization.php`, add this at the very top/start of the `push_inventory()` method body to simulate the step never running:
```php
throw new \Exception( 'Simulated crash: push_inventory never ran' );
```
6. Run a manual sync from WooCommerce > Settings > Square > Update.
7. Open Square Dashboard - both products should now exist but with 0 inventory, because `push_inventory` was never reached.
8. Remove the throw line from step 5. This is the bug this PR fixes.

**Scenario 2 - sync fails mid-way (fix limits the damage)**

9. Switch branch to this PR branch (`SQUARE-323`).
10. Delete the test products from Square Dashboard but leave them in WooCommerce.
11. Clear the Square meta from those products so they route through `upsert_new_products` again. Run this SQL against the `wp_postmeta` table, replacing the IDs with your actual product IDs:
```sql
DELETE FROM wp_postmeta
WHERE post_id IN (700, 701)
AND meta_key IN ('_square_item_id', '_square_item_variation_id');
```
12. Create `wp-content/mu-plugins/square-323-test.php` to force the batch size to 1 so each product is its own batch:
```php
<?php
// SQUARE-323 crash test - DELETE THIS FILE when done.
add_filter( 'wc_square_sync_max_objects_per_upsert', function() {
    return 1;
} );
```
13. Add this temporary block at the very top/start of the `push_inventory_for_products()` method body in `includes/Sync/Manual_Synchronization.php` to crash on the second inline push:
```php
// SQUARE-323 CRASH TEST - REMOVE AFTER TESTING.
$call_count = (int) get_transient( 'sq323_push_count' );
set_transient( 'sq323_push_count', ++$call_count, 5 * MINUTE_IN_SECONDS );
if ( $call_count > 1 ) {
    throw new \Exception( 'Simulated crash on second inline inventory push' );
}
// END CRASH TEST.
```
Also reset the counter before running manual sync every time, direct SQL command to run in DB (or just manually delete it manually): `DELETE FROM wp_options WHERE option_name LIKE '%sq323_push_count%';`
14. Run manual sync.
15. Open Square Dashboard - the first product processed should have correct inventory (its inline push completed before the crash). The second product should exist in Square with 0 inventory (crash happened before its inline push fired).
16. Without this fix, both products would have 0 inventory (step 7) - this confirms the inline push protects completed batches even when the sync fails mid-way.

**Scenario 3 - full clean sync succeeds with all inventory correct**

17. Remove the mu-plugin file from step 12 and remove the temporary throw block from step 13.
18. Delete both test products from Square Dashboard.
19. Clear the Square meta again:
```sql
DELETE FROM wp_postmeta
WHERE post_id IN (700, 701)
AND meta_key IN ('_square_item_id', '_square_item_variation_id');
```
20. Run manual sync.
21. Confirm the sync completes without errors.
22. Open Square Dashboard - both products should exist with the correct inventory counts matching WooCommerce stock quantities.
23. Check the debug log (WooCommerce > Status > Logs) and confirm you see `Pushed inventory inline for N newly upserted products.` for each batch.

### Changelog entry

> Fix – Syncing new products to Square no longer leaves them at zero inventory if the sync fails partway through.