### PR TITLE
Nest reducedMotion under contextOptions in Playwright config

### DIFF
--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -65,7 +65,9 @@ module.exports = defineConfig({
     storageState: 'state.json',
     navigationTimeout: 60000,
     // Disable CSS animations/transitions so Playwright doesn't time out on @wordpress/components buttons.
-    reducedMotion: 'reduce',
+    contextOptions: {
+      reducedMotion: 'reduce',
+    },
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## Context

PR #507 added `reducedMotion: 'reduce'` directly under the top-level `use` block in `tests/e2e/config/playwright.config.js` to stop Playwright 1.57+ stability checks from timing out on CSS transitions.

Per Playwright's TestOptions docs, `reducedMotion` is not a recognized top-level `use` key, it only reaches the browser context through `contextOptions`. Flagged during review on a related woocommerce-xero PR: https://github.com/woocommerce/woocommerce-xero/pull/614#discussion_r3518897998

## Change

Nest the option correctly:

```js
contextOptions: {
  reducedMotion: 'reduce',
},
```

## Test plan

- [x] Run e2e sync tests and confirm no stability timeouts on settings save

Closes #516