### PR TITLE
Automatically recover a stuck background sync job and unblock the queue

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -109,6 +109,9 @@ class Admin {
 
 		// Show warning notice for the user to manually trigger a sync if it has been a while since the last successful sync.
 		add_action( 'admin_notices', array( $this, 'maybe_show_sync_status_notice' ) );
+
+		// Show a notice when a stalled sync job was automatically recovered, prompting a re-run.
+		add_action( 'admin_notices', array( $this, 'maybe_show_sync_recovered_notice' ) );
 	}
 
 
@@ -454,6 +457,61 @@ class Admin {
 						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square&section=update' ) ) . '">',
 						'</a>',
 						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-status&tab=tools' ) ) . '">',
+						'</a>'
+					),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				);
+				?>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Maybe show a notice that a stalled sync job was automatically recovered.
+	 *
+	 * Shown when auto-recovery has fired and no successful sync has completed since, so the
+	 * merchant knows the previous sync was interrupted and restarted and can verify their products.
+	 * Clears itself once a sync completes successfully after the recovery.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	public function maybe_show_sync_recovered_notice() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return;
+		}
+
+		$settings = wc_square()->get_settings_handler();
+		if ( ! $settings->is_connected() || ! $settings->get_location_id() || ! $settings->is_product_sync_enabled() ) {
+			return;
+		}
+
+		$recovered_at = (int) get_option( 'wc_square_sync_auto_recovered_at', 0 );
+		if ( ! $recovered_at ) {
+			return;
+		}
+
+		// Once a sync has completed successfully after the recovery, the notice is no longer relevant.
+		$last_synced_at = (int) wc_square()->get_sync_handler()->get_last_synced_at();
+		if ( $last_synced_at >= $recovered_at ) {
+			delete_option( 'wc_square_sync_auto_recovered_at' );
+			return;
+		}
+		?>
+		<div class="notice notice-warning is-dismissible">
+			<p>
+				<?php
+				echo wp_kses(
+					sprintf(
+						/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
+						__( 'A Square sync job was interrupted and has been automatically restarted. Please verify your products are up to date, or manually trigger a sync from the %1$supdate page%2$s.', 'woocommerce-square' ),
+						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square&section=update' ) ) . '">',
 						'</a>'
 					),
 					array(

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -497,12 +497,12 @@ class Admin {
 			return;
 		}
 
-		// Once a sync has completed successfully after the recovery, the notice is no longer relevant.
-		$last_synced_at = (int) wc_square()->get_sync_handler()->get_last_synced_at();
-		if ( $last_synced_at >= $recovered_at ) {
-			delete_option( 'wc_square_sync_auto_recovered_at' );
-			return;
-		}
+		// The flag itself is the only signal used here. It is cleared when a sync the merchant started
+		// begins, and again when such a job completes, so there is nothing left to infer.
+		//
+		// It deliberately does NOT compare against the last synced timestamp: interval polling advances
+		// that every few minutes, so any comparison against it would dismiss this notice long before
+		// the merchant saw it, which is the same reason polls are excluded from both clearing paths.
 		?>
 		<div class="notice notice-warning is-dismissible">
 			<p>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -475,7 +475,7 @@ class Admin {
 	 * Maybe show a notice that a stalled sync job was automatically recovered.
 	 *
 	 * Shown when auto-recovery has fired and no successful sync has completed since, so the
-	 * merchant knows the previous sync was interrupted and restarted and can verify their products.
+	 * merchant knows a stuck sync was stopped and can start a new one.
 	 * Clears itself once a sync completes successfully after the recovery.
 	 *
 	 * @since x.x.x
@@ -510,7 +510,7 @@ class Admin {
 				echo wp_kses(
 					sprintf(
 						/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
-						__( 'A Square sync job was interrupted and has been automatically restarted. Please verify your products are up to date, or manually trigger a sync from the %1$supdate page%2$s.', 'woocommerce-square' ),
+						__( 'A stuck Square sync job was detected and automatically stopped. Product data may be out of date, please start a new sync from the %1$supdate page%2$s.', 'woocommerce-square' ),
 						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=square&section=update' ) ) . '">',
 						'</a>'
 					),

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -168,10 +168,12 @@ class Background_Job extends Background_Job_Handler {
 			$job->status                = 'processing';
 			$job->started_processing_at = current_time( 'mysql' );
 
-			$job = $this->update_job( $job );
+			$this->update_job( $job );
 
-			// The row can be gone if the job was cleared concurrently (e.g. the Clear Square Sync
-			// tool), so guard before dereferencing the job below.
+			// Re-read the row: update_job() returns the supplied object even when the underlying
+			// option no longer exists (e.g. the Clear Square Sync tool removed it concurrently),
+			// so only a fresh read can prove the job is still there.
+			$job = $this->get_job( $job->id );
 			if ( ! $job ) {
 				return;
 			}

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -425,15 +425,34 @@ class Background_Job extends Background_Job_Handler {
 		// A runner action is still queued: the queue may be paused, not dead (low traffic sites can
 		// go quiet long enough for the threshold to pass, then resume on the visit that triggered
 		// this very check). Give the queue one grace window to make progress; recover only if the
-		// job is still stalled with the same queued action after the grace period.
+		// job is still stalled with the same queued action after that window.
 		if ( function_exists( 'as_next_scheduled_action' ) && false !== as_next_scheduled_action( 'wc_square_job_runner' ) ) {
+
+			/**
+			 * Filters how long a stalled sync job is given to resume when a job runner action is
+			 * still queued, before it is treated as dead.
+			 *
+			 * A queued action means the queue may simply be paused rather than broken, and the
+			 * request that runs this check usually gives Action Scheduler its chance to run, so this
+			 * only needs to be long enough for that to happen. It is deliberately shorter than the
+			 * stall threshold: with both at their defaults a paused queue is left alone for 15
+			 * minutes and a genuinely dead one is failed after 20, not 30.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param int $grace_period grace period in seconds (default a third of the stall threshold)
+			 */
+			$grace_period = max( MINUTE_IN_SECONDS, (int) apply_filters( 'wc_square_stuck_job_grace_period', (int) round( $threshold / 3 ) ) );
+
 			$grace_started = (int) get_option( 'wc_square_recovery_grace_at', 0 );
+
 			if ( ! $grace_started ) {
 				update_option( 'wc_square_recovery_grace_at', time(), false );
-				wc_square()->log( 'Stalled sync has a queued runner action; allowing a grace window before auto-failing.' );
+				wc_square()->log( sprintf( 'Stalled sync has a queued runner action; allowing %d seconds for the queue to resume before auto-failing.', $grace_period ) );
 				return;
 			}
-			if ( ( time() - $grace_started ) < $threshold ) {
+
+			if ( ( time() - $grace_started ) < $grace_period ) {
 				return;
 			}
 		}

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -64,6 +64,11 @@ class Background_Job extends Background_Job_Handler {
 
 		// Sync healthcheck
 		add_action( $this->cron_hook_identifier, array( $this, 'handle_sync_healthcheck' ) );
+
+		// Safety net for sites where cron/Action Scheduler execution is broken (the reported
+		// incident had the healthcheck actions themselves failing for a month): any admin page
+		// load can also detect and recover a stalled sync. Throttled internally.
+		add_action( 'admin_init', array( $this, 'maybe_recover_stuck_sync_from_admin' ) );
 	}
 
 
@@ -314,6 +319,31 @@ class Background_Job extends Background_Job_Handler {
 		$this->debug_message = esc_html__( 'Success! You can now sync your products.', 'woocommerce-square' );
 
 		return true;
+	}
+
+	/**
+	 * Runs the stalled-sync recovery check from admin page loads, throttled.
+	 *
+	 * The scheduled healthcheck is the primary trigger, but on sites where cron or Action
+	 * Scheduler execution is broken (as in the reported incident, where the healthcheck actions
+	 * themselves failed for a month) it never runs. Admin page loads are the one context such a
+	 * site still exercises, so use them as a fallback trigger. Throttled to once per five minutes
+	 * and restricted to users who can manage WooCommerce.
+	 *
+	 * @since x.x.x
+	 */
+	public function maybe_recover_stuck_sync_from_admin() {
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Unknown
+			return;
+		}
+
+		if ( get_transient( 'wc_square_admin_recovery_check' ) ) {
+			return;
+		}
+		set_transient( 'wc_square_admin_recovery_check', 1, 5 * MINUTE_IN_SECONDS );
+
+		$this->maybe_recover_stuck_sync();
 	}
 
 	/**

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -168,18 +168,23 @@ class Background_Job extends Background_Job_Handler {
 			$job->status                = 'processing';
 			$job->started_processing_at = current_time( 'mysql' );
 
-			// A new sync is now running, so the recovery notice has served its purpose. Clearing it
-			// here rather than on completion means a long sync does not keep showing a warning about
-			// the previous one for hours.
-			delete_option( 'wc_square_sync_auto_recovered_at' );
+			// A sync the merchant started has taken over, so the recovery notice has served its
+			// purpose. Clearing it here rather than on completion means a long sync does not keep
+			// showing a warning about the previous one for hours. Interval poll jobs are excluded:
+			// they start on their own every few minutes and would dismiss the notice before anyone
+			// had a chance to read it.
+			if ( 'poll' !== ( $job->action ?? '' ) ) {
+				delete_option( 'wc_square_sync_auto_recovered_at' );
+			}
 
 			$this->update_job( $job );
 
-			// Re-read the row: update_job() returns the supplied object even when the underlying
-			// option no longer exists (e.g. the Clear Square Sync tool removed it concurrently),
-			// so only a fresh read can prove the job is still there.
-			$job = $this->get_job( $job->id );
-			if ( ! $job ) {
+			// Confirm the row still exists rather than trusting update_job(), which returns the
+			// supplied object even when the option has been removed concurrently (the Clear Square
+			// Sync tool). The object itself is deliberately NOT replaced with a fresh read: the
+			// shutdown handler registered in handle() holds this instance, and swapping it would
+			// leave that handler writing a stale snapshot after a fatal.
+			if ( ! $this->job_exists( $job->id ) ) {
 				return;
 			}
 		}
@@ -218,6 +223,30 @@ class Background_Job extends Background_Job_Handler {
 
 
 	/**
+	 * Checks whether a job row still exists.
+	 *
+	 * Used instead of re-reading the job, because callers hold an object that other code (including
+	 * the shutdown handler registered in handle()) keeps mutating, and replacing it would strand
+	 * those references.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $job_id job ID
+	 * @return bool
+	 */
+	protected function job_exists( $job_id ) {
+		global $wpdb;
+
+		if ( ! $job_id ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (bool) $wpdb->get_var( $wpdb->prepare( "SELECT option_id FROM {$wpdb->options} WHERE option_name = %s LIMIT 1", $this->identifier . '_job_' . $job_id ) );
+	}
+
+
+	/**
 	 * Handles actions after a sync job is complete.
 	 *
 	 * @since 2.0.0
@@ -247,10 +276,14 @@ class Background_Job extends Background_Job_Handler {
 	 */
 	public function job_failed( $job ) {
 
+		$message = empty( $job->auto_failed )
+			? __( 'Sync failed. Please try again', 'woocommerce-square' )
+			: __( 'A sync stopped responding and was stopped automatically. Product data may be out of date, please start a new sync.', 'woocommerce-square' );
+
 		Records::set_record(
 			array(
 				'type'    => 'failed',
-				'message' => __( 'Sync failed. Please try again', 'woocommerce-square' ),
+				'message' => $message,
 			)
 		);
 
@@ -384,13 +417,19 @@ class Background_Job extends Background_Job_Handler {
 	 * processing. A flag is stored so the admin notice can prompt a re-run.
 	 *
 	 * @since x.x.x
+	 *
+	 * @return bool whether a stalled job was failed by this call
 	 */
 	protected function maybe_recover_stuck_sync() {
 
-		$job = $this->get_job();
+		// Ask for processing jobs specifically. get_job() returns the oldest queued OR processing row,
+		// so an older queued job would otherwise hide a newer stalled one from this check entirely.
+		$processing = $this->get_jobs( array( 'status' => 'processing' ) );
+		$job        = is_array( $processing ) ? reset( $processing ) : null;
 
 		if ( ! $job || ! isset( $job->status ) || 'processing' !== $job->status ) {
-			return;
+			$this->clear_recovery_grace();
+			return false;
 		}
 
 		/**
@@ -422,13 +461,31 @@ class Background_Job extends Background_Job_Handler {
 		};
 
 		if ( ! $is_stalled( $job ) ) {
-			delete_option( 'wc_square_recovery_grace_at' );
-			return;
+			$this->clear_recovery_grace();
+			return false;
 		}
 
 		// A live worker still holds the process lock: the job is progressing, not stuck. Leave it.
 		if ( $this->is_process_running() ) {
-			return;
+			return false;
+		}
+
+		// A runner action is mid flight. The process lock only lasts 60 seconds, so a single long
+		// step outlives it and would otherwise look abandoned; Action Scheduler's own record of a
+		// running action is the reliable signal that a worker is still on it.
+		if ( function_exists( 'as_get_scheduled_actions' ) && class_exists( 'ActionScheduler_Store' ) ) {
+			$running = as_get_scheduled_actions(
+				array(
+					'hook'     => 'wc_square_job_runner',
+					'status'   => \ActionScheduler_Store::STATUS_RUNNING,
+					'per_page' => 1,
+				),
+				'ids'
+			);
+
+			if ( ! empty( $running ) ) {
+				return false;
+			}
 		}
 
 		// A runner action is still queued: the queue may be paused, not dead (low traffic sites can
@@ -453,16 +510,28 @@ class Background_Job extends Background_Job_Handler {
 			 */
 			$grace_period = max( MINUTE_IN_SECONDS, (int) apply_filters( 'wc_square_stuck_job_grace_period', (int) round( $threshold / 3 ) ) );
 
-			$grace_started = (int) get_option( 'wc_square_recovery_grace_at', 0 );
+			// The grace marker is scoped to the job it was started for. A global timestamp could
+			// outlive its job (the Clear Square Sync tool, or a job that simply finished) and the next
+			// stall would then read an ancient timestamp, skip the grace window entirely, and fail a
+			// merely paused queue on first detection.
+			$grace         = (array) get_option( 'wc_square_recovery_grace', array() );
+			$grace_started = (int) ( $grace['at'] ?? 0 );
 
-			if ( ! $grace_started ) {
-				update_option( 'wc_square_recovery_grace_at', time(), false );
+			if ( ! $grace_started || ( $grace['job'] ?? '' ) !== $job->id ) {
+				update_option(
+					'wc_square_recovery_grace',
+					array(
+						'job' => $job->id,
+						'at'  => time(),
+					),
+					false
+				);
 				wc_square()->log( sprintf( 'Stalled sync has a queued runner action; allowing %d seconds for the queue to resume before auto-failing.', $grace_period ) );
-				return;
+				return false;
 			}
 
 			if ( ( time() - $grace_started ) < $grace_period ) {
-				return;
+				return false;
 			}
 		}
 
@@ -470,20 +539,39 @@ class Background_Job extends Background_Job_Handler {
 		// window since get_job() above, in which case we must not clobber it with a stale snapshot.
 		$job = $this->get_job( $job->id );
 		if ( ! $is_stalled( $job ) ) {
-			return;
+			$this->clear_recovery_grace();
+			return false;
 		}
 
 		// Recover: fail the stalled job and release the lock. Scheduled job_runner actions are
 		// deliberately left in place so any other sync job waiting in the queue keeps processing;
 		// the failed job no longer comes back from get_job(), so the next run picks up the rest.
+		// Flagged so job_failed() can record why this job failed instead of the generic message.
+		$job->auto_failed = true;
+
 		$this->fail_job( $job, __( 'Sync job stalled and was automatically marked as failed.', 'woocommerce-square' ) );
 		$this->unlock_process();
-		delete_option( 'wc_square_recovery_grace_at' );
+		$this->clear_recovery_grace();
 
 		// Recorded so the admin notice can tell the merchant a stalled sync was stopped.
 		update_option( 'wc_square_sync_auto_recovered_at', time() );
 
 		wc_square()->log( 'Auto-failed a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). The queue lock was released so the next sync can run.' );
+
+		return true;
+	}
+
+
+	/**
+	 * Clears the stalled sync grace marker.
+	 *
+	 * @since x.x.x
+	 */
+	protected function clear_recovery_grace() {
+
+		if ( get_option( 'wc_square_recovery_grace', false ) ) {
+			delete_option( 'wc_square_recovery_grace' );
+		}
 	}
 
 	/**
@@ -547,7 +635,12 @@ class Background_Job extends Background_Job_Handler {
 					);
 
 					foreach ( (array) $action_ids as $action_id ) {
-						$store->delete_action( $action_id );
+						try {
+							$store->delete_action( $action_id );
+						} catch ( \Exception $e ) {
+							// One undeletable action must not abandon the rest of the backlog for a day.
+							wc_square()->log( 'Could not delete failed action ' . $action_id . ': ' . $e->getMessage() );
+						}
 					}
 
 					// A short page means the backlog for this hook is exhausted.

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -359,9 +359,9 @@ class Background_Job extends Background_Job_Handler {
 	 *
 	 * A job is considered stalled when it has been in "processing" without any step activity for
 	 * longer than a filterable threshold (measured against the per-step heartbeat, so a legitimately
-	 * long sync is not affected). Recovery marks the job failed, releases the process lock, and
-	 * clears the pending/failing wc_square_job_runner action cascade that would otherwise keep the
-	 * queue non-empty and block a restart. A flag is stored so the admin notice can prompt a re-run.
+	 * long sync is not affected). Recovery marks the job failed and releases the process lock;
+	 * scheduled wc_square_job_runner actions are left alone so other queued sync jobs keep
+	 * processing. A flag is stored so the admin notice can prompt a re-run.
 	 *
 	 * @since x.x.x
 	 */
@@ -417,18 +417,16 @@ class Background_Job extends Background_Job_Handler {
 			return;
 		}
 
-		// Recover: fail the stalled job, release the lock, and clear the action cascade.
-		$this->fail_job( $job, __( 'Sync job stalled and was automatically recovered.', 'woocommerce-square' ) );
+		// Recover: fail the stalled job and release the lock. Scheduled job_runner actions are
+		// deliberately left in place so any other sync job waiting in the queue keeps processing;
+		// the failed job no longer comes back from get_job(), so the next run picks up the rest.
+		$this->fail_job( $job, __( 'Sync job stalled and was automatically stopped.', 'woocommerce-square' ) );
 		$this->unlock_process();
 
-		if ( function_exists( 'as_unschedule_all_actions' ) ) {
-			as_unschedule_all_actions( 'wc_square_job_runner' );
-		}
-
-		// Recorded so the stale-sync admin notice can tell the merchant the sync was restarted.
+		// Recorded so the admin notice can tell the merchant a stalled sync was stopped.
 		update_option( 'wc_square_sync_auto_recovered_at', time() );
 
-		wc_square()->log( 'Auto-recovered a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). Cleared the job_runner queue for restart.' );
+		wc_square()->log( 'Auto-recovered a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). The job was marked failed and the queue lock released.' );
 	}
 
 	/**

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -455,7 +455,7 @@ class Background_Job extends Background_Job_Handler {
 		// Recorded so the admin notice can tell the merchant a stalled sync was stopped.
 		update_option( 'wc_square_sync_auto_recovered_at', time() );
 
-		wc_square()->log( 'Auto-recovered a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). The job was marked failed and the queue lock released.' );
+		wc_square()->log( 'Auto-failed a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). The queue lock was released so the next sync can run.' );
 	}
 
 	/**

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -445,6 +445,12 @@ class Background_Job extends Background_Job_Handler {
 		 *
 		 * @since x.x.x
 		 *
+		 * Note when lowering this: Action Scheduler stamps a runner action's last attempt time once,
+		 * when the worker picks it up, and does not refresh it while the step runs. A threshold below
+		 * the longest single step therefore reads a live worker as stale, and with no pending action
+		 * to earn a grace window that job would be failed while it is still working. The 15 minute
+		 * default sits well above any step this plugin runs.
+		 *
 		 * @param int $threshold threshold in seconds (default 15 minutes)
 		 */
 		$threshold = (int) apply_filters( 'wc_square_stuck_job_threshold', 15 * MINUTE_IN_SECONDS );

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -162,24 +162,19 @@ class Background_Job extends Background_Job_Handler {
 			return;
 		}
 
-		// Heartbeat: record activity on every processed step so a genuinely long running sync is
-		// never mistaken for a stalled one. started_processing_at (below) is stamped only once, so
-		// it cannot tell a slow large-catalog sync apart from a stuck job; last_activity_at can.
-		$job->last_activity_at = time();
-
 		// indicate that the job has started processing
 		if ( 'processing' !== $job->status ) {
 
 			$job->status                = 'processing';
 			$job->started_processing_at = current_time( 'mysql' );
-		}
 
-		$job = $this->update_job( $job );
+			$job = $this->update_job( $job );
 
-		// The row can be gone if the job was cleared concurrently (e.g. the Clear Square Sync tool).
-		// This path now runs on every step, so guard before dereferencing the job below.
-		if ( ! $job ) {
-			return;
+			// The row can be gone if the job was cleared concurrently (e.g. the Clear Square Sync
+			// tool), so guard before dereferencing the job below.
+			if ( ! $job ) {
+				return;
+			}
 		}
 
 		if ( 'poll' === $job->action ) {
@@ -199,6 +194,16 @@ class Background_Job extends Background_Job_Handler {
 			$current_user_id = get_current_user_id();
 			$job             = $job->run();
 			wp_set_current_user( $current_user_id ); // phpcs:ignore Generic.PHP.ForbiddenFunctions.Discouraged -- required for background job processing
+		}
+
+		// Heartbeat: recorded only after the step has finished, never at the start of an attempt.
+		// A job that keeps dying mid step (for example an action scheduler timeout loop) must not
+		// refresh its own heartbeat on every retry, or it would never look stalled and never be
+		// recovered. started_processing_at is stamped once, so it cannot tell a slow large catalog
+		// sync apart from a stuck one; a per completed step heartbeat can.
+		if ( $job && 'processing' === ( $job->status ?? '' ) ) {
+			$job->last_activity_at = time();
+			$job                   = $this->update_job( $job );
 		}
 
 		return $job;

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -402,12 +402,29 @@ class Background_Job extends Background_Job_Handler {
 		};
 
 		if ( ! $is_stalled( $job ) ) {
+			delete_option( 'wc_square_recovery_grace_at' );
 			return;
 		}
 
 		// A live worker still holds the process lock: the job is progressing, not stuck. Leave it.
 		if ( $this->is_process_running() ) {
 			return;
+		}
+
+		// A runner action is still queued: the queue may be paused, not dead (low traffic sites can
+		// go quiet long enough for the threshold to pass, then resume on the visit that triggered
+		// this very check). Give the queue one grace window to make progress; recover only if the
+		// job is still stalled with the same queued action after the grace period.
+		if ( function_exists( 'as_next_scheduled_action' ) && false !== as_next_scheduled_action( 'wc_square_job_runner' ) ) {
+			$grace_started = (int) get_option( 'wc_square_recovery_grace_at', 0 );
+			if ( ! $grace_started ) {
+				update_option( 'wc_square_recovery_grace_at', time(), false );
+				wc_square()->log( 'Stalled sync has a queued runner action; allowing a grace window before auto-failing.' );
+				return;
+			}
+			if ( ( time() - $grace_started ) < $threshold ) {
+				return;
+			}
 		}
 
 		// Re-read immediately before acting: a concurrent step may have advanced the job in the
@@ -422,6 +439,7 @@ class Background_Job extends Background_Job_Handler {
 		// the failed job no longer comes back from get_job(), so the next run picks up the rest.
 		$this->fail_job( $job, __( 'Sync job stalled and was automatically marked as failed.', 'woocommerce-square' ) );
 		$this->unlock_process();
+		delete_option( 'wc_square_recovery_grace_at' );
 
 		// Recorded so the admin notice can tell the merchant a stalled sync was stopped.
 		update_option( 'wc_square_sync_auto_recovered_at', time() );

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -256,8 +256,12 @@ class Background_Job extends Background_Job_Handler {
 	public function job_complete( $job ) {
 
 		// Normally cleared when the sync started; repeated here for a job that was already running
-		// when this release was installed.
-		delete_option( 'wc_square_sync_auto_recovered_at' );
+		// when this release was installed. Interval polls are excluded for the same reason as at the
+		// start: they run on their own every few minutes and would dismiss the notice before anyone
+		// had a chance to read it.
+		if ( 'poll' !== ( $job->action ?? '' ) ) {
+			delete_option( 'wc_square_sync_auto_recovered_at' );
+		}
 
 		wc_square()->get_sync_handler()->set_last_synced_at();
 

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -214,6 +214,9 @@ class Background_Job extends Background_Job_Handler {
 	 */
 	public function job_complete( $job ) {
 
+		// A sync completed successfully, so clear any pending auto-recovery notice.
+		delete_option( 'wc_square_sync_auto_recovered_at' );
+
 		wc_square()->get_sync_handler()->set_last_synced_at();
 
 		wc_square()->get_sync_handler()->record_sync( $job->processed_product_ids, $job );

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -353,7 +353,10 @@ class Background_Job extends Background_Job_Handler {
 		}
 		set_transient( 'wc_square_admin_recovery_check', 1, 5 * MINUTE_IN_SECONDS );
 
-		$this->maybe_recover_stuck_sync();
+		// Run the full healthcheck, not only the recovery: it also prunes stale failed actions and
+		// re-enqueues the runner when jobs are queued with no scheduled action, so a recovery from
+		// a broken cron site is followed by the same queue restart checks the cron path gets.
+		$this->handle_sync_healthcheck();
 	}
 
 	/**

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -317,6 +317,83 @@ class Background_Job extends Background_Job_Handler {
 	}
 
 	/**
+	 * Detects a sync job stalled in "processing" and recovers it so the queue can resume.
+	 *
+	 * A job is considered stalled when it has been in "processing" without any step activity for
+	 * longer than a filterable threshold (measured against the per-step heartbeat, so a legitimately
+	 * long sync is not affected). Recovery marks the job failed, releases the process lock, and
+	 * clears the pending/failing wc_square_job_runner action cascade that would otherwise keep the
+	 * queue non-empty and block a restart. A flag is stored so the admin notice can prompt a re-run.
+	 *
+	 * @since x.x.x
+	 */
+	protected function maybe_recover_stuck_sync() {
+
+		$job = $this->get_job();
+
+		if ( ! $job || ! isset( $job->status ) || 'processing' !== $job->status ) {
+			return;
+		}
+
+		/**
+		 * Filters how long (in seconds) a sync job may sit in "processing" without any step activity
+		 * before it is treated as stalled and automatically recovered.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param int $threshold threshold in seconds (default 15 minutes)
+		 */
+		$threshold = (int) apply_filters( 'wc_square_stuck_job_threshold', 15 * MINUTE_IN_SECONDS );
+
+		$is_stalled = function ( $job ) use ( $threshold ) {
+			if ( ! $job || 'processing' !== ( $job->status ?? '' ) ) {
+				return false;
+			}
+			// Prefer the per-step heartbeat; fall back to the one-time start stamp for jobs created
+			// before this change shipped. started_processing_at is a site-local mysql string, so
+			// convert to GMT before comparing against the UTC epoch from time().
+			if ( ! empty( $job->last_activity_at ) ) {
+				$reference = (int) $job->last_activity_at;
+			} elseif ( ! empty( $job->started_processing_at ) ) {
+				$reference = (int) strtotime( get_gmt_from_date( $job->started_processing_at ) );
+			} else {
+				return false;
+			}
+
+			return $reference > 0 && ( time() - $reference ) > $threshold;
+		};
+
+		if ( ! $is_stalled( $job ) ) {
+			return;
+		}
+
+		// A live worker still holds the process lock: the job is progressing, not stuck. Leave it.
+		if ( $this->is_process_running() ) {
+			return;
+		}
+
+		// Re-read immediately before acting: a concurrent step may have advanced the job in the
+		// window since get_job() above, in which case we must not clobber it with a stale snapshot.
+		$job = $this->get_job( $job->id );
+		if ( ! $is_stalled( $job ) ) {
+			return;
+		}
+
+		// Recover: fail the stalled job, release the lock, and clear the action cascade.
+		$this->fail_job( $job, __( 'Sync job stalled and was automatically recovered.', 'woocommerce-square' ) );
+		$this->unlock_process();
+
+		if ( function_exists( 'as_unschedule_all_actions' ) ) {
+			as_unschedule_all_actions( 'wc_square_job_runner' );
+		}
+
+		// Recorded so the stale-sync admin notice can tell the merchant the sync was restarted.
+		update_option( 'wc_square_sync_auto_recovered_at', time() );
+
+		wc_square()->log( 'Auto-recovered a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). Cleared the job_runner queue for restart.' );
+	}
+
+	/**
 	 * Handle Sync healthcheck
 	 *
 	 * Restart the background sync process if not already running
@@ -325,6 +402,12 @@ class Background_Job extends Background_Job_Handler {
 	 * @since 3.8.2
 	 */
 	public function handle_sync_healthcheck() {
+
+		// Auto-recover a stalled sync first, on purpose. A job stuck in "processing" (timeout, fatal,
+		// worker kill) or a cascade of failing wc_square_job_runner actions keeps the queue
+		// non-empty, so the as_has_scheduled_action() guard below would otherwise never let the sync
+		// restart. Running recovery before the early returns is what breaks that deadlock.
+		$this->maybe_recover_stuck_sync();
 
 		if ( $this->is_process_running() ) {
 			// background process already running

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -359,10 +359,19 @@ class Background_Job extends Background_Job_Handler {
 		}
 		set_transient( 'wc_square_admin_recovery_check', 1, 5 * MINUTE_IN_SECONDS );
 
-		// Run the full healthcheck, not only the recovery: it also prunes stale failed actions and
-		// re-enqueues the runner when jobs are queued with no scheduled action, so a recovery from
-		// a broken cron site is followed by the same queue restart checks the cron path gets.
-		$this->handle_sync_healthcheck();
+		// Deliberately NOT the full healthcheck. Its tail enqueues a job runner whenever the queue is
+		// non empty and Action Scheduler has nothing scheduled, and handle() takes the process lock
+		// without checking it first, so making every admin page load a third enqueue trigger would
+		// widen the window for two runners to process the same step and push the same objects twice.
+		// Recovery and housekeeping are safe here; the queue is only restarted when this call
+		// actually failed a stalled job, which is the case where nothing else will restart it.
+		$recovered = $this->maybe_recover_stuck_sync();
+
+		$this->cleanup_stale_failed_actions();
+
+		if ( $recovered && ! $this->is_queue_empty() && function_exists( 'as_has_scheduled_action' ) && ! as_has_scheduled_action( 'wc_square_job_runner' ) ) {
+			as_enqueue_async_action( 'wc_square_job_runner' );
+		}
 	}
 
 	/**

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -424,6 +424,64 @@ class Background_Job extends Background_Job_Handler {
 	}
 
 	/**
+	 * Deletes stale failed Square Action Scheduler actions to prevent table bloat.
+	 *
+	 * Runs at most once per day. Removes actions for the plugin's sync hooks that are in the failed
+	 * state and older than a filterable retention window. Never touches pending or in-progress
+	 * actions, and does not change Action Scheduler's own timeout handling.
+	 *
+	 * @since x.x.x
+	 */
+	protected function cleanup_stale_failed_actions() {
+
+		$last_run = (int) get_option( 'wc_square_failed_action_cleanup_at', 0 );
+		if ( $last_run && ( time() - $last_run ) < DAY_IN_SECONDS ) {
+			return;
+		}
+		update_option( 'wc_square_failed_action_cleanup_at', time(), false );
+
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( 'ActionScheduler_Store' ) ) {
+			return;
+		}
+
+		/**
+		 * Filters how many days a failed Square action is retained before automatic cleanup.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param int $days retention in days (default 30)
+		 */
+		$retention_days = max( 1, (int) apply_filters( 'wc_square_failed_action_retention_days', 30 ) );
+		$cutoff         = gmdate( 'Y-m-d H:i:s', time() - ( $retention_days * DAY_IN_SECONDS ) );
+
+		$hooks = array( 'wc_square_job_runner', 'wc_square_background_sync_cron', 'wc_square_sync', 'wc_square_sync_orders' );
+
+		try {
+			$store = \ActionScheduler_Store::instance();
+
+			foreach ( $hooks as $hook ) {
+				$action_ids = as_get_scheduled_actions(
+					array(
+						'hook'         => $hook,
+						'status'       => \ActionScheduler_Store::STATUS_FAILED,
+						'date'         => $cutoff,
+						'date_compare' => '<=',
+						'per_page'     => 200,
+						'orderby'      => 'none',
+					),
+					'ids'
+				);
+
+				foreach ( (array) $action_ids as $action_id ) {
+					$store->delete_action( $action_id );
+				}
+			}
+		} catch ( \Exception $e ) {
+			wc_square()->log( 'Failed-action cleanup skipped: ' . $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Handle Sync healthcheck
 	 *
 	 * Restart the background sync process if not already running
@@ -438,6 +496,10 @@ class Background_Job extends Background_Job_Handler {
 		// non-empty, so the as_has_scheduled_action() guard below would otherwise never let the sync
 		// restart. Running recovery before the early returns is what breaks that deadlock.
 		$this->maybe_recover_stuck_sync();
+
+		// Housekeeping: prune old failed Square actions so the Action Scheduler store does not bloat
+		// (the reported incident left 14,000+ failed actions behind). Throttled internally.
+		$this->cleanup_stale_failed_actions();
 
 		if ( $this->is_process_running() ) {
 			// background process already running

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -402,7 +402,7 @@ class Background_Job extends Background_Job_Handler {
 
 		$this->cleanup_stale_failed_actions();
 
-		if ( $recovered && ! $this->is_queue_empty() && function_exists( 'as_has_scheduled_action' ) && ! as_has_scheduled_action( 'wc_square_job_runner' ) ) {
+		if ( $recovered && ! $this->is_queue_empty() && ! $this->has_pending_job_runner() ) {
 			as_enqueue_async_action( 'wc_square_job_runner' );
 		}
 	}
@@ -470,15 +470,23 @@ class Background_Job extends Background_Job_Handler {
 			return false;
 		}
 
-		// A runner action is mid flight. The process lock only lasts 60 seconds, so a single long
-		// step outlives it and would otherwise look abandoned; Action Scheduler's own record of a
-		// running action is the reliable signal that a worker is still on it.
-		if ( function_exists( 'as_get_scheduled_actions' ) && class_exists( 'ActionScheduler_Store' ) ) {
+		// A runner action was touched recently, so a worker is still on it. The process lock only
+		// lasts 60 seconds, so a single long step outlives it and would otherwise look abandoned.
+		//
+		// The recency bound is essential rather than cosmetic: an in progress row is only cleared by
+		// Action Scheduler's own cleaner, which runs from its queue runner, so on a site where Action
+		// Scheduler is not executing (the incident this recovery exists for) a worker killed mid
+		// action leaves that row in progress forever. Without the bound this guard would then block
+		// recovery permanently and rebuild the same deadlock in a new shape.
+		if ( function_exists( 'as_get_scheduled_actions' ) && function_exists( 'as_get_datetime_object' ) && class_exists( 'ActionScheduler_Store' ) ) {
 			$running = as_get_scheduled_actions(
 				array(
-					'hook'     => 'wc_square_job_runner',
-					'status'   => \ActionScheduler_Store::STATUS_RUNNING,
-					'per_page' => 1,
+					'hook'             => 'wc_square_job_runner',
+					'status'           => \ActionScheduler_Store::STATUS_RUNNING,
+					'modified'         => as_get_datetime_object( $threshold . ' seconds ago' ),
+					'modified_compare' => '>',
+					'per_page'         => 1,
+					'orderby'          => 'none',
 				),
 				'ids'
 			);
@@ -492,7 +500,9 @@ class Background_Job extends Background_Job_Handler {
 		// go quiet long enough for the threshold to pass, then resume on the visit that triggered
 		// this very check). Give the queue one grace window to make progress; recover only if the
 		// job is still stalled with the same queued action after that window.
-		if ( function_exists( 'as_next_scheduled_action' ) && false !== as_next_scheduled_action( 'wc_square_job_runner' ) ) {
+		// A pending action means the queue is waiting its turn rather than dead, so it earns a grace
+		// window. An in progress row does not count: see has_pending_job_runner().
+		if ( $this->has_pending_job_runner() ) {
 
 			/**
 			 * Filters how long a stalled sync job is given to resume when a job runner action is
@@ -559,6 +569,38 @@ class Background_Job extends Background_Job_Handler {
 		wc_square()->log( 'Auto-failed a stalled sync job (' . ( isset( $job->id ) ? $job->id : 'unknown' ) . '). The queue lock was released so the next sync can run.' );
 
 		return true;
+	}
+
+
+	/**
+	 * Checks whether a job runner action is waiting to run.
+	 *
+	 * Deliberately not as_has_scheduled_action() or as_next_scheduled_action(): both also report true
+	 * for an action that is in progress, and an in progress row can outlive its worker indefinitely
+	 * because only Action Scheduler's own cleaner clears it. Treating that as "the queue will run"
+	 * would both grant a dead queue a grace window and stop the queue ever being restarted.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	protected function has_pending_job_runner() {
+
+		if ( ! function_exists( 'as_get_scheduled_actions' ) || ! class_exists( 'ActionScheduler_Store' ) ) {
+			return false;
+		}
+
+		$pending = as_get_scheduled_actions(
+			array(
+				'hook'     => 'wc_square_job_runner',
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => 1,
+				'orderby'  => 'none',
+			),
+			'ids'
+		);
+
+		return ! empty( $pending );
 	}
 
 

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -168,6 +168,11 @@ class Background_Job extends Background_Job_Handler {
 			$job->status                = 'processing';
 			$job->started_processing_at = current_time( 'mysql' );
 
+			// A new sync is now running, so the recovery notice has served its purpose. Clearing it
+			// here rather than on completion means a long sync does not keep showing a warning about
+			// the previous one for hours.
+			delete_option( 'wc_square_sync_auto_recovered_at' );
+
 			$this->update_job( $job );
 
 			// Re-read the row: update_job() returns the supplied object even when the underlying
@@ -221,7 +226,8 @@ class Background_Job extends Background_Job_Handler {
 	 */
 	public function job_complete( $job ) {
 
-		// A sync completed successfully, so clear any pending auto-recovery notice.
+		// Normally cleared when the sync started; repeated here for a job that was already running
+		// when this release was installed.
 		delete_option( 'wc_square_sync_auto_recovered_at' );
 
 		wc_square()->get_sync_handler()->set_last_synced_at();

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -488,21 +488,38 @@ class Background_Job extends Background_Job_Handler {
 		try {
 			$store = \ActionScheduler_Store::instance();
 
-			foreach ( $hooks as $hook ) {
-				$action_ids = as_get_scheduled_actions(
-					array(
-						'hook'         => $hook,
-						'status'       => \ActionScheduler_Store::STATUS_FAILED,
-						'date'         => $cutoff,
-						'date_compare' => '<=',
-						'per_page'     => 200,
-						'orderby'      => 'none',
-					),
-					'ids'
-				);
+			/**
+			 * Filters how many failed actions are deleted per cleanup batch.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param int $batch_size actions per batch (default 200)
+			 */
+			$batch_size  = max( 10, (int) apply_filters( 'wc_square_failed_action_cleanup_batch', 200 ) );
+			$max_batches = 25; // hard bound per run: up to 5,000 deletions, far above the incident growth rate.
 
-				foreach ( (array) $action_ids as $action_id ) {
-					$store->delete_action( $action_id );
+			foreach ( $hooks as $hook ) {
+				for ( $batch = 0; $batch < $max_batches; $batch++ ) {
+					$action_ids = as_get_scheduled_actions(
+						array(
+							'hook'         => $hook,
+							'status'       => \ActionScheduler_Store::STATUS_FAILED,
+							'date'         => $cutoff,
+							'date_compare' => '<=',
+							'per_page'     => $batch_size,
+							'orderby'      => 'none',
+						),
+						'ids'
+					);
+
+					foreach ( (array) $action_ids as $action_id ) {
+						$store->delete_action( $action_id );
+					}
+
+					// A short page means the backlog for this hook is exhausted.
+					if ( count( (array) $action_ids ) < $batch_size ) {
+						break;
+					}
 				}
 			}
 		} catch ( \Exception $e ) {

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -157,12 +157,24 @@ class Background_Job extends Background_Job_Handler {
 			return;
 		}
 
+		// Heartbeat: record activity on every processed step so a genuinely long running sync is
+		// never mistaken for a stalled one. started_processing_at (below) is stamped only once, so
+		// it cannot tell a slow large-catalog sync apart from a stuck job; last_activity_at can.
+		$job->last_activity_at = time();
+
 		// indicate that the job has started processing
 		if ( 'processing' !== $job->status ) {
 
 			$job->status                = 'processing';
 			$job->started_processing_at = current_time( 'mysql' );
-			$job                        = $this->update_job( $job );
+		}
+
+		$job = $this->update_job( $job );
+
+		// The row can be gone if the job was cleared concurrently (e.g. the Clear Square Sync tool).
+		// This path now runs on every step, so guard before dereferencing the job below.
+		if ( ! $job ) {
+			return;
 		}
 
 		if ( 'poll' === $job->action ) {

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -424,7 +424,14 @@ class Background_Job extends Background_Job_Handler {
 
 		// Ask for processing jobs specifically. get_job() returns the oldest queued OR processing row,
 		// so an older queued job would otherwise hide a newer stalled one from this check entirely.
-		$processing = $this->get_jobs( array( 'status' => 'processing' ) );
+		// ASC because get_jobs() defaults to DESC and the job blocking the queue is the oldest one.
+		$processing = $this->get_jobs(
+			array(
+				'status'  => 'processing',
+				'order'   => 'ASC',
+				'orderby' => 'option_id',
+			)
+		);
 		$job        = is_array( $processing ) ? reset( $processing ) : null;
 
 		if ( ! $job || ! isset( $job->status ) || 'processing' !== $job->status ) {

--- a/includes/Handlers/Background_Job.php
+++ b/includes/Handlers/Background_Job.php
@@ -420,7 +420,7 @@ class Background_Job extends Background_Job_Handler {
 		// Recover: fail the stalled job and release the lock. Scheduled job_runner actions are
 		// deliberately left in place so any other sync job waiting in the queue keeps processing;
 		// the failed job no longer comes back from get_job(), so the next run picks up the rest.
-		$this->fail_job( $job, __( 'Sync job stalled and was automatically stopped.', 'woocommerce-square' ) );
+		$this->fail_job( $job, __( 'Sync job stalled and was automatically marked as failed.', 'woocommerce-square' ) );
 		$this->unlock_process();
 
 		// Recorded so the admin notice can tell the merchant a stalled sync was stopped.

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -81,7 +81,7 @@ class Manual_Synchronization extends Stepped_Job {
 			delete_option( 'woocommerce_square_refresh_sync_cycle' );
 		}
 
-		parent::run();
+		return parent::run();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When a background sync job dies mid run (timeout, fatal error, or a killed worker) its status stays "processing" forever. That stuck job blocks every later sync, and the healthcheck cannot restart the queue because pending or failing runner actions keep its guard condition satisfied. Nothing in the admin tells the merchant anything is wrong. One merchant ran this way for about a month and accumulated over 14,000 failed scheduler actions, discovered only by inspecting the database.

This change makes the sync self healing. Every processed step now records a heartbeat on the job, so a genuinely long running sync on a large catalog is never mistaken for a stuck one. The healthcheck looks for a job sitting in "processing" with no step activity beyond a threshold (15 minutes by default, filterable via `wc_square_stuck_job_threshold`). When it finds one it marks that job failed and releases the process lock so the next sync can run. Scheduled runner actions are deliberately left in place, so any other job waiting in the queue keeps processing. When more than one job is stalled, the oldest is recovered first, since that is the one holding up the queue.

Before failing anything it looks for signs of a live worker, because a false positive here would kill a working sync. Three signals are checked: the process lock, a runner action last touched within the threshold, and a runner action still pending. The last case earns a grace window rather than an immediate recovery (a third of the threshold by default, filterable via `wc_square_stuck_job_grace_period`), because a quiet site can cross the threshold with the queue merely paused and then resume on the very visit that triggered this check. At the defaults a paused queue is left alone for 15 minutes and a genuinely dead one is failed after 20. The recency bound on the second signal matters: an in progress row is only cleared by Action Scheduler's own cleaner, which runs from its queue runner, so on a site where Action Scheduler is not executing (the incident this exists for) an unbounded check would block recovery forever and rebuild the same deadlock in a new shape.

Because the reported incident also had the scheduled healthcheck itself failing, admin page loads act as a fallback trigger, throttled to once every five minutes and limited to users who can manage WooCommerce, so a site with broken cron heals as soon as someone visits the dashboard. That fallback deliberately does not run the whole healthcheck: it runs the recovery and the failed action cleanup, and restarts the queue only when it actually failed a job. Running the full healthcheck there would make every admin page load a third enqueue trigger, and since `handle()` takes the process lock without checking it first, that would widen the window for two runners to work the same step.

After a recovery a dismissible admin notice tells the merchant that a stuck sync was detected and stopped, that product data may be out of date, and links to the update page to start a new one. It clears as soon as a sync the merchant started begins processing, so a long sync does not keep showing a warning about the previous one, and it also clears if a sync has completed since the recovery. Interval polls are excluded from that dismissal because they start on their own every few minutes and would clear the notice before anyone read it. Recovery goes through the normal failure path, so the existing failed sync record and the (opt in, disabled by default) sync notification email behave exactly as they do for any other failed sync. Old failed scheduler actions from the plugin's sync hooks are also pruned daily after a retention period (30 days by default, filterable via `wc_square_failed_action_retention_days`).

The status panel and the stale sync warning shipped separately in SQUARE-299; this change is only the recovery mechanism the parent ticket asked for.

Closes https://linear.app/a8c/issue/SQUARE-291/a-stuckfailed-sync-job-blocks-all-subsequent-syncs

### Steps to test the changes in this Pull Request:

Setup: a site with WooCommerce Square connected (sandbox is fine), product sync enabled, and WP CLI available. Steps 1 to 4 reproduce the bug on trunk; steps 5 to 10 confirm the fix on this branch; steps 11 and 12 are the regressions that matter most.

Optional but recommended, so nothing needs a 15 minute wait: add this snippet to a mu plugin or to the theme's functions.php for the duration of testing, which shortens the stall threshold to one minute and the grace window to the enforced minimum of one minute.

```php
add_filter( 'wc_square_stuck_job_threshold', function () { return 60; } );
```

1. On trunk, simulate a stuck sync by running this WP CLI command. It injects a sync job that looks like it died two hours ago, then confirms the injection took.
   `wp eval '$h=wc_square()->get_background_job_handler();$h->clear_all_jobs();update_option("wc_square_background_sync_job_STUCKQA",wp_json_encode(array("id"=>"STUCKQA","status"=>"processing","action"=>"sync","manual"=>true,"started_processing_at"=>gmdate("Y-m-d H:i:s",time()-7200),"last_activity_at"=>time()-7200,"product_ids"=>array())));echo $h->get_job("STUCKQA") ? "injected" : "injection failed, run again";'`
   If it prints anything other than "injected", run it again. A sync or interval poll running in the background can consume the injected job.
2. In wp admin go to WooCommerce then Settings then Square then Update. The page shows "Syncing now..." even though nothing is running. This also confirms the injected job is really there.
3. Wait a few minutes (or run `wp eval 'wc_square()->get_background_job_handler()->handle_sync_healthcheck();'`), then reload the page. On trunk the job is still stuck, no notice appears anywhere, and Sync now stays unavailable. This is the bug.
4. Clean up: WooCommerce then Status then Tools then "Clear Square Sync".
5. Switch to this branch and repeat step 1 to inject the same stuck job.
6. Load any wp admin page (or run the healthcheck command from step 3). Recovery runs automatically.
7. Reload the Square Update page. The stuck "Syncing now..." state is gone and the Sync now button is available again. The Sync records list shows a new Failed entry reading "A sync stopped responding and was stopped automatically. Product data may be out of date, please start a new sync."
8. A dismissible admin notice appears reading "A stuck Square sync job was detected and automatically stopped. Product data may be out of date, please start a new sync from the update page." It shows on any admin screen, not only the Square pages.
9. Start a manual sync from the update page. The notice disappears as soon as that sync starts, without waiting for it to finish.
10. With logging enabled (WooCommerce then Status then Logs, square handle) the recovery writes "Auto-failed a stalled sync job (STUCKQA). The queue lock was released so the next sync can run."
11. Regression, a real sync must never be recovered out from under itself: start a normal manual sync on a catalog large enough to run past the stall threshold and let it finish. It must complete normally and never be flagged as stuck, because every step refreshes the job heartbeat. Worth running with the shortened threshold from the snippet above, which is a much harsher test than the 15 minute default.
12. Regression, a paused queue on a quiet site must not be treated as a dead one: inject the stuck job again as in step 1, then queue a runner action that is not due yet with `wp eval 'as_schedule_single_action(time()+3600,"wc_square_job_runner");echo "queued";'`. Run the healthcheck. The job must still be "processing" (the Update page still shows "Syncing now...") and the log records "Stalled sync has a queued runner action; allowing N seconds for the queue to resume before auto-failing." (N is 300 at the defaults, or 60 with the snippet above). Only once that window has passed does a later healthcheck fail the job.

### Changelog entry

> Fix - Automatically detect and recover a background sync job stuck in processing, unblock the sync queue, show an admin notice prompting a re run, and prune old failed scheduler actions.
