### PR TITLE
Prevent Square sync errors from interrupting checkout and refunds for orders paid via other gateways

### DIFF
--- a/includes/Handlers/Order.php
+++ b/includes/Handlers/Order.php
@@ -479,7 +479,21 @@ class Order {
 
 		wc_square()->log( 'Order from other gateway Refund inventory updates syncing..' );
 		$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $inventory_adjustments ) ) . '_change_inventory' );
-		wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_adjustments );
+
+		// Same protection as the checkout path: a Square API failure during a refund of an order
+		// paid through another gateway must not abort the refund flow. Log and continue.
+		try {
+			wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_adjustments );
+		} catch ( \Exception $exception ) {
+			wc_square()->log(
+				sprintf(
+					'Square inventory sync failed for refund #%d of order #%d from other gateway (refund flow left untouched): %s',
+					$refund_id,
+					$order_id,
+					$exception->getMessage()
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/Handlers/Order.php
+++ b/includes/Handlers/Order.php
@@ -396,10 +396,26 @@ class Order {
 
 		wc_square()->log( 'New order from other gateway inventory syncing..' );
 		$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $inventory_adjustments ) ) . '_change_inventory' );
-		wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_adjustments );
 
-		// Reset the staged inventory updates.
-		$this->products_to_sync = array();
+		// This runs inside checkout and stock-reduction hooks for orders paid through OTHER
+		// gateways, so a Square API failure (e.g. an expired connection throwing an auth
+		// exception) must never bubble up - it would abort the payment flow mid transition and
+		// let the gateway mark an already paid order as failed. Log and continue instead; stock
+		// converges on the next successful sync.
+		try {
+			wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_adjustments );
+		} catch ( \Exception $exception ) {
+			wc_square()->log(
+				sprintf(
+					'Square inventory sync failed for order from other gateway (order flow left untouched, %d adjustment(s) skipped): %s',
+					count( $inventory_adjustments ),
+					$exception->getMessage()
+				)
+			);
+		} finally {
+			// Always reset, or the shutdown hook re-attempts the same failing call in this request.
+			$this->products_to_sync = array();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

When a store takes an order through a gateway other than Square (for example WooPayments or Cash on Delivery) and inventory sync is enabled, the plugin pushes the stock change to Square during checkout. If that Square API call fails (for example an expired connection raising an auth exception), the exception bubbles up into the checkout flow and the gateway marks an already paid order as Failed.

This change wraps the two inventory sync calls that run inside order flows for other gateways so a Square API failure is logged and the order or refund flow continues untouched. Stock converges on the next successful sync. The checkout path also always resets its staged updates so the shutdown hook does not retry the same failing call within the request.

The refund path had a second consequence worth noting: an exception thrown during the refund hook caused WooCommerce to delete the refund record that had just been created, so the merchant lost the refund itself, not only the stock update. This change protects that flow as well.

Behavior when Square is the payment gateway is unchanged.

Linear ticket: https://linear.app/a8c/issue/SQUARE-167/sync-error-interrupting-payment-flow

### Steps to test the changes in this Pull Request:

Setup: connect the site to a Square sandbox, set Square as the system of record appropriately, and enable inventory sync. Create a simple product that is synced with Square and has stock.

To simulate a Square API failure on demand, give the product a broken Square link by running this once (replace 123 with the product ID):

`wp post meta update 123 _square_item_variation_id BROKENID123456789012345678`

**Checkout must survive a Square failure**

1. On trunk, buy the product using Cash on Delivery and complete checkout.
1. Observe the failure: the order does not complete cleanly because the Square inventory call fails during checkout.
1. Switch to this branch and repeat the purchase.
1. The order completes normally and stays in Processing. WooCommerce > Status > Logs (square source) shows a line starting with "Square inventory sync failed for order from other gateway".

**Refunds must survive a Square failure**

1. Still on this branch, open the order in the admin and refund the purchased item with restock checked.
1. The refund completes and remains attached to the order.
1. The logs show a line starting with "Square inventory sync failed for refund".

**Square orders are unaffected**

1. Remove the broken meta or use a correctly synced product, pay through the Square gateway, and confirm checkout, order status and stock behave exactly as before.

### Changelog entry

> Fix - Square inventory sync errors no longer interrupt checkout or refunds for orders paid through other payment gateways.

Closes #528