### PR TITLE
Stop Square inventory pulls from zeroing WooCommerce stock and honor the per product sync setting

### DIFF
--- a/includes/Handlers/Order.php
+++ b/includes/Handlers/Order.php
@@ -27,6 +27,7 @@ use WooCommerce\Square\Framework\PaymentGateway\Payment_Gateway;
 use WooCommerce\Square\Framework\Square_Helper;
 use WooCommerce\Square\Plugin;
 use WooCommerce\Square\Handlers\Product;
+use WooCommerce\Square\Sync\Helper;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -370,9 +371,55 @@ class Order {
 	 *
 	 * @since 2.0.8
 	 */
+	/**
+	 * Returns the Square catalog objects for these products that Square has never counted.
+	 *
+	 * A relative adjustment is only meaningful once Square holds a count, so callers use this to
+	 * decide when to send an absolute count instead. An unavailable answer returns an empty list, so
+	 * the caller keeps the existing adjustment behaviour rather than guessing.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int[] $product_ids WooCommerce product IDs.
+	 * @return string[] catalog object IDs with no inventory history.
+	 */
+	private static function get_objects_without_inventory_history( array $product_ids ) {
+
+		$square_ids = array();
+
+		foreach ( $product_ids as $product_id ) {
+			$square_id = Product::get_square_item_variation_id( $product_id, false );
+
+			if ( $square_id ) {
+				$square_ids[] = $square_id;
+			}
+		}
+
+		if ( ! $square_ids ) {
+			return array();
+		}
+
+		$with_history = Helper::get_catalog_objects_with_inventory_history( $square_ids );
+
+		if ( null === $with_history ) {
+			return array();
+		}
+
+		return array_values( array_diff( $square_ids, $with_history ) );
+	}
+
+
 	public function maybe_sync_staged_inventory_updates() {
 
 		$inventory_adjustments = array();
+
+		// An order sends a relative adjustment, which assumes Square already holds a count for the
+		// item. When it does not, and the merchant enabled inventory sync after the item was created,
+		// the delta becomes Square's whole count and the two sides drift apart immediately: a sale of
+		// one leaves WooCommerce at 19 and Square at -1. For those objects send WooCommerce's current
+		// quantity as an absolute count instead, which establishes the baseline; every later order can
+		// then adjust from it normally.
+		$never_counted = self::get_objects_without_inventory_history( array_keys( $this->products_to_sync ) );
 
 		foreach ( $this->products_to_sync as $product_id => $adjustment ) {
 
@@ -381,7 +428,13 @@ class Order {
 				continue;
 			}
 
-			$inventory_adjustment = Product::get_inventory_change_adjustment_type( $product, $adjustment );
+			$square_id = Product::get_square_item_variation_id( $product_id, false );
+
+			if ( $square_id && in_array( $square_id, $never_counted, true ) ) {
+				$inventory_adjustment = Product::get_inventory_change_physical_count_type( $product );
+			} else {
+				$inventory_adjustment = Product::get_inventory_change_adjustment_type( $product, $adjustment );
+			}
 
 			if ( empty( $inventory_adjustment ) ) {
 				continue;

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -457,6 +457,23 @@ class Product {
 	 * @throws \Exception
 	 */
 	public static function update_products_stock_from_square( $product_ids ) {
+
+		// Respect the per-product "Sync with Square" setting: this method backs automatic pulls
+		// (e.g. the add to cart inventory refresh), and a product the merchant unticked or
+		// unlinked must not have its stock overwritten from Square. Filtering up front also
+		// avoids needless Square API calls for excluded products.
+		$product_ids = array_filter(
+			(array) $product_ids,
+			function ( $product_id ) {
+				$product = wc_get_product( $product_id );
+				return $product instanceof \WC_Product && self::is_synced_with_square( $product );
+			}
+		);
+
+		if ( empty( $product_ids ) ) {
+			return;
+		}
+
 		$products_map = self::get_square_meta( $product_ids, 'square_item_variation_id' );
 		$square_ids   = array_keys( $products_map );
 
@@ -478,9 +495,19 @@ class Product {
 			$inventory_hash     = Helper::get_catalog_objects_inventory_stats( $square_ids );
 			$inventory_tracking = Helper::get_catalog_inventory_tracking( $response->get_data()->getObjects() );
 
+			// Verify zero counts against Square's inventory change history: a never-counted item
+			// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written
+			// (SQUARE-145).
+			$zero_object_ids = array();
+			foreach ( $inventory_hash as $object_id => $object_quantity ) {
+				if ( 0.0 === (float) $object_quantity ) {
+					$zero_object_ids[] = $object_id;
+				}
+			}
+			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+
 			foreach ( $response->get_data()->getObjects() as $catalog_object ) {
 				$square_id               = $catalog_object->getId();
-				$stock                   = $inventory_hash[ $square_id ] ?? 0;
 				$inventory_tracking_data = $inventory_tracking[ $square_id ] ?? array();
 				$is_inventory_tracking   = $inventory_tracking_data['track_inventory'] ?? false;
 				$sold_out                = $inventory_tracking_data['sold_out'] ?? false;
@@ -492,12 +519,27 @@ class Product {
 					continue;
 				}
 
-				if ( $is_inventory_tracking ) {
-					$product->set_manage_stock( true );
-					$product->set_stock_quantity( $stock );
-				} else {
+				if ( $is_inventory_tracking && isset( $inventory_hash[ $square_id ] ) ) {
+
+					$changed = Helper::apply_square_inventory_count(
+						$product,
+						(float) $inventory_hash[ $square_id ],
+						(bool) $sold_out,
+						in_array( $square_id, $verified_zero_ids, true )
+					);
+
+					if ( ! $changed ) {
+						continue;
+					}
+				} elseif ( ! $is_inventory_tracking ) {
+
+					// Not tracked in Square: reflect availability only; manage_stock is merchant
+					// intent and is not changed here.
 					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
-					$product->set_manage_stock( false );
+				} else {
+
+					// Tracked but no IN_STOCK count returned: "no information", never a zero.
+					continue;
 				}
 
 				$product->save();

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -402,7 +402,8 @@ class Product {
 		}
 		$inventory_tracking = Helper::get_catalog_inventory_tracking( array( $result->get_data()->getObject() ) );
 
-		$stock = 0;
+		$stock        = 0;
+		$has_in_stock = false;
 
 		if ( $response->get_data() && $response->get_data()->getCounts() ) {
 
@@ -410,7 +411,8 @@ class Product {
 			foreach ( $response->get_data()->getCounts() as $count ) {
 
 				if ( 'IN_STOCK' === $count->getState() ) {
-					$stock += (float) $count->getQuantity();
+					$stock       += (float) $count->getQuantity();
+					$has_in_stock = true;
 				}
 			}
 		}
@@ -419,13 +421,23 @@ class Product {
 		$is_inventory_tracking   = $inventory_tracking_data['track_inventory'] ?? false;
 		$sold_out                = $inventory_tracking_data['sold_out'] ?? false;
 
-		if ( $is_inventory_tracking ) {
-			$product->set_manage_stock( true );
-			$product->set_stock_quantity( $stock );
-		} else {
+		if ( $is_inventory_tracking && $has_in_stock ) {
+
+			// A zero needs provenance: a never-counted item reports IN_STOCK 0 exactly like a real
+			// sellout, and only real zeros may be written (SQUARE-145).
+			$zero_verified = false;
+			if ( 0.0 === (float) $stock ) {
+				$zero_verified = in_array( $square_id, Helper::get_catalog_objects_with_inventory_history( array( $square_id ) ), true );
+			}
+
+			Helper::apply_square_inventory_count( $product, (float) $stock, (bool) $sold_out, $zero_verified );
+		} elseif ( ! $is_inventory_tracking ) {
+
+			// Not tracked in Square: reflect availability only; manage_stock is merchant intent
+			// and is not changed here.
 			$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
-			$product->set_manage_stock( false );
 		}
+		// Tracked but no IN_STOCK count returned: "no information", never a zero.
 
 		if ( $save ) {
 			$product->save();

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -502,12 +502,7 @@ class Product {
 			// Verify zero counts against Square's inventory change history: a never-counted item
 			// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written
 			// (SQUARE-145).
-			$zero_object_ids = array();
-			foreach ( $inventory_hash as $object_id => $object_quantity ) {
-				if ( 0.0 === (float) $object_quantity ) {
-					$zero_object_ids[] = $object_id;
-				}
-			}
+			$zero_object_ids   = Helper::zero_count_object_ids( $inventory_hash );
 			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 			if ( null === $verified_zero_ids ) {

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -427,7 +427,11 @@ class Product {
 			// sellout, and only real zeros may be written (SQUARE-145).
 			$zero_verified = false;
 			if ( 0.0 === (float) $stock ) {
-				$zero_verified = in_array( $square_id, Helper::get_catalog_objects_with_inventory_history( array( $square_id ) ), true );
+				$verified_ids  = Helper::get_catalog_objects_with_inventory_history( array( $square_id ) );
+				$zero_verified = is_array( $verified_ids ) && in_array( $square_id, $verified_ids, true );
+				if ( null === $verified_ids ) {
+					wc_square()->log( 'Could not verify the zero inventory count against Square history for product #' . $product->get_id() . '; stock left unchanged.' );
+				}
 			}
 
 			Helper::apply_square_inventory_count( $product, (float) $stock, (bool) $sold_out, $zero_verified );
@@ -505,6 +509,14 @@ class Product {
 				}
 			}
 			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+
+			if ( null === $verified_zero_ids ) {
+				// Verification unavailable: never throw on this path (it runs inside checkout via
+				// the add to cart refresh); treat every zero as unverified and let the next
+				// trigger retry naturally.
+				wc_square()->log( 'Could not verify zero inventory counts against Square history; zero stock writes skipped for this refresh.' );
+				$verified_zero_ids = array();
+			}
 
 			foreach ( $response->get_data()->getObjects() as $catalog_object ) {
 				$square_id               = $catalog_object->getId();

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -1568,21 +1568,54 @@ class Product {
 	 */
 	public static function get_inventory_change_physical_count_type( \WC_Product $product ) {
 
-		$inventory_change    = null;
 		$square_variation_id = self::get_square_item_variation_id( $product->get_id(), false );
-		if ( $square_variation_id ) {
 
-			$inventory_physical_count = new \Square\Models\InventoryPhysicalCount();
-			$inventory_physical_count->setCatalogObjectId( $square_variation_id );
-			$inventory_physical_count->setQuantity( '' . max( 0, $product->get_stock_quantity() ) );
-			$inventory_physical_count->setLocationId( wc_square()->get_settings_handler()->get_location_id() );
-			$inventory_physical_count->setState( 'IN_STOCK' );
-			$inventory_physical_count->setOccurredAt( gmdate( 'Y-m-d\TH:i:sP' ) );
-
-			$inventory_change = new \Square\Models\InventoryChange();
-			$inventory_change->setType( 'PHYSICAL_COUNT' );
-			$inventory_change->setPhysicalCount( $inventory_physical_count );
+		if ( ! $square_variation_id ) {
+			return null;
 		}
+
+		if ( $product->get_manage_stock() ) {
+
+			$quantity = $product->get_stock_quantity();
+
+			// An unresolved quantity must never be coerced to zero: pushing a fabricated 0 marks
+			// the item sold out in Square and poisons its inventory history (SQUARE-145).
+			if ( null === $quantity ) {
+				wc_square()->log(
+					sprintf(
+						'Skipped pushing inventory for product #%d: stock is managed but no quantity is set.',
+						$product->get_id()
+					)
+				);
+				return null;
+			}
+
+			// Square cannot hold negative counts; backordered stock is represented as zero.
+			$quantity = max( 0, $quantity );
+		} elseif ( 'outofstock' === $product->get_stock_status() ) {
+
+			// Not stock-managed but out of stock: push an explicit zero so the item is
+			// deterministically marked sold out in Square (sold_out is read-only and only becomes
+			// true through a tracked count of zero), including items that previously held a
+			// positive count.
+			$quantity = 0;
+		} else {
+
+			// Not stock-managed and in stock: there is no real number to send; the item is left
+			// untracked in Square, which is the sellable state.
+			return null;
+		}
+
+		$inventory_physical_count = new \Square\Models\InventoryPhysicalCount();
+		$inventory_physical_count->setCatalogObjectId( $square_variation_id );
+		$inventory_physical_count->setQuantity( '' . $quantity );
+		$inventory_physical_count->setLocationId( wc_square()->get_settings_handler()->get_location_id() );
+		$inventory_physical_count->setState( 'IN_STOCK' );
+		$inventory_physical_count->setOccurredAt( gmdate( 'Y-m-d\TH:i:sP' ) );
+
+		$inventory_change = new \Square\Models\InventoryChange();
+		$inventory_change->setType( 'PHYSICAL_COUNT' );
+		$inventory_change->setPhysicalCount( $inventory_physical_count );
 
 		return $inventory_change;
 	}

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -437,9 +437,15 @@ class Product {
 			Helper::apply_square_inventory_count( $product, (float) $stock, (bool) $sold_out, $zero_verified );
 		} elseif ( ! $is_inventory_tracking ) {
 
-			// Not tracked in Square: reflect availability only; manage_stock is merchant intent
-			// and is not changed here.
+			// Not tracked in Square: reflect availability. Whether stock management follows depends on
+			// who owns the setting. Under WooCommerce SOR it is merchant intent and is left alone, so a
+			// Square side toggle cannot silently invert the system of record. Under Square SOR the
+			// authority is reversed, so tracking off is mirrored onto the product.
 			$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+			if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) {
+				$product->set_manage_stock( false );
+			}
 		}
 		// Tracked but no IN_STOCK count returned: "no information", never a zero.
 

--- a/includes/Handlers/Product.php
+++ b/includes/Handlers/Product.php
@@ -546,9 +546,14 @@ class Product {
 					}
 				} elseif ( ! $is_inventory_tracking ) {
 
-					// Not tracked in Square: reflect availability only; manage_stock is merchant
-					// intent and is not changed here.
+					// Not tracked in Square: reflect availability. Stock management follows only when
+					// Square owns the setting; under WooCommerce SOR it is merchant intent and is
+					// left alone, so a Square side toggle cannot silently invert the system of record.
 					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+					if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) {
+						$product->set_manage_stock( false );
+					}
 				} else {
 
 					// Tracked but no IN_STOCK count returned: "no information", never a zero.

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -449,15 +449,21 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 					}
 				}
 
-				if ( ! $location_override ) {
+				// Out of stock needs an override, created if the item has none, because tracking is the
+				// only way to reach Square's sold out state. In stock only RELEASES tracking on an
+				// override that already exists: creating one purely to say "not tracked" would
+				// overwrite a merchant's own Square side tracking for an item WooCommerce does not
+				// manage, which is not ours to decide.
+				if ( ! $location_override && $is_out_of_stock ) {
 					$location_override = new \Square\Models\ItemVariationLocationOverrides();
 					$location_override->setLocationId( $configured_location );
 					$location_overrides[] = $location_override;
 				}
 
-				$location_override->setTrackInventory( $is_out_of_stock );
-
-				$variation_data->setLocationOverrides( $location_overrides );
+				if ( $location_override ) {
+					$location_override->setTrackInventory( $is_out_of_stock );
+					$variation_data->setLocationOverrides( $location_overrides );
+				}
 			}
 		}
 

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -412,26 +412,52 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 			$location_overrides = $variation_data->getLocationOverrides();
 
 			/*
-			 * Only update track_inventory if it's not set.
+			 * Only update the base track_inventory if it's not set.
 			 * This will only update inventory tracking on new variations.
 			 * inventory tracking will remain the same for existing variations.
 			 */
 			if ( is_null( $track_inventory ) && is_null( $location_overrides ) ) {
 				$variation_data->setTrackInventory( $product->get_manage_stock() );
+			}
 
-				// If the product is not managing stock and is out of stock, set it as sold out.
-				if ( ! $product->get_manage_stock() && 'outofstock' === $product->get_stock_status() ) {
-					$configured_location = wc_square()->get_settings_handler()->get_location_id();
-					$location_override   = new \Square\Models\ItemVariationLocationOverrides();
-					$location_override->setLocationId( $configured_location );
-					// We need to set track_inventory to true to be able to set sold_out to true, without it will be ignored.
-					$location_override->setTrackInventory( true );
-					$location_override->setSoldOut( true );
-					$location_overrides = array( $location_override );
+			/*
+			 * For products that do not manage stock in WooCommerce, the configured location's
+			 * tracking override always follows the current WooCommerce availability:
+			 *
+			 * - out of stock: tracking on. Square's sold_out flag is read-only and only becomes
+			 *   true through a tracked count of zero, so tracking (plus the explicit zero count
+			 *   pushed by the inventory step) is the only API way to mark the item sold out.
+			 * - in stock: tracking off, which is the sellable state for an untracked item. This
+			 *   also clears the sold-out state when a product comes back in stock; previously the
+			 *   override was only ever written for new variations, so a product that went out of
+			 *   stock once stayed sold out in Square forever.
+			 *
+			 * The override is merged into any existing overrides so location price overrides are
+			 * preserved.
+			 */
+			if ( ! $product->get_manage_stock() ) {
+				$configured_location = wc_square()->get_settings_handler()->get_location_id();
+				$is_out_of_stock     = 'outofstock' === $product->get_stock_status();
 
-					// Set the location overrides.
-					$variation_data->setLocationOverrides( $location_overrides );
+				$location_overrides = is_array( $location_overrides ) ? $location_overrides : array();
+				$location_override  = null;
+
+				foreach ( $location_overrides as $existing_override ) {
+					if ( $existing_override->getLocationId() === $configured_location ) {
+						$location_override = $existing_override;
+						break;
+					}
 				}
+
+				if ( ! $location_override ) {
+					$location_override = new \Square\Models\ItemVariationLocationOverrides();
+					$location_override->setLocationId( $configured_location );
+					$location_overrides[] = $location_override;
+				}
+
+				$location_override->setTrackInventory( $is_out_of_stock );
+
+				$variation_data->setLocationOverrides( $location_overrides );
 			}
 		}
 

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -349,21 +349,41 @@ class Helper {
 
 		$quantity = (float) $quantity;
 
-		// A variation inheriting stock management reports the string 'parent': its quantity and
-		// availability are governed by the parent's pooled stock, a quantity written to it is
-		// invisible (reads come from the parent) and a stock status write is overridden by the
-		// pool. A per-variation Square count, positive or zero, is not applicable data here; the
-		// pool is merchant intent and one variation's count must not alter stock shared by its
-		// siblings or convert the variation to its own management.
+		// A variation inheriting stock management reports the string 'parent': its quantity is
+		// governed by the parent's pooled stock, so a quantity written to it is invisible until the
+		// variation manages its own stock, and a stock status write is overridden by the pool.
+		//
+		// Who owns that decision depends on the system of record. Under WooCommerce SOR the pool is
+		// merchant intent, so a per-variation Square count is not applicable data and is skipped.
+		// Under Square SOR the authority is reversed: a positive count is applied and the variation
+		// takes over its own stock, which is what the plugin did before this changeset.
+		//
+		// A zero or negative count is skipped in both modes. Those are the counts that wiped stock
+		// (SQUARE-145), and writing one into a pool would move stock shared with sibling variations
+		// on the strength of a single variation's reading.
 		if ( 'parent' === $product->get_manage_stock() ) {
+
+			$square_is_system_of_record = wc_square()->get_settings_handler()->is_system_of_record_square();
+
+			if ( ! $square_is_system_of_record || $quantity <= 0 ) {
+				wc_square()->log(
+					sprintf(
+						'Skipped writing a stock quantity to variation #%1$d: its stock is managed by the parent product pool%2$s.',
+						$product->get_id(),
+						$square_is_system_of_record ? ' and the count was not positive' : ''
+					)
+				);
+
+				return false;
+			}
+
 			wc_square()->log(
 				sprintf(
-					'Skipped writing a stock quantity to variation #%d: its stock is managed by the parent product pool.',
-					$product->get_id()
+					'Variation #%1$d inherits parent stock, but Square is the system of record and reports %2$s in stock, so the variation now manages its own stock.',
+					$product->get_id(),
+					$quantity
 				)
 			);
-
-			return false;
 		}
 
 		if ( $quantity > 0 ) {

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -94,6 +94,40 @@ class Helper {
 	}
 
 	/**
+	 * Collects the catalog object ids whose count is zero.
+	 *
+	 * Callers hold counts in two shapes: a plain id to quantity map, and an id to stats map where the
+	 * quantity sits under a key. Both are accepted so the zero collection is written once.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $counts id keyed counts, values either a quantity or an array of stats
+	 * @param string|null $quantity_key key holding the quantity when values are arrays
+	 * @return string[] ids whose count is exactly zero
+	 */
+	public static function zero_count_object_ids( array $counts, $quantity_key = null ) {
+
+		$zero_object_ids = array();
+
+		foreach ( $counts as $object_id => $value ) {
+
+			if ( null !== $quantity_key ) {
+				if ( ! is_array( $value ) || ! isset( $value[ $quantity_key ] ) ) {
+					continue;
+				}
+				$value = $value[ $quantity_key ];
+			}
+
+			if ( 0.0 === (float) $value ) {
+				$zero_object_ids[] = $object_id;
+			}
+		}
+
+		return $zero_object_ids;
+	}
+
+
+	/**
 	 * Returns the subset of catalog object IDs that have real inventory history in Square.
 	 *
 	 * A tracked item that has never had a count recorded reports an IN_STOCK count of 0 that is

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -257,11 +257,23 @@ class Helper {
 			return true;
 		}
 
-		// A negative count is only reachable through real inventory movement (an item that was
-		// never counted reads exactly zero), so it is a proven sellout and does not need the
-		// history check. WooCommerce does not hold negative stock, so it lands on zero.
+		// A negative count can only come from real inventory movement, because an item that was
+		// never counted reads exactly zero, so it needs no history check. Square itself cannot hold
+		// a negative quantity (which is why the push side clamps at zero) but WooCommerce can, and a
+		// store that allows backorders uses it to record how deep it is oversold, so the value is
+		// written through rather than flattened. manage_stock is still left alone: only a positive
+		// count mirrors Square tracking onto that setting.
 		if ( $quantity < 0 ) {
-			$zero_verified = true;
+
+			if ( ! $product->get_manage_stock() ) {
+				$product->set_stock_status( 'outofstock' );
+
+				return true;
+			}
+
+			$product->set_stock_quantity( $quantity );
+
+			return true;
 		}
 
 		// Zero count: never change the product's manage_stock setting in either direction.

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -37,6 +37,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class Helper {
 
+
+	/** @var int catalog objects held in the unverified zero count retry list */
+	const MAX_UNVERIFIED_ZERO_COUNTS = 1000;
+
 	/**
 	 * Get the inventory tracking value for the given catalog object ids.
 	 *
@@ -239,16 +243,22 @@ class Helper {
 			}
 		}
 
-		// Drop anything that has sat here for a week, and keep the list bounded so a long incident
-		// cannot grow it without limit.
+		// Give up on anything that has sat here for a week. That is the one remaining window where a
+		// zero could be missed for good, and it is deliberately far longer than any plausible Square
+		// incident.
 		foreach ( $pending as $catalog_object_id => $first_seen ) {
 			if ( $now - (int) $first_seen > WEEK_IN_SECONDS ) {
 				unset( $pending[ $catalog_object_id ] );
+				wc_square()->log( 'Stopped waiting to verify the zero count for catalog object ' . $catalog_object_id . ': it has been pending for over a week.' );
 			}
 		}
 
-		if ( count( $pending ) > 1000 ) {
-			$pending = array_slice( $pending, -1000, null, true );
+		// Keep the list bounded. Retries run oldest first, so the OLDEST entries are kept and the
+		// newest are dropped: evicting the oldest would keep discarding the entries being worked.
+		if ( count( $pending ) > self::MAX_UNVERIFIED_ZERO_COUNTS ) {
+			$dropped = count( $pending ) - self::MAX_UNVERIFIED_ZERO_COUNTS;
+			$pending = array_slice( $pending, 0, self::MAX_UNVERIFIED_ZERO_COUNTS, true );
+			wc_square()->log( sprintf( 'The unverified zero count list is full; %d newer entries were not kept.', $dropped ) );
 		}
 
 		update_option( 'wc_square_unverified_zero_counts', $pending, false );

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -98,13 +98,15 @@ class Helper {
 	 * sale leaves a PHYSICAL_COUNT / ADJUSTMENT record. Callers use this to decide whether a zero
 	 * count may be written to WooCommerce (real) or must be ignored (phantom).
 	 *
-	 * On an API failure this returns an empty array, which callers must treat as "no zeros are
-	 * verified" - failing closed so an outage can never cause a zero to be written.
+	 * On an API failure this returns null, which callers MUST treat as "verification unavailable":
+	 * never write the zero, and never advance a watermark or processed marker past the item, or a
+	 * genuine sellout would be permanently skipped once the API recovers. Null is distinct from an
+	 * empty array, which is a POSITIVE verification that none of the ids have history.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param string[] $catalog_object_ids catalog object (variation) IDs to check
-	 * @return string[] IDs that have at least one real inventory change recorded
+	 * @return string[]|null IDs with at least one real inventory change, or null when Square could not be asked
 	 */
 	public static function get_catalog_objects_with_inventory_history( $catalog_object_ids ) {
 
@@ -140,8 +142,8 @@ class Helper {
 					$data = $response->get_data();
 
 					if ( ! $data instanceof \Square\Models\BatchRetrieveInventoryChangesResponse ) {
-						wc_square()->log( 'Could not verify inventory history for zero counts, skipping zero writes: unexpected API response.' );
-						return array();
+						wc_square()->log( 'Could not verify inventory history for zero counts: unexpected API response.' );
+						return null;
 					}
 
 					if ( is_array( $data->getChanges() ) ) {
@@ -167,8 +169,8 @@ class Helper {
 				} while ( $cursor && ! empty( $remaining ) );
 			}
 		} catch ( \Exception $exception ) {
-			wc_square()->log( 'Could not verify inventory history for zero counts, skipping zero writes: ' . $exception->getMessage() );
-			return array();
+			wc_square()->log( 'Could not verify inventory history for zero counts: ' . $exception->getMessage() );
+			return null;
 		}
 
 		return array_keys( $with_history );

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -211,6 +211,83 @@ class Helper {
 
 
 	/**
+	 * Remembers catalog objects whose zero count could not be verified, for a later retry.
+	 *
+	 * Using the read window as the retry mechanism forces a choice between a window that grows on
+	 * every failed poll and a window that is eventually dropped, which would skip a genuine sellout
+	 * permanently. Remembering the specific objects avoids both: the watermark advances normally and
+	 * these objects are re-checked by id until they resolve.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string[] $catalog_object_ids objects whose zero count is still unverified
+	 */
+	public static function remember_unverified_zero_counts( $catalog_object_ids ) {
+
+		$catalog_object_ids = array_filter( (array) $catalog_object_ids );
+
+		if ( empty( $catalog_object_ids ) ) {
+			return;
+		}
+
+		$pending = (array) get_option( 'wc_square_unverified_zero_counts', array() );
+		$now     = time();
+
+		foreach ( $catalog_object_ids as $catalog_object_id ) {
+			if ( ! isset( $pending[ $catalog_object_id ] ) ) {
+				$pending[ $catalog_object_id ] = $now;
+			}
+		}
+
+		// Drop anything that has sat here for a week, and keep the list bounded so a long incident
+		// cannot grow it without limit.
+		foreach ( $pending as $catalog_object_id => $first_seen ) {
+			if ( $now - (int) $first_seen > WEEK_IN_SECONDS ) {
+				unset( $pending[ $catalog_object_id ] );
+			}
+		}
+
+		if ( count( $pending ) > 1000 ) {
+			$pending = array_slice( $pending, -1000, null, true );
+		}
+
+		update_option( 'wc_square_unverified_zero_counts', $pending, false );
+	}
+
+
+	/**
+	 * Gets the catalog object IDs waiting for their zero count to be verified.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string[]
+	 */
+	public static function get_unverified_zero_counts() {
+
+		return array_keys( (array) get_option( 'wc_square_unverified_zero_counts', array() ) );
+	}
+
+
+	/**
+	 * Forgets catalog objects whose zero count no longer needs a retry.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string[] $catalog_object_ids resolved objects
+	 */
+	public static function forget_unverified_zero_counts( $catalog_object_ids ) {
+
+		$pending = (array) get_option( 'wc_square_unverified_zero_counts', array() );
+
+		foreach ( (array) $catalog_object_ids as $catalog_object_id ) {
+			unset( $pending[ $catalog_object_id ] );
+		}
+
+		update_option( 'wc_square_unverified_zero_counts', $pending, false );
+	}
+
+
+	/**
 	 * Applies a Square IN_STOCK count to a WooCommerce product using the sync write policy.
 	 *
 	 * Policy (SQUARE-145 / SQUARE-359):

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -176,6 +176,79 @@ class Helper {
 
 
 	/**
+	 * Applies a Square IN_STOCK count to a WooCommerce product using the sync write policy.
+	 *
+	 * Policy (SQUARE-145 / SQUARE-359):
+	 * - A positive count is trusted (a phantom is always zero): write the quantity and keep the
+	 *   existing behavior of enabling stock management to mirror Square tracking.
+	 * - A zero count never changes manage_stock. For a stock-managed product it is written only
+	 *   when Square's change history proves a real count was ever recorded ($zero_verified);
+	 *   a phantom zero from a never-counted item is skipped. For a product that does not manage
+	 *   stock, counts are ignored entirely and only the stock status is reflected.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WC_Product $product the WooCommerce product or variation
+	 * @param float $quantity the IN_STOCK quantity reported by Square
+	 * @param bool $sold_out whether Square reports the item as sold out at the configured location
+	 * @param bool $zero_verified whether a zero count is backed by real inventory history
+	 * @return bool whether the product was modified (caller is responsible for saving)
+	 */
+	public static function apply_square_inventory_count( \WC_Product $product, $quantity, $sold_out, $zero_verified ) {
+
+		$quantity = (float) $quantity;
+
+		if ( $quantity > 0 ) {
+			$product->set_stock_quantity( $quantity );
+			$product->set_manage_stock( true );
+
+			return true;
+		}
+
+		// Zero count: never change the product's manage_stock setting in either direction.
+
+		// A variation inheriting stock management reports the string 'parent': its quantity and
+		// availability are governed by the parent's pooled stock, a quantity written to it is
+		// invisible (reads come from the parent) and a stock status write is overridden by the
+		// pool. A per-variation Square count is not applicable data here; the pool is merchant
+		// intent and one variation's count must not alter stock shared by its siblings.
+		if ( 'parent' === $product->get_manage_stock() ) {
+			wc_square()->log(
+				sprintf(
+					'Skipped writing a zero stock quantity to variation #%d: its stock is managed by the parent product pool.',
+					$product->get_id()
+				)
+			);
+
+			return false;
+		}
+
+		if ( ! $product->get_manage_stock() ) {
+			// Not stock-managed in WooCommerce: counts are not data for this product; reflect
+			// availability only.
+			$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+			return true;
+		}
+
+		if ( $zero_verified ) {
+			$product->set_stock_quantity( 0 );
+
+			return true;
+		}
+
+		wc_square()->log(
+			sprintf(
+				'Skipped writing a zero stock quantity to product #%d: Square has no inventory history for the item (phantom zero from an uncounted catalog object).',
+				$product->get_id()
+			)
+		);
+
+		return false;
+	}
+
+
+	/**
 	 * Get the inventory tracking value for the given catalog objects.
 	 *
 	 * @param \Square\Models\CatalogObject[] $catalog_objects The catalog objects.

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -90,6 +90,92 @@ class Helper {
 	}
 
 	/**
+	 * Returns the subset of catalog object IDs that have real inventory history in Square.
+	 *
+	 * A tracked item that has never had a count recorded reports an IN_STOCK count of 0 that is
+	 * indistinguishable from a genuine sellout by state alone. Square's inventory change history is
+	 * the reliable discriminator: a never-counted item has an empty history, while any real count or
+	 * sale leaves a PHYSICAL_COUNT / ADJUSTMENT record. Callers use this to decide whether a zero
+	 * count may be written to WooCommerce (real) or must be ignored (phantom).
+	 *
+	 * On an API failure this returns an empty array, which callers must treat as "no zeros are
+	 * verified" - failing closed so an outage can never cause a zero to be written.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string[] $catalog_object_ids catalog object (variation) IDs to check
+	 * @return string[] IDs that have at least one real inventory change recorded
+	 */
+	public static function get_catalog_objects_with_inventory_history( $catalog_object_ids ) {
+
+		$catalog_object_ids = array_values( array_filter( (array) $catalog_object_ids ) );
+
+		if ( empty( $catalog_object_ids ) ) {
+			return array();
+		}
+
+		$with_history = array();
+
+		try {
+			foreach ( array_chunk( $catalog_object_ids, 100 ) as $chunk ) {
+				$remaining = array_flip( $chunk );
+				$cursor    = null;
+
+				// Results are paginated globally across the requested IDs (oldest first), so a
+				// single page can be exhausted by high-activity items before a quiet item's only
+				// record appears: the cursor must be followed or a real sellout is misread as a
+				// phantom.
+				do {
+					// No `types` request filter: the API rejects TRANSFER as a filter value, and
+					// filtering to the other two would misread an item whose only history is a
+					// transfer as never counted. All change types are fetched and matched below.
+					$response = wc_square()->get_api()->batch_retrieve_inventory_changes(
+						array(
+							'catalog_object_ids' => $chunk,
+							'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
+							'cursor'             => $cursor,
+						)
+					);
+
+					$data = $response->get_data();
+
+					if ( ! $data instanceof \Square\Models\BatchRetrieveInventoryChangesResponse ) {
+						wc_square()->log( 'Could not verify inventory history for zero counts, skipping zero writes: unexpected API response.' );
+						return array();
+					}
+
+					if ( is_array( $data->getChanges() ) ) {
+						foreach ( $data->getChanges() as $change ) {
+							$object_id = null;
+
+							if ( $change->getPhysicalCount() ) {
+								$object_id = $change->getPhysicalCount()->getCatalogObjectId();
+							} elseif ( $change->getAdjustment() ) {
+								$object_id = $change->getAdjustment()->getCatalogObjectId();
+							} elseif ( $change->getTransfer() ) {
+								$object_id = $change->getTransfer()->getCatalogObjectId();
+							}
+
+							if ( $object_id ) {
+								$with_history[ $object_id ] = true;
+								unset( $remaining[ $object_id ] );
+							}
+						}
+					}
+
+					$cursor = $data->getCursor();
+				} while ( $cursor && ! empty( $remaining ) );
+			}
+		} catch ( \Exception $exception ) {
+			wc_square()->log( 'Could not verify inventory history for zero counts, skipping zero writes: ' . $exception->getMessage() );
+			return array();
+		}
+
+		return array_keys( $with_history );
+	}
+
+
+	/**
 	 * Get the inventory tracking value for the given catalog objects.
 	 *
 	 * @param \Square\Models\CatalogObject[] $catalog_objects The catalog objects.

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -257,6 +257,13 @@ class Helper {
 			return true;
 		}
 
+		// A negative count is only reachable through real inventory movement (an item that was
+		// never counted reads exactly zero), so it is a proven sellout and does not need the
+		// history check. WooCommerce does not hold negative stock, so it lands on zero.
+		if ( $quantity < 0 ) {
+			$zero_verified = true;
+		}
+
 		// Zero count: never change the product's manage_stock setting in either direction.
 
 		if ( ! $product->get_manage_stock() ) {

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -120,53 +120,38 @@ class Helper {
 
 		try {
 			foreach ( array_chunk( $catalog_object_ids, 100 ) as $chunk ) {
-				$remaining = array_flip( $chunk );
-				$cursor    = null;
 
-				// Results are paginated globally across the requested IDs (oldest first), so a
-				// single page can be exhausted by high-activity items before a quiet item's only
-				// record appears: the cursor must be followed or a real sellout is misread as a
-				// phantom.
-				do {
-					// No `types` request filter: the API rejects TRANSFER as a filter value, and
-					// filtering to the other two would misread an item whose only history is a
-					// transfer as never counted. All change types are fetched and matched below.
-					$response = wc_square()->get_api()->batch_retrieve_inventory_changes(
-						array(
-							'catalog_object_ids' => $chunk,
-							'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
-							'cursor'             => $cursor,
-						)
-					);
+				// First page for the whole chunk. When Square reports no further pages, every id
+				// missing from it is positively verified as having no history. When more pages
+				// exist, walking them all would page through the busiest item's entire history
+				// just to prove a quiet item empty, so unresolved ids are re-queried individually
+				// instead (a single id with no records answers in one page).
+				$page = self::fetch_inventory_changes_page( $chunk );
+				if ( null === $page ) {
+					return null;
+				}
 
-					$data = $response->get_data();
+				foreach ( $page['object_ids'] as $object_id ) {
+					$with_history[ $object_id ] = true;
+				}
 
-					if ( ! $data instanceof \Square\Models\BatchRetrieveInventoryChangesResponse ) {
-						wc_square()->log( 'Could not verify inventory history for zero counts: unexpected API response.' );
+				$unresolved = array_diff( $chunk, array_keys( $with_history ) );
+
+				if ( empty( $unresolved ) || empty( $page['cursor'] ) ) {
+					continue;
+				}
+
+				foreach ( $unresolved as $object_id ) {
+					$single = self::fetch_inventory_changes_page( array( $object_id ) );
+					if ( null === $single ) {
 						return null;
 					}
-
-					if ( is_array( $data->getChanges() ) ) {
-						foreach ( $data->getChanges() as $change ) {
-							$object_id = null;
-
-							if ( $change->getPhysicalCount() ) {
-								$object_id = $change->getPhysicalCount()->getCatalogObjectId();
-							} elseif ( $change->getAdjustment() ) {
-								$object_id = $change->getAdjustment()->getCatalogObjectId();
-							} elseif ( $change->getTransfer() ) {
-								$object_id = $change->getTransfer()->getCatalogObjectId();
-							}
-
-							if ( $object_id ) {
-								$with_history[ $object_id ] = true;
-								unset( $remaining[ $object_id ] );
-							}
-						}
+					if ( ! empty( $single['object_ids'] ) ) {
+						$with_history[ $object_id ] = true;
 					}
-
-					$cursor = $data->getCursor();
-				} while ( $cursor && ! empty( $remaining ) );
+					// Empty first page for a single id means no history: pagination is oldest
+					// first per id, so any record would appear on the first page.
+				}
 			}
 		} catch ( \Exception $exception ) {
 			wc_square()->log( 'Could not verify inventory history for zero counts: ' . $exception->getMessage() );
@@ -174,6 +159,54 @@ class Helper {
 		}
 
 		return array_keys( $with_history );
+	}
+
+	/**
+	 * Fetches one page of inventory changes for the given catalog object ids.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string[] $catalog_object_ids ids to query
+	 * @return array|null { object_ids: string[] with a change on this page, cursor: string|null } or null on failure
+	 */
+	protected static function fetch_inventory_changes_page( array $catalog_object_ids ) {
+
+		$response = wc_square()->get_api()->batch_retrieve_inventory_changes(
+			array(
+				'catalog_object_ids' => $catalog_object_ids,
+				'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
+			)
+		);
+
+		$data = $response->get_data();
+
+		if ( ! $data instanceof \Square\Models\BatchRetrieveInventoryChangesResponse ) {
+			wc_square()->log( 'Could not verify inventory history for zero counts: unexpected API response.' );
+			return null;
+		}
+
+		$object_ids = array();
+
+		foreach ( is_array( $data->getChanges() ) ? $data->getChanges() : array() as $change ) {
+			$object_id = null;
+
+			if ( $change->getPhysicalCount() ) {
+				$object_id = $change->getPhysicalCount()->getCatalogObjectId();
+			} elseif ( $change->getAdjustment() ) {
+				$object_id = $change->getAdjustment()->getCatalogObjectId();
+			} elseif ( $change->getTransfer() ) {
+				$object_id = $change->getTransfer()->getCatalogObjectId();
+			}
+
+			if ( $object_id ) {
+				$object_ids[ $object_id ] = true;
+			}
+		}
+
+		return array(
+			'object_ids' => array_keys( $object_ids ),
+			'cursor'     => $data->getCursor(),
+		);
 	}
 
 

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -38,9 +38,6 @@ defined( 'ABSPATH' ) || exit;
 class Helper {
 
 
-	/** @var int catalog objects held in the unverified zero count retry list */
-	const MAX_UNVERIFIED_ZERO_COUNTS = 1000;
-
 	/**
 	 * Maximum group narrowing passes before falling back to one request per unresolved id.
 	 *
@@ -326,89 +323,6 @@ class Helper {
 			'object_ids' => $returned,
 			'cursor'     => $data->getCursor(),
 		);
-	}
-
-
-	/**
-	 * Remembers catalog objects whose zero count could not be verified, for a later retry.
-	 *
-	 * Using the read window as the retry mechanism forces a choice between a window that grows on
-	 * every failed poll and a window that is eventually dropped, which would skip a genuine sellout
-	 * permanently. Remembering the specific objects avoids both: the watermark advances normally and
-	 * these objects are re-checked by id until they resolve.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string[] $catalog_object_ids objects whose zero count is still unverified
-	 */
-	public static function remember_unverified_zero_counts( $catalog_object_ids ) {
-
-		$catalog_object_ids = array_filter( (array) $catalog_object_ids );
-
-		if ( empty( $catalog_object_ids ) ) {
-			return;
-		}
-
-		$pending = (array) get_option( 'wc_square_unverified_zero_counts', array() );
-		$now     = time();
-
-		foreach ( $catalog_object_ids as $catalog_object_id ) {
-			if ( ! isset( $pending[ $catalog_object_id ] ) ) {
-				$pending[ $catalog_object_id ] = $now;
-			}
-		}
-
-		// Give up on anything that has sat here for a week. That is the one remaining window where a
-		// zero could be missed for good, and it is deliberately far longer than any plausible Square
-		// incident.
-		foreach ( $pending as $catalog_object_id => $first_seen ) {
-			if ( $now - (int) $first_seen > WEEK_IN_SECONDS ) {
-				unset( $pending[ $catalog_object_id ] );
-				wc_square()->log( 'Stopped waiting to verify the zero count for catalog object ' . $catalog_object_id . ': it has been pending for over a week.' );
-			}
-		}
-
-		// Keep the list bounded. Retries run oldest first, so the OLDEST entries are kept and the
-		// newest are dropped: evicting the oldest would keep discarding the entries being worked.
-		if ( count( $pending ) > self::MAX_UNVERIFIED_ZERO_COUNTS ) {
-			$dropped = count( $pending ) - self::MAX_UNVERIFIED_ZERO_COUNTS;
-			$pending = array_slice( $pending, 0, self::MAX_UNVERIFIED_ZERO_COUNTS, true );
-			wc_square()->log( sprintf( 'The unverified zero count list is full; %d newer entries were not kept.', $dropped ) );
-		}
-
-		update_option( 'wc_square_unverified_zero_counts', $pending, false );
-	}
-
-
-	/**
-	 * Gets the catalog object IDs waiting for their zero count to be verified.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return string[]
-	 */
-	public static function get_unverified_zero_counts() {
-
-		return array_keys( (array) get_option( 'wc_square_unverified_zero_counts', array() ) );
-	}
-
-
-	/**
-	 * Forgets catalog objects whose zero count no longer needs a retry.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string[] $catalog_object_ids resolved objects
-	 */
-	public static function forget_unverified_zero_counts( $catalog_object_ids ) {
-
-		$pending = (array) get_option( 'wc_square_unverified_zero_counts', array() );
-
-		foreach ( (array) $catalog_object_ids as $catalog_object_id ) {
-			unset( $pending[ $catalog_object_id ] );
-		}
-
-		update_option( 'wc_square_unverified_zero_counts', $pending, false );
 	}
 
 

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -260,11 +260,26 @@ class Helper {
 		// Zero count: never change the product's manage_stock setting in either direction.
 
 		if ( ! $product->get_manage_stock() ) {
-			// Not stock-managed in WooCommerce: counts are not data for this product; reflect
-			// availability only.
-			$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
 
-			return true;
+			// Not stock-managed in WooCommerce, so a quantity is never written. A zero still has to
+			// stop the product selling, but only when it is a proven sellout: an unproven zero (a
+			// tracked item that was never counted) must not mark a product the merchant keeps
+			// permanently sellable as out of stock. A zero is also never a reason to force a
+			// product back in stock, so this branch only ever writes out of stock.
+			if ( $zero_verified ) {
+				$product->set_stock_status( 'outofstock' );
+
+				return true;
+			}
+
+			wc_square()->log(
+				sprintf(
+					'Skipped marking product #%d out of stock: Square has no inventory history for the item, so its zero count is not a proven sellout.',
+					$product->get_id()
+				)
+			);
+
+			return false;
 		}
 
 		if ( $zero_verified ) {

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -42,6 +42,17 @@ class Helper {
 	const MAX_UNVERIFIED_ZERO_COUNTS = 1000;
 
 	/**
+	 * Maximum group narrowing passes before falling back to one request per unresolved id.
+	 *
+	 * Bounds the worst case: without it a page that resolves a single id each time would issue one
+	 * group request per id on top of the per id fallback.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	const MAX_HISTORY_NARROWING_PASSES = 5;
+
+	/**
 	 * Get the inventory tracking value for the given catalog object ids.
 	 *
 	 * @param array $catalog_object_ids The catalog object ids.
@@ -164,7 +175,7 @@ class Helper {
 				// exist, walking them all would page through the busiest item's entire history
 				// just to prove a quiet item empty, so unresolved ids are re-queried individually
 				// instead (a single id with no records answers in one page).
-				$page = self::fetch_inventory_changes_page( $chunk );
+				$page = static::fetch_inventory_changes_page( $chunk );
 				if ( null === $page ) {
 					return null;
 				}
@@ -179,16 +190,56 @@ class Helper {
 					continue;
 				}
 
-				foreach ( $unresolved as $object_id ) {
-					$single = self::fetch_inventory_changes_page( array( $object_id ) );
+				// Re-ask for the unresolved ids as a group before falling back to one request each.
+				// A shared page holds the OLDEST changes across every id in it, so one busy id can
+				// fill the page and hide a quiet id's record; asking again with the busy ids removed
+				// usually settles the whole remainder in a single request, and settles it positively
+				// when the response comes back empty with no further pages.
+				$remaining = array_values( $unresolved );
+				$passes    = 0;
+
+				while ( ! empty( $remaining ) && $passes < self::MAX_HISTORY_NARROWING_PASSES ) {
+
+					++$passes;
+
+					$group = static::fetch_inventory_changes_page( $remaining );
+					if ( null === $group ) {
+						return null;
+					}
+
+					$before = count( $remaining );
+
+					foreach ( $group['object_ids'] as $object_id ) {
+						$with_history[ $object_id ] = true;
+					}
+
+					$remaining = array_values( array_diff( $remaining, array_keys( $with_history ) ) );
+
+					// No further pages, so every id still remaining has no history at all. That is a
+					// positive verification, not an unknown, and the loop is done.
+					if ( empty( $group['cursor'] ) ) {
+						$remaining = array();
+						break;
+					}
+
+					// More pages exist but this one named none of the remaining ids, so narrowing has
+					// stalled and another group request would return the same page.
+					if ( count( $remaining ) === $before ) {
+						break;
+					}
+				}
+
+				// Anything still unresolved is settled one id at a time, where an empty first page is
+				// conclusive: pagination is oldest first, so a single id with any record shows it there.
+				foreach ( $remaining as $object_id ) {
+					$single = static::fetch_inventory_changes_page( array( $object_id ) );
 					if ( null === $single ) {
 						return null;
 					}
-					if ( ! empty( $single['object_ids'] ) ) {
+					// Membership, not emptiness: a response is only proof for the id it actually names.
+					if ( in_array( $object_id, $single['object_ids'], true ) ) {
 						$with_history[ $object_id ] = true;
 					}
-					// Empty first page for a single id means no history: pagination is oldest
-					// first per id, so any record would appear on the first page.
 				}
 			}
 		} catch ( \Exception $exception ) {

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -292,8 +292,38 @@ class Helper {
 			}
 		}
 
+		$returned = array_keys( $object_ids );
+
+		// Square honors catalog_object_ids only while at least one of the supplied ids exists. When
+		// none of them exists it silently drops the filter and answers with the whole location's
+		// change history, so a response naming ids we did not ask about means exactly one thing:
+		// none of the ids in this request exist in Square any more (a stale local mapping).
+		//
+		// That is a conclusive answer, not an unknown. A catalog object that does not exist cannot
+		// have sold out, so report no history and no further pages: the caller then treats these ids
+		// as unverified zeros and leaves the products alone. Without this check the per id branch
+		// below would read the unrelated history as proof and write the zero, which is the very bug
+		// SQUARE-145 fixes, for exactly the products whose mappings are stale.
+		$unexpected = array_diff( $returned, $catalog_object_ids );
+
+		if ( ! empty( $unexpected ) ) {
+
+			wc_square()->log(
+				sprintf(
+					'Square ignored the catalog object filter for %1$d id(s), which means none of them exist there any more; treating them as having no inventory history. First id: %2$s',
+					count( $catalog_object_ids ),
+					reset( $catalog_object_ids )
+				)
+			);
+
+			return array(
+				'object_ids' => array(),
+				'cursor'     => null,
+			);
+		}
+
 		return array(
-			'object_ids' => array_keys( $object_ids ),
+			'object_ids' => $returned,
 			'cursor'     => $data->getCursor(),
 		);
 	}

--- a/includes/Sync/Helper.php
+++ b/includes/Sync/Helper.php
@@ -198,6 +198,23 @@ class Helper {
 
 		$quantity = (float) $quantity;
 
+		// A variation inheriting stock management reports the string 'parent': its quantity and
+		// availability are governed by the parent's pooled stock, a quantity written to it is
+		// invisible (reads come from the parent) and a stock status write is overridden by the
+		// pool. A per-variation Square count, positive or zero, is not applicable data here; the
+		// pool is merchant intent and one variation's count must not alter stock shared by its
+		// siblings or convert the variation to its own management.
+		if ( 'parent' === $product->get_manage_stock() ) {
+			wc_square()->log(
+				sprintf(
+					'Skipped writing a stock quantity to variation #%d: its stock is managed by the parent product pool.',
+					$product->get_id()
+				)
+			);
+
+			return false;
+		}
+
 		if ( $quantity > 0 ) {
 			$product->set_stock_quantity( $quantity );
 			$product->set_manage_stock( true );
@@ -206,22 +223,6 @@ class Helper {
 		}
 
 		// Zero count: never change the product's manage_stock setting in either direction.
-
-		// A variation inheriting stock management reports the string 'parent': its quantity and
-		// availability are governed by the parent's pooled stock, a quantity written to it is
-		// invisible (reads come from the parent) and a stock status write is overridden by the
-		// pool. A per-variation Square count is not applicable data here; the pool is merchant
-		// intent and one variation's count must not alter stock shared by its siblings.
-		if ( 'parent' === $product->get_manage_stock() ) {
-			wc_square()->log(
-				sprintf(
-					'Skipped writing a zero stock quantity to variation #%d: its stock is managed by the parent product pool.',
-					$product->get_id()
-				)
-			);
-
-			return false;
-		}
 
 		if ( ! $product->get_manage_stock() ) {
 			// Not stock-managed in WooCommerce: counts are not data for this product; reflect

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -308,8 +308,17 @@ class Interval_Polling extends Stepped_Job {
 				$stock_status = $product->get_stock_status();
 				$out_of_stock = 'outofstock' === $stock_status;
 
-				// If Inventory tracking is the same as the product's manage stock setting and sold_old value same, skip.
-				if ( (bool) $is_tracking_inventory === (bool) $manage_stock && (bool) $sold_out === (bool) $out_of_stock ) {
+				// Nothing to do when the product already agrees with Square.
+				//
+				// Tracking is only worth comparing against manage_stock where the poll can still
+				// change it, which is Square SOR. Under WooCommerce SOR the poll leaves manage_stock
+				// alone, so a product tracked off in Square with Manage stock on in WooCommerce would
+				// never satisfy that comparison and would be saved on every poll for ever. There,
+				// availability is the only thing the poll writes, so it is the only thing to compare.
+				$square_owns_stock_setting = wc_square()->get_settings_handler()->is_system_of_record_square();
+				$tracking_already_matches  = ! $square_owns_stock_setting || (bool) $is_tracking_inventory === (bool) $manage_stock;
+
+				if ( $tracking_already_matches && (bool) $sold_out === (bool) $out_of_stock ) {
 					continue;
 				}
 				$catalog_objects_to_update[] = $catalog_object_id;

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -469,6 +469,10 @@ class Interval_Polling extends Stepped_Job {
 
 			$verified_zero_ids = array();
 
+			// Verification never succeeded for this window, so hold the inventory watermark back
+			// even though the step completes: the same window is then read again on the next poll
+			// and a genuine sellout is not skipped permanently.
+			$this->set_attr( 'hold_inventory_watermark', true );
 		} else {
 			$this->clear_unverified_zero_count_attempts( 'update_inventory_counts' );
 		}
@@ -516,8 +520,16 @@ class Interval_Polling extends Stepped_Job {
 		$this->set_attr( 'update_inventory_counts_count', $update_count + count( $catalog_objects_inventory_stats ) );
 
 		if ( ! $cursor ) {
-			// When all the inventory counts are synced then set the last sync time to the start time that was stored
-			wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
+			// When all the inventory counts are synced then set the last sync time to the start time
+			// that was stored, unless a zero count in this window could not be verified: holding the
+			// watermark back makes the next poll read the same window again so a genuine sellout is
+			// not skipped permanently.
+			if ( $this->get_attr( 'hold_inventory_watermark', false ) ) {
+				$this->set_attr( 'hold_inventory_watermark', false );
+				wc_square()->log( 'Inventory watermark held back: a zero count in this window could not be verified, so the window is read again on the next poll.' );
+			} else {
+				wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
+			}
 
 			$this->complete_step( 'update_inventory_counts' );
 		}

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -330,6 +330,12 @@ class Interval_Polling extends Stepped_Job {
 				}
 			}
 			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+			if ( null === $verified_zero_ids ) {
+				// Verification unavailable: stop this cycle WITHOUT advancing any progress marker,
+				// or a genuine sellout would be permanently skipped once the API recovers. The
+				// step retries on the next run.
+				throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next cycle.' );
+			}
 
 			foreach ( $catalog_objects_to_update as $catalog_object_id ) {
 				$product = Product::get_product_by_square_variation_id( $catalog_object_id );
@@ -445,6 +451,12 @@ class Interval_Polling extends Stepped_Job {
 			}
 		}
 		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+		if ( null === $verified_zero_ids ) {
+			// Verification unavailable: stop this cycle WITHOUT advancing any progress marker,
+			// or a genuine sellout would be permanently skipped once the API recovers. The
+			// step retries on the next run.
+			throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next cycle.' );
+		}
 
 		foreach ( $catalog_objects_inventory_stats as $catalog_object_id => $stats ) {
 

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -342,7 +342,7 @@ class Interval_Polling extends Stepped_Job {
 				// skipped and the job can finish.
 				$verified_zero_ids = array();
 			} else {
-				$this->clear_unverified_zero_count_attempts();
+				$this->clear_unverified_zero_count_attempts( 'update_inventory_tracking' );
 			}
 
 			foreach ( $catalog_objects_to_update as $catalog_object_id ) {
@@ -468,8 +468,9 @@ class Interval_Polling extends Stepped_Job {
 			}
 
 			$verified_zero_ids = array();
+
 		} else {
-			$this->clear_unverified_zero_count_attempts();
+			$this->clear_unverified_zero_count_attempts( 'update_inventory_counts' );
 		}
 
 		foreach ( $catalog_objects_inventory_stats as $catalog_object_id => $stats ) {
@@ -517,6 +518,7 @@ class Interval_Polling extends Stepped_Job {
 		if ( ! $cursor ) {
 			// When all the inventory counts are synced then set the last sync time to the start time that was stored
 			wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
+
 			$this->complete_step( 'update_inventory_counts' );
 		}
 	}

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -317,8 +317,19 @@ class Interval_Polling extends Stepped_Job {
 		}
 
 		if ( ! empty( $catalog_objects_to_update ) ) {
-			// Catalog Inventory data.
+			// Catalog Inventory data (IN_STOCK counts only).
 			$inventory_hash = Helper::get_catalog_objects_inventory_stats( $catalog_objects_to_update );
+
+			// A zero IN_STOCK count is ambiguous: a real sellout and a never-counted new item look
+			// identical. Verify zeros against Square's inventory change history so phantom zeros
+			// from uncounted items are never written to WooCommerce (SQUARE-145).
+			$zero_object_ids = array();
+			foreach ( $inventory_hash as $object_id => $object_quantity ) {
+				if ( 0.0 === (float) $object_quantity ) {
+					$zero_object_ids[] = $object_id;
+				}
+			}
+			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 			foreach ( $catalog_objects_to_update as $catalog_object_id ) {
 				$product = Product::get_product_by_square_variation_id( $catalog_object_id );
@@ -327,20 +338,28 @@ class Interval_Polling extends Stepped_Job {
 					$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 					$sold_out              = $inventory_data['sold_out'] ?? false;
 
-					/* If catalog object is tracked and has a quantity > 0 set in Square. */
 					if ( $is_tracking_inventory && isset( $inventory_hash[ $catalog_object_id ] ) ) {
-						$product->set_stock_quantity( (float) $inventory_hash[ $catalog_object_id ] );
-						$product->set_manage_stock( true );
 
-						/* If the catalog object is tracked but the quantity in Square is set to 0. */
+						$changed = Helper::apply_square_inventory_count(
+							$product,
+							(float) $inventory_hash[ $catalog_object_id ],
+							(bool) $sold_out,
+							in_array( $catalog_object_id, $verified_zero_ids, true )
+						);
+
+						if ( ! $changed ) {
+							continue;
+						}
 					} elseif ( $is_tracking_inventory ) {
-						$product->set_stock_quantity( 0 );
-						$product->set_manage_stock( true );
 
-						/* If the catalog object is not tracked in Square at all. */
+						// Tracked in Square but no IN_STOCK count returned: that is "no information",
+						// never a zero. Leave the product untouched (SQUARE-145).
+						continue;
 					} else {
+
+						// Not tracked in Square: reflect availability only. The product's
+						// manage_stock setting is merchant intent and is not changed here.
 						$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
-						$product->set_manage_stock( false );
 					}
 
 					$product->save();
@@ -404,25 +423,28 @@ class Interval_Polling extends Stepped_Job {
 			// users (SQUARE-7) and for uncounted items (SQUARE-145). Ignore them.
 			if ( 'IN_STOCK' !== $count->getState() ) {
 				continue;
-				// Else if the catalog object is IN_STOCK, then mark IN_STOCK as true and set the quantity for later use.
-			} elseif ( 'IN_STOCK' === $count->getState() ) {
-				$catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] = array(
-					'IN_STOCK' => true,
-					'quantity' => $count->getQuantity(),
-				);
-				// Else if the catalog object doesn't have an IN_STOCK status, then mark IN_STOCK as false and set the quantity as 0 for later use.
-			} else {
-				$catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] = array(
-					'IN_STOCK' => false,
-					'quantity' => 0,
-				);
 			}
+
+			$catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] = array(
+				'IN_STOCK' => true,
+				'quantity' => $count->getQuantity(),
+			);
 		}
 
 		// Get the inventory tracking for catalog objects.
 		$catalog_objects_tracking_stats = Helper::get_catalog_objects_tracking_stats(
 			array_keys( $catalog_objects_inventory_stats )
 		);
+
+		// Verify zero counts against Square's inventory change history: a never-counted item
+		// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written.
+		$zero_object_ids = array();
+		foreach ( $catalog_objects_inventory_stats as $object_id => $stats ) {
+			if ( 0.0 === (float) $stats['quantity'] ) {
+				$zero_object_ids[] = $object_id;
+			}
+		}
+		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 		foreach ( $catalog_objects_inventory_stats as $catalog_object_id => $stats ) {
 
@@ -440,11 +462,20 @@ class Interval_Polling extends Stepped_Job {
 				$sold_out              = $inventory_data['sold_out'] ?? false;
 
 				if ( $is_tracking_inventory ) {
-					$product->set_manage_stock( true );
-					$product->set_stock_quantity( $stats['quantity'] );
+					$changed = Helper::apply_square_inventory_count(
+						$product,
+						(float) $stats['quantity'],
+						(bool) $sold_out,
+						in_array( $catalog_object_id, $verified_zero_ids, true )
+					);
+
+					if ( ! $changed ) {
+						continue;
+					}
 				} else {
+					// Not tracked in Square: reflect availability only; manage_stock is merchant
+					// intent and is not changed here.
 					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
-					$product->set_manage_stock( false );
 				}
 
 				$product->save();

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -360,9 +360,14 @@ class Interval_Polling extends Stepped_Job {
 						continue;
 					} else {
 
-						// Not tracked in Square: reflect availability only. The product's
-						// manage_stock setting is merchant intent and is not changed here.
+						// Not tracked in Square: reflect availability. Stock management follows only
+						// when Square owns the setting; under WooCommerce SOR it is merchant intent
+						// and is left alone.
 						$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+						if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) {
+							$product->set_manage_stock( false );
+						}
 					}
 
 					$product->save();

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -41,6 +41,9 @@ class Interval_Polling extends Stepped_Job {
 	/** @var int catalog objects re-checked per poll from the unverified zero count list */
 	const MAX_ZERO_COUNT_RETRIES_PER_POLL = 200;
 
+	/** @var int catalog object ids sent per inventory counts request while retrying */
+	const MAX_ZERO_COUNT_RETRY_IDS_PER_REQUEST = 100;
+
 	/**
 	 * Assigns the next steps needed for this sync job.
 	 *
@@ -419,17 +422,40 @@ class Interval_Polling extends Stepped_Job {
 		$pending = array_slice( $pending, 0, self::MAX_ZERO_COUNT_RETRIES_PER_POLL );
 
 		try {
-			$counts_response = wc_square()->get_api()->batch_retrieve_inventory_counts(
-				array(
-					'catalog_object_ids' => $pending,
-					'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
-					'states'             => array( 'IN_STOCK' ),
-				)
-			);
-
 			$counts = array();
-			foreach ( ( $counts_response->get_data() && is_array( $counts_response->get_data()->getCounts() ) ) ? $counts_response->get_data()->getCounts() : array() as $count ) {
-				$counts[ $count->getCatalogObjectId() ] = $count->getQuantity();
+
+			// The read has to be COMPLETE before a missing id can be read as "no count any more":
+			// an odd response or an unread second page would otherwise look like proof that the
+			// object is gone and would erase the very backlog this list exists to protect. Ids are
+			// chunked and every cursor is followed, and any response that is not the expected type
+			// abandons the pass with the list untouched.
+			foreach ( array_chunk( $pending, self::MAX_ZERO_COUNT_RETRY_IDS_PER_REQUEST ) as $chunk ) {
+
+				$cursor = null;
+
+				do {
+					$counts_response = wc_square()->get_api()->batch_retrieve_inventory_counts(
+						array(
+							'catalog_object_ids' => $chunk,
+							'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
+							'states'             => array( 'IN_STOCK' ),
+							'cursor'             => $cursor,
+						)
+					);
+
+					$counts_data = $counts_response->get_data();
+
+					if ( ! $counts_data instanceof BatchRetrieveInventoryCountsResponse ) {
+						wc_square()->log( 'Skipped retrying unverified zero counts: the inventory counts response was missing or invalid.' );
+						return;
+					}
+
+					foreach ( is_array( $counts_data->getCounts() ) ? $counts_data->getCounts() : array() as $count ) {
+						$counts[ $count->getCatalogObjectId() ] = $count->getQuantity();
+					}
+
+					$cursor = $counts_data->getCursor();
+				} while ( $cursor );
 			}
 
 			$zero_ids = array();

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -341,6 +341,11 @@ class Interval_Polling extends Stepped_Job {
 				// Attempts exhausted: proceed with no zero verified, so only the zero writes are
 				// skipped and the job can finish.
 				$verified_zero_ids = array();
+
+				// This step reads the same watermark as the counts step, and an object can appear in
+				// this window without appearing in that one, so hold the watermark here as well or
+				// this window would never be read again.
+				$this->set_attr( 'hold_inventory_watermark', true );
 			} else {
 				$this->clear_unverified_zero_count_attempts( 'update_inventory_tracking' );
 			}

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -584,28 +584,13 @@ class Interval_Polling extends Stepped_Job {
 
 		// Verify zero counts against Square's inventory change history: a never-counted item
 		// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written.
-		$zero_object_ids = array();
-		foreach ( $catalog_objects_inventory_stats as $object_id => $stats ) {
-			if ( 0.0 === (float) $stats['quantity'] ) {
-				$zero_object_ids[] = $object_id;
-			}
-		}
-		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+		$zero_object_ids   = Helper::zero_count_object_ids( $catalog_objects_inventory_stats, 'quantity' );
+		$verified_zero_ids = $this->resolve_zero_count_verification( 'update_inventory_counts', $zero_object_ids );
+
 		if ( null === $verified_zero_ids ) {
-
-			// Verification unavailable. Return WITHOUT advancing the cursor or the inventory
-			// watermark so the step runs again, rather than throwing and failing the job.
-			if ( $this->should_retry_unverified_zero_counts( 'update_inventory_counts' ) ) {
-				return;
-			}
-
-			$verified_zero_ids = array();
-
-			// Remember the objects so they are re-checked by id on later polls: the watermark can
-			// then advance normally without this window being lost.
-			Helper::remember_unverified_zero_counts( $zero_object_ids );
-		} else {
-			$this->clear_unverified_zero_count_attempts( 'update_inventory_counts' );
+			// Verification unavailable and retries remain: return WITHOUT advancing the cursor or the
+			// inventory watermark so the step runs again, rather than throwing and failing the job.
+			return;
 		}
 
 		foreach ( $catalog_objects_inventory_stats as $catalog_object_id => $stats ) {

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -38,8 +38,8 @@ defined( 'ABSPATH' ) || exit;
 class Interval_Polling extends Stepped_Job {
 
 
-	/** @var int consecutive polls that may hold the inventory watermark before it advances anyway */
-	const MAX_INVENTORY_WATERMARK_HOLDS = 3;
+	/** @var int catalog objects re-checked per poll from the unverified zero count list */
+	const MAX_ZERO_COUNT_RETRIES_PER_POLL = 200;
 
 	/**
 	 * Assigns the next steps needed for this sync job.
@@ -346,10 +346,9 @@ class Interval_Polling extends Stepped_Job {
 				// skipped and the job can finish.
 				$verified_zero_ids = array();
 
-				// This step reads the same watermark as the counts step, and an object can appear in
-				// this window without appearing in that one, so hold the watermark here as well or
-				// this window would never be read again.
-				$this->set_attr( 'hold_inventory_watermark', true );
+				// Remember the objects so they are re-checked by id on later polls: the watermark can
+				// then advance normally without this window being lost.
+				Helper::remember_unverified_zero_counts( $zero_object_ids );
 			} else {
 				$this->clear_unverified_zero_count_attempts( 'update_inventory_tracking' );
 			}
@@ -398,6 +397,96 @@ class Interval_Polling extends Stepped_Job {
 			$this->complete_step( 'update_inventory_tracking' );
 		}
 	}
+
+	/**
+	 * Re-checks catalog objects whose zero count could not be verified on an earlier poll.
+	 *
+	 * These are looked up by id rather than by the read window, so a Square incident cannot make the
+	 * window grow and cannot cause a genuine sellout to be skipped permanently. Objects leave the
+	 * list as soon as they resolve, whether that means a zero was finally written, the count came
+	 * back positive, or the object no longer reports a count at all.
+	 *
+	 * @since x.x.x
+	 */
+	protected function retry_unverified_zero_counts() {
+
+		$pending = Helper::get_unverified_zero_counts();
+
+		if ( empty( $pending ) ) {
+			return;
+		}
+
+		$pending = array_slice( $pending, 0, self::MAX_ZERO_COUNT_RETRIES_PER_POLL );
+
+		try {
+			$counts_response = wc_square()->get_api()->batch_retrieve_inventory_counts(
+				array(
+					'catalog_object_ids' => $pending,
+					'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
+					'states'             => array( 'IN_STOCK' ),
+				)
+			);
+
+			$counts = array();
+			foreach ( ( $counts_response->get_data() && is_array( $counts_response->get_data()->getCounts() ) ) ? $counts_response->get_data()->getCounts() : array() as $count ) {
+				$counts[ $count->getCatalogObjectId() ] = $count->getQuantity();
+			}
+
+			$zero_ids = array();
+			foreach ( $counts as $object_id => $quantity ) {
+				if ( 0.0 === (float) $quantity ) {
+					$zero_ids[] = $object_id;
+				}
+			}
+
+			$verified = Helper::get_catalog_objects_with_inventory_history( $zero_ids );
+
+			if ( null === $verified ) {
+				// Still unavailable: leave the list untouched and try again on the next poll.
+				return;
+			}
+
+			$tracking = Helper::get_catalog_objects_tracking_stats( $pending );
+			$resolved = array();
+
+			foreach ( $pending as $object_id ) {
+
+				// No count at all any more (item deleted or no longer tracked): nothing to retry.
+				if ( ! isset( $counts[ $object_id ] ) ) {
+					$resolved[] = $object_id;
+					continue;
+				}
+
+				$product = Product::get_product_by_square_variation_id( $object_id );
+
+				if ( ! $product instanceof \WC_Product || ! Product::is_synced_with_square( $product ) ) {
+					$resolved[] = $object_id;
+					continue;
+				}
+
+				$quantity = (float) $counts[ $object_id ];
+
+				// An unverified zero stays on the list; anything else is settled now.
+				if ( 0.0 === $quantity && ! in_array( $object_id, $verified, true ) ) {
+					continue;
+				}
+
+				if ( Helper::apply_square_inventory_count( $product, $quantity, (bool) ( $tracking[ $object_id ]['sold_out'] ?? false ), true ) ) {
+					$product->save();
+				}
+
+				$resolved[] = $object_id;
+			}
+
+			if ( $resolved ) {
+				Helper::forget_unverified_zero_counts( $resolved );
+				wc_square()->log( sprintf( 'Resolved %d previously unverified zero counts by id.', count( $resolved ) ) );
+			}
+		} catch ( \Exception $exception ) {
+			wc_square()->log( 'Could not retry unverified zero counts: ' . $exception->getMessage() );
+		}
+	}
+
 
 	/**
 	 * Updates the inventory counts from the latest in Square.
@@ -478,10 +567,9 @@ class Interval_Polling extends Stepped_Job {
 
 			$verified_zero_ids = array();
 
-			// Verification never succeeded for this window, so hold the inventory watermark back
-			// even though the step completes: the same window is then read again on the next poll
-			// and a genuine sellout is not skipped permanently.
-			$this->set_attr( 'hold_inventory_watermark', true );
+			// Remember the objects so they are re-checked by id on later polls: the watermark can
+			// then advance normally without this window being lost.
+			Helper::remember_unverified_zero_counts( $zero_object_ids );
 		} else {
 			$this->clear_unverified_zero_count_attempts( 'update_inventory_counts' );
 		}
@@ -533,27 +621,11 @@ class Interval_Polling extends Stepped_Job {
 			// that was stored, unless a zero count in this window could not be verified: holding the
 			// watermark back makes the next poll read the same window again so a genuine sellout is
 			// not skipped permanently.
-			if ( $this->get_attr( 'hold_inventory_watermark', false ) ) {
+			// Objects whose zero count could not be verified are retried by id, so the watermark can
+			// advance on schedule: the read window never grows and nothing is permanently skipped.
+			$this->retry_unverified_zero_counts();
 
-				$this->set_attr( 'hold_inventory_watermark', false );
-
-				// Holding the watermark makes the next poll read the same window again, but holding
-				// it through a long Square incident would grow that window on every poll. Allow a
-				// few consecutive holds and then move on: the merchant has already been alerted.
-				$holds = (int) get_option( 'wc_square_inventory_watermark_holds', 0 ) + 1;
-
-				if ( $holds >= self::MAX_INVENTORY_WATERMARK_HOLDS ) {
-					update_option( 'wc_square_inventory_watermark_holds', 0, false );
-					wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
-					wc_square()->log( 'Zero counts stayed unverified across several polls; advancing the inventory watermark so the read window stops growing.' );
-				} else {
-					update_option( 'wc_square_inventory_watermark_holds', $holds, false );
-					wc_square()->log( sprintf( 'Inventory watermark held back (%1$d of %2$d): a zero count in this window could not be verified, so the window is read again on the next poll.', $holds, self::MAX_INVENTORY_WATERMARK_HOLDS ) );
-				}
-			} else {
-				update_option( 'wc_square_inventory_watermark_holds', 0, false );
-				wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
-			}
+			wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
 
 			$this->complete_step( 'update_inventory_counts' );
 		}

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -482,9 +482,14 @@ class Interval_Polling extends Stepped_Job {
 						continue;
 					}
 				} else {
-					// Not tracked in Square: reflect availability only; manage_stock is merchant
-					// intent and is not changed here.
+					// Not tracked in Square: reflect availability. Stock management follows only when
+					// Square owns the setting; under WooCommerce SOR it is merchant intent and is
+					// left alone, so a Square side toggle cannot silently invert the system of record.
 					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+					if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) {
+						$product->set_manage_stock( false );
+					}
 				}
 
 				$product->save();

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -37,6 +37,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class Interval_Polling extends Stepped_Job {
 
+
+	/** @var int consecutive polls that may hold the inventory watermark before it advances anyway */
+	const MAX_INVENTORY_WATERMARK_HOLDS = 3;
+
 	/**
 	 * Assigns the next steps needed for this sync job.
 	 *
@@ -530,9 +534,24 @@ class Interval_Polling extends Stepped_Job {
 			// watermark back makes the next poll read the same window again so a genuine sellout is
 			// not skipped permanently.
 			if ( $this->get_attr( 'hold_inventory_watermark', false ) ) {
+
 				$this->set_attr( 'hold_inventory_watermark', false );
-				wc_square()->log( 'Inventory watermark held back: a zero count in this window could not be verified, so the window is read again on the next poll.' );
+
+				// Holding the watermark makes the next poll read the same window again, but holding
+				// it through a long Square incident would grow that window on every poll. Allow a
+				// few consecutive holds and then move on: the merchant has already been alerted.
+				$holds = (int) get_option( 'wc_square_inventory_watermark_holds', 0 ) + 1;
+
+				if ( $holds >= self::MAX_INVENTORY_WATERMARK_HOLDS ) {
+					update_option( 'wc_square_inventory_watermark_holds', 0, false );
+					wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
+					wc_square()->log( 'Zero counts stayed unverified across several polls; advancing the inventory watermark so the read window stops growing.' );
+				} else {
+					update_option( 'wc_square_inventory_watermark_holds', $holds, false );
+					wc_square()->log( sprintf( 'Inventory watermark held back (%1$d of %2$d): a zero count in this window could not be verified, so the window is read again on the next poll.', $holds, self::MAX_INVENTORY_WATERMARK_HOLDS ) );
+				}
 			} else {
+				update_option( 'wc_square_inventory_watermark_holds', 0, false );
 				wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
 			}
 

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -398,8 +398,11 @@ class Interval_Polling extends Stepped_Job {
 		$catalog_objects_inventory_stats = array();
 
 		foreach ( $response->get_counts() as $count ) {
-			// If catalog stats array already contains the catalog object marked as IN_STOCK, then continue.
-			if ( isset( $catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] ) && $catalog_objects_inventory_stats[ $count->getCatalogObjectId() ]['IN_STOCK'] ) {
+			// Only explicit IN_STOCK counts are usable data. Other states (SOLD, WASTE, ORDERED,
+			// RECEIVED_FROM_VENDOR, RESERVED, ...) are movements or purchase-order stages, not the
+			// available quantity - coercing them to zero is what wiped stock for purchase-order
+			// users (SQUARE-7) and for uncounted items (SQUARE-145). Ignore them.
+			if ( 'IN_STOCK' !== $count->getState() ) {
 				continue;
 				// Else if the catalog object is IN_STOCK, then mark IN_STOCK as true and set the quantity for later use.
 			} elseif ( 'IN_STOCK' === $count->getState() ) {

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -297,6 +297,13 @@ class Interval_Polling extends Stepped_Job {
 			$sold_out              = $inventory_data['sold_out'] ?? false;
 			$product               = Product::get_product_by_square_variation_id( $catalog_object_id );
 			if ( $product instanceof \WC_Product ) {
+				// Respect the per-product "Sync with Square" setting: the push side already honours
+				// it, and the automatic pull must too, or unticking/unlinking cannot stop Square
+				// from overwriting this product's stock.
+				if ( ! Product::is_synced_with_square( $product ) ) {
+					continue;
+				}
+
 				$manage_stock = $product->get_manage_stock();
 				$stock_status = $product->get_stock_status();
 				$out_of_stock = 'outofstock' === $stock_status;
@@ -420,6 +427,11 @@ class Interval_Polling extends Stepped_Job {
 
 			// Square can return multiple "types" of counts, WooCommerce only distinguishes whether a product is in stock or not
 			if ( $product instanceof \WC_Product ) {
+				// Respect the per-product "Sync with Square" setting on the pull side as well.
+				if ( ! Product::is_synced_with_square( $product ) ) {
+					continue;
+				}
+
 				$inventory_data        = $catalog_objects_tracking_stats[ $catalog_object_id ] ?? array();
 				$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 				$sold_out              = $inventory_data['sold_out'] ?? false;

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -331,10 +331,18 @@ class Interval_Polling extends Stepped_Job {
 			}
 			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 			if ( null === $verified_zero_ids ) {
-				// Verification unavailable: stop this cycle WITHOUT advancing any progress marker,
-				// or a genuine sellout would be permanently skipped once the API recovers. The
-				// step retries on the next run.
-				throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next cycle.' );
+
+				// Verification unavailable. Return WITHOUT advancing any progress marker so the
+				// step runs again, rather than throwing, which would fail the whole job.
+				if ( $this->should_retry_unverified_zero_counts( 'update_inventory_tracking' ) ) {
+					return;
+				}
+
+				// Attempts exhausted: proceed with no zero verified, so only the zero writes are
+				// skipped and the job can finish.
+				$verified_zero_ids = array();
+			} else {
+				$this->clear_unverified_zero_count_attempts();
 			}
 
 			foreach ( $catalog_objects_to_update as $catalog_object_id ) {
@@ -452,10 +460,16 @@ class Interval_Polling extends Stepped_Job {
 		}
 		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 		if ( null === $verified_zero_ids ) {
-			// Verification unavailable: stop this cycle WITHOUT advancing any progress marker,
-			// or a genuine sellout would be permanently skipped once the API recovers. The
-			// step retries on the next run.
-			throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next cycle.' );
+
+			// Verification unavailable. Return WITHOUT advancing the cursor or the inventory
+			// watermark so the step runs again, rather than throwing and failing the job.
+			if ( $this->should_retry_unverified_zero_counts( 'update_inventory_counts' ) ) {
+				return;
+			}
+
+			$verified_zero_ids = array();
+		} else {
+			$this->clear_unverified_zero_count_attempts();
 		}
 
 		foreach ( $catalog_objects_inventory_stats as $catalog_object_id => $stats ) {

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -37,10 +37,6 @@ defined( 'ABSPATH' ) || exit;
  */
 class Interval_Polling extends Stepped_Job {
 
-
-
-
-
 	/**
 	 * Assigns the next steps needed for this sync job.
 	 *

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -38,14 +38,8 @@ defined( 'ABSPATH' ) || exit;
 class Interval_Polling extends Stepped_Job {
 
 
-	/** @var int catalog objects re-checked per poll from the unverified zero count list */
-	const MAX_ZERO_COUNT_RETRIES_PER_POLL = 200;
 
-	/** @var int catalog object ids sent per inventory counts request while retrying */
-	const MAX_ZERO_COUNT_RETRY_IDS_PER_REQUEST = 100;
 
-	/** @var int pages read per chunk while retrying before the pass is abandoned */
-	const MAX_ZERO_COUNT_RETRY_PAGES = 20;
 
 	/**
 	 * Assigns the next steps needed for this sync job.
@@ -338,7 +332,9 @@ class Interval_Polling extends Stepped_Job {
 
 			if ( null === $verified_zero_ids ) {
 				// Verification unavailable and retries remain: return WITHOUT advancing any progress
-				// marker so the step runs again, rather than throwing and failing the whole job.
+				// marker so the step runs again, rather than throwing and failing the whole job. Once
+				// the retries are spent this step proceeds writing no zeros, and the counts step keeps
+				// the shared window in place so this window is read again on the next poll.
 				return;
 			}
 
@@ -386,141 +382,6 @@ class Interval_Polling extends Stepped_Job {
 			$this->complete_step( 'update_inventory_tracking' );
 		}
 	}
-
-	/**
-	 * Re-checks catalog objects whose zero count could not be verified on an earlier poll.
-	 *
-	 * These are looked up by id rather than by the read window, so a Square incident cannot make the
-	 * window grow and cannot cause a genuine sellout to be skipped permanently. Objects leave the
-	 * list as soon as they resolve, whether that means a zero was finally written, the count came
-	 * back positive, or the object no longer reports a count at all.
-	 *
-	 * @since x.x.x
-	 */
-	protected function retry_unverified_zero_counts() {
-
-		$pending = Helper::get_unverified_zero_counts();
-
-		if ( empty( $pending ) ) {
-			return;
-		}
-
-		$pending = array_slice( $pending, 0, self::MAX_ZERO_COUNT_RETRIES_PER_POLL );
-
-		try {
-			$counts = array();
-
-			// The read has to be COMPLETE before a missing id can be read as "no count any more":
-			// an odd response or an unread second page would otherwise look like proof that the
-			// object is gone and would erase the very backlog this list exists to protect. Ids are
-			// chunked and every cursor is followed, and any response that is not the expected type
-			// abandons the pass with the list untouched.
-			foreach ( array_chunk( $pending, self::MAX_ZERO_COUNT_RETRY_IDS_PER_REQUEST ) as $chunk ) {
-
-				$cursor = null;
-				$page   = 0;
-
-				do {
-
-					// A cursor that never advances would spin here inside a background job, so the
-					// pass is capped. Hitting the cap means the read is incomplete, which must not be
-					// mistaken for proof that the remaining ids are gone.
-					if ( ++$page > self::MAX_ZERO_COUNT_RETRY_PAGES ) {
-						wc_square()->log( 'Stopped retrying unverified zero counts: the inventory counts response kept paginating past the page limit.' );
-						return;
-					}
-
-					$counts_response = wc_square()->get_api()->batch_retrieve_inventory_counts(
-						array(
-							'catalog_object_ids' => $chunk,
-							'location_ids'       => array( wc_square()->get_settings_handler()->get_location_id() ),
-							'states'             => array( 'IN_STOCK' ),
-							'cursor'             => $cursor,
-						)
-					);
-
-					$counts_data = $counts_response->get_data();
-
-					if ( ! $counts_data instanceof BatchRetrieveInventoryCountsResponse ) {
-						wc_square()->log( 'Skipped retrying unverified zero counts: the inventory counts response was missing or invalid.' );
-						return;
-					}
-
-					foreach ( is_array( $counts_data->getCounts() ) ? $counts_data->getCounts() : array() as $count ) {
-
-						// Keep only what was asked for. Square drops the catalog object filter when
-						// none of the supplied ids still exists there, and a chunk of stale mappings
-						// is exactly that case, so an unfiltered answer would otherwise pull other
-						// products' counts into this retry pass.
-						if ( ! in_array( $count->getCatalogObjectId(), $chunk, true ) ) {
-							continue;
-						}
-
-						$counts[ $count->getCatalogObjectId() ] = $count->getQuantity();
-					}
-
-					$cursor = $counts_data->getCursor();
-				} while ( $cursor );
-			}
-
-			$zero_ids = Helper::zero_count_object_ids( $counts );
-
-			$verified = Helper::get_catalog_objects_with_inventory_history( $zero_ids );
-
-			if ( null === $verified ) {
-				// Still unavailable: leave the list untouched and try again on the next poll.
-				return;
-			}
-
-			$tracking = Helper::get_catalog_objects_tracking_stats( $pending );
-			$resolved = array();
-
-			foreach ( $pending as $object_id ) {
-
-				// No count at all any more (item deleted or no longer tracked): nothing to retry.
-				if ( ! isset( $counts[ $object_id ] ) ) {
-					$resolved[] = $object_id;
-					continue;
-				}
-
-				$product = Product::get_product_by_square_variation_id( $object_id );
-
-				if ( ! $product instanceof \WC_Product || ! Product::is_synced_with_square( $product ) ) {
-					$resolved[] = $object_id;
-					continue;
-				}
-
-				$quantity = (float) $counts[ $object_id ];
-
-				// Past the check above there is no unresolved state left in this loop: the history
-				// lookup succeeded, so it is a positive verification of the whole zero set and an id
-				// missing from it is PROVEN to have no history. That is a phantom, the answer cannot
-				// change while the count stays at zero, and the correct action is to never write it.
-				// Leaving it pending would fill the list with entries that can never resolve, and
-				// because retries take the oldest first they would starve the genuine sellouts queued
-				// behind them.
-				if ( 0.0 === $quantity && ! in_array( $object_id, $verified, true ) ) {
-					wc_square()->log( sprintf( 'Confirmed catalog object %s has no inventory history: its zero count is a phantom, so no stock was written and it leaves the retry list.', $object_id ) );
-					$resolved[] = $object_id;
-					continue;
-				}
-
-				if ( Helper::apply_square_inventory_count( $product, $quantity, (bool) ( $tracking[ $object_id ]['sold_out'] ?? false ), true ) ) {
-					$product->save();
-				}
-
-				$resolved[] = $object_id;
-			}
-
-			if ( $resolved ) {
-				Helper::forget_unverified_zero_counts( $resolved );
-				wc_square()->log( sprintf( 'Resolved %d previously unverified zero counts by id.', count( $resolved ) ) );
-			}
-		} catch ( \Exception $exception ) {
-			wc_square()->log( 'Could not retry unverified zero counts: ' . $exception->getMessage() );
-		}
-	}
-
 
 	/**
 	 * Updates the inventory counts from the latest in Square.
@@ -636,15 +497,25 @@ class Interval_Polling extends Stepped_Job {
 		$this->set_attr( 'update_inventory_counts_count', $update_count + count( $catalog_objects_inventory_stats ) );
 
 		if ( ! $cursor ) {
-			// When all the inventory counts are synced then set the last sync time to the start time
-			// that was stored, unless a zero count in this window could not be verified: holding the
-			// watermark back makes the next poll read the same window again so a genuine sellout is
-			// not skipped permanently.
-			// Objects whose zero count could not be verified are retried by id, so the watermark can
-			// advance on schedule: the read window never grows and nothing is permanently skipped.
-			$this->retry_unverified_zero_counts();
 
-			wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
+			// All counts in this window are processed, so the watermark may move to the start time
+			// stored above, with one exception: if a zero count in this window could not be verified
+			// after the retries, the window is left in place. Counts are read by updated_after, so the
+			// same window is read again on the next poll and those exact objects come back with it.
+			// Advancing here instead would skip a genuine sellout for good, because Square would not
+			// report that object again until something else changed it.
+			// Both inventory steps read this one watermark and only this step advances it, so a window
+			// either step could not verify has to stay put. Checking only this step's flag would let it
+			// move the window over objects the tracking step had to leave unverified.
+			if ( $this->zero_verification_exhausted( 'update_inventory_counts' )
+				|| $this->zero_verification_exhausted( 'update_inventory_tracking' ) ) {
+
+				wc_square()->log( 'Zero inventory counts in this window could not be verified against Square history; keeping the inventory sync window so the next poll reads it again.' );
+
+			} else {
+
+				wc_square()->get_sync_handler()->set_inventory_last_synced_at( $last_sync_timestamp );
+			}
 
 			$this->complete_step( 'update_inventory_counts' );
 		}

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -333,30 +333,13 @@ class Interval_Polling extends Stepped_Job {
 			// A zero IN_STOCK count is ambiguous: a real sellout and a never-counted new item look
 			// identical. Verify zeros against Square's inventory change history so phantom zeros
 			// from uncounted items are never written to WooCommerce (SQUARE-145).
-			$zero_object_ids = array();
-			foreach ( $inventory_hash as $object_id => $object_quantity ) {
-				if ( 0.0 === (float) $object_quantity ) {
-					$zero_object_ids[] = $object_id;
-				}
-			}
-			$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+			$zero_object_ids   = Helper::zero_count_object_ids( $inventory_hash );
+			$verified_zero_ids = $this->resolve_zero_count_verification( 'update_inventory_tracking', $zero_object_ids );
+
 			if ( null === $verified_zero_ids ) {
-
-				// Verification unavailable. Return WITHOUT advancing any progress marker so the
-				// step runs again, rather than throwing, which would fail the whole job.
-				if ( $this->should_retry_unverified_zero_counts( 'update_inventory_tracking' ) ) {
-					return;
-				}
-
-				// Attempts exhausted: proceed with no zero verified, so only the zero writes are
-				// skipped and the job can finish.
-				$verified_zero_ids = array();
-
-				// Remember the objects so they are re-checked by id on later polls: the watermark can
-				// then advance normally without this window being lost.
-				Helper::remember_unverified_zero_counts( $zero_object_ids );
-			} else {
-				$this->clear_unverified_zero_count_attempts( 'update_inventory_tracking' );
+				// Verification unavailable and retries remain: return WITHOUT advancing any progress
+				// marker so the step runs again, rather than throwing and failing the whole job.
+				return;
 			}
 
 			foreach ( $catalog_objects_to_update as $catalog_object_id ) {
@@ -464,6 +447,15 @@ class Interval_Polling extends Stepped_Job {
 					}
 
 					foreach ( is_array( $counts_data->getCounts() ) ? $counts_data->getCounts() : array() as $count ) {
+
+						// Keep only what was asked for. Square drops the catalog object filter when
+						// none of the supplied ids still exists there, and a chunk of stale mappings
+						// is exactly that case, so an unfiltered answer would otherwise pull other
+						// products' counts into this retry pass.
+						if ( ! in_array( $count->getCatalogObjectId(), $chunk, true ) ) {
+							continue;
+						}
+
 						$counts[ $count->getCatalogObjectId() ] = $count->getQuantity();
 					}
 
@@ -471,12 +463,7 @@ class Interval_Polling extends Stepped_Job {
 				} while ( $cursor );
 			}
 
-			$zero_ids = array();
-			foreach ( $counts as $object_id => $quantity ) {
-				if ( 0.0 === (float) $quantity ) {
-					$zero_ids[] = $object_id;
-				}
-			}
+			$zero_ids = Helper::zero_count_object_ids( $counts );
 
 			$verified = Helper::get_catalog_objects_with_inventory_history( $zero_ids );
 

--- a/includes/Sync/Interval_Polling.php
+++ b/includes/Sync/Interval_Polling.php
@@ -44,6 +44,9 @@ class Interval_Polling extends Stepped_Job {
 	/** @var int catalog object ids sent per inventory counts request while retrying */
 	const MAX_ZERO_COUNT_RETRY_IDS_PER_REQUEST = 100;
 
+	/** @var int pages read per chunk while retrying before the pass is abandoned */
+	const MAX_ZERO_COUNT_RETRY_PAGES = 20;
+
 	/**
 	 * Assigns the next steps needed for this sync job.
 	 *
@@ -432,8 +435,18 @@ class Interval_Polling extends Stepped_Job {
 			foreach ( array_chunk( $pending, self::MAX_ZERO_COUNT_RETRY_IDS_PER_REQUEST ) as $chunk ) {
 
 				$cursor = null;
+				$page   = 0;
 
 				do {
+
+					// A cursor that never advances would spin here inside a background job, so the
+					// pass is capped. Hitting the cap means the read is incomplete, which must not be
+					// mistaken for proof that the remaining ids are gone.
+					if ( ++$page > self::MAX_ZERO_COUNT_RETRY_PAGES ) {
+						wc_square()->log( 'Stopped retrying unverified zero counts: the inventory counts response kept paginating past the page limit.' );
+						return;
+					}
+
 					$counts_response = wc_square()->get_api()->batch_retrieve_inventory_counts(
 						array(
 							'catalog_object_ids' => $chunk,
@@ -492,8 +505,16 @@ class Interval_Polling extends Stepped_Job {
 
 				$quantity = (float) $counts[ $object_id ];
 
-				// An unverified zero stays on the list; anything else is settled now.
+				// Past the check above there is no unresolved state left in this loop: the history
+				// lookup succeeded, so it is a positive verification of the whole zero set and an id
+				// missing from it is PROVEN to have no history. That is a phantom, the answer cannot
+				// change while the count stays at zero, and the correct action is to never write it.
+				// Leaving it pending would fill the list with entries that can never resolve, and
+				// because retries take the oldest first they would starve the genuine sellouts queued
+				// behind them.
 				if ( 0.0 === $quantity && ! in_array( $object_id, $verified, true ) ) {
+					wc_square()->log( sprintf( 'Confirmed catalog object %s has no inventory history: its zero count is a phantom, so no stock was written and it leaves the retry list.', $object_id ) );
+					$resolved[] = $object_id;
 					continue;
 				}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1405,7 +1405,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$all_changes = array_merge( ...array_values( $inventory_changes ) );
 
-		$this->remember_pushed_inventory_objects( $all_changes );
+		$this->exclude_pushed_objects_from_inventory_pull( $all_changes );
 
 		// Chunk by the batch limit in case the set of products has many variations.
 		$chunks = array_chunk( $all_changes, self::BATCH_CHANGE_INVENTORY_LIMIT );
@@ -1580,7 +1580,7 @@ class Manual_Synchronization extends Stepped_Job {
 			$result            = wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_changes );
 
 			// Recorded after the push so pull_inventory() can skip reading these counts straight back.
-			$this->remember_pushed_inventory_objects( $inventory_changes );
+			$this->exclude_pushed_objects_from_inventory_pull( $inventory_changes );
 		}
 
 		$this->set_attr( 'inventory_push_product_ids', $product_ids );
@@ -1892,17 +1892,18 @@ class Manual_Synchronization extends Stepped_Job {
 
 
 	/**
-	 * Records the catalog objects whose inventory counts this job has pushed to Square.
+	 * Drops the catalog objects whose counts this job just pushed from the inventory pull queue.
 	 *
-	 * Used by pull_inventory() to avoid reading a count straight back after writing it. Square's
-	 * inventory is eventually consistent, so the read can still answer with the pre-push value, and
-	 * for an item that had never been counted it answers zero, which would undo the push.
+	 * Square's inventory is eventually consistent, so reading a count straight back after writing it
+	 * can answer with the pre-push value, and for an item that had never been counted it answers zero,
+	 * which would undo the push. Both push sites run before pull_inventory in the step order, so
+	 * removing the ids here is enough and needs no second attribute.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param \Square\Models\InventoryChange[] $inventory_changes changes that were pushed
 	 */
-	protected function remember_pushed_inventory_objects( array $inventory_changes ) {
+	protected function exclude_pushed_objects_from_inventory_pull( array $inventory_changes ) {
 
 		$object_ids = array();
 
@@ -1923,10 +1924,13 @@ class Manual_Synchronization extends Stepped_Job {
 			return;
 		}
 
-		$this->set_attr(
-			'pushed_inventory_variation_ids',
-			array_values( array_unique( array_merge( (array) $this->get_attr( 'pushed_inventory_variation_ids', array() ), $object_ids ) ) )
-		);
+		$queued = (array) $this->get_attr( 'pull_inventory_variation_ids', array() );
+		$kept   = array_values( array_diff( $queued, $object_ids ) );
+
+		if ( count( $kept ) !== count( $queued ) ) {
+			$this->set_attr( 'pull_inventory_variation_ids', $kept );
+			wc_square()->log( sprintf( 'Removed %d catalog object(s) from the inventory pull queue because this job just pushed their counts.', count( $queued ) - count( $kept ) ) );
+		}
 	}
 
 
@@ -1967,26 +1971,6 @@ class Manual_Synchronization extends Stepped_Job {
 			// remove IDs that have already been processed
 			$square_variation_ids = array_diff( $square_variation_ids, $processed_ids );
 
-			// Never read back a count this same job pushed. Square's inventory is eventually
-			// consistent, so a freshly pushed count can still answer with the previous value, or with
-			// zero for an item that had none before, and writing that back would undo the push. Only
-			// objects this job pushed are skipped; everything else, which is every product that
-			// already existed in Square, is still pulled.
-			$pushed_ids = (array) $this->get_attr( 'pushed_inventory_variation_ids', array() );
-
-			if ( $pushed_ids ) {
-				$skipped              = array_intersect( $square_variation_ids, $pushed_ids );
-				$square_variation_ids = array_values( array_diff( $square_variation_ids, $pushed_ids ) );
-
-				if ( $skipped ) {
-					$this->set_attr(
-						'processed_square_variation_ids',
-						array_values( array_unique( array_merge( $processed_ids, $skipped ) ) )
-					);
-
-					wc_square()->log( sprintf( 'Skipped pulling inventory for %d catalog object(s) this job just pushed.', count( $skipped ) ) );
-				}
-			}
 
 			if ( empty( $square_variation_ids ) ) {
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2093,9 +2093,14 @@ class Manual_Synchronization extends Stepped_Job {
 					}
 				} elseif ( ! $is_tracking_inventory ) {
 
-					// Not tracked in Square: reflect availability only; manage_stock is merchant
-					// intent and is not changed here.
+					// Not tracked in Square: reflect availability. Stock management follows only when
+					// Square owns the setting; under WooCommerce SOR it is merchant intent and is
+					// left alone, so a Square side toggle cannot silently invert the system of record.
 					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+					if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) {
+						$product->set_manage_stock( false );
+					}
 					$product->save();
 				}
 				// Tracked in Square but no IN_STOCK count returned: "no information", never a

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1466,16 +1466,19 @@ class Manual_Synchronization extends Stepped_Job {
 			foreach ( $product->get_children() as $child_id ) {
 
 				$child = wc_get_product( $child_id );
-				if ( ! $child instanceof \WC_Product || ! $child->get_manage_stock() ) {
+				if ( ! $child instanceof \WC_Product ) {
 					continue;
 				}
 
+				// The count builder decides per product state: managed -> real quantity (skipping
+				// unresolved quantities), unmanaged out of stock -> explicit zero to mark the item
+				// sold out, unmanaged in stock -> nothing.
 				$change = Product::get_inventory_change_physical_count_type( $child );
 				if ( $change ) {
 					$changes[] = $change;
 				}
 			}
-		} elseif ( $product->get_manage_stock() ) {
+		} else {
 
 			$change = Product::get_inventory_change_physical_count_type( $product );
 			if ( $change ) {
@@ -1516,7 +1519,7 @@ class Manual_Synchronization extends Stepped_Job {
 					foreach ( $product->get_children() as $child_id ) {
 
 						$child = wc_get_product( $child_id );
-						if ( ! $child instanceof \WC_Product || ! $child->get_manage_stock() ) {
+						if ( ! $child instanceof \WC_Product ) {
 							continue;
 						}
 
@@ -1532,8 +1535,11 @@ class Manual_Synchronization extends Stepped_Job {
 						}
 					}
 				} else {
-					// Simple product: try SKU-based lookup if unmapped but synced (e.g. mapping lost after timeout).
-					if ( ! $square_variation_id && $product->get_sku() && $product->get_manage_stock() && $sku_lookups_this_step < self::MAX_SKU_LOOKUPS_PER_PUSH_STEP ) {
+					// Simple product: try SKU-based lookup if unmapped but synced (e.g. mapping lost
+					// after timeout). Not gated on manage_stock: the push matrix decides what an
+					// unmanaged product pushes (an explicit zero when out of stock), so it needs its
+					// mapping restored too.
+					if ( ! $square_variation_id && $product->get_sku() && $sku_lookups_this_step < self::MAX_SKU_LOOKUPS_PER_PUSH_STEP ) {
 						++$sku_lookups_this_step;
 						$square_variation_id = Product::get_square_variation_id_by_sku( $product->get_sku(), $product_id, true );
 					}
@@ -1542,7 +1548,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 						$inventory_change = Product::get_inventory_change_physical_count_type( $product );
 
-						if ( $inventory_change && $product->get_manage_stock() ) {
+						if ( $inventory_change ) {
 							$product_inventory_changes[] = $inventory_change;
 						}
 					}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1971,7 +1971,6 @@ class Manual_Synchronization extends Stepped_Job {
 			// remove IDs that have already been processed
 			$square_variation_ids = array_diff( $square_variation_ids, $processed_ids );
 
-
 			if ( empty( $square_variation_ids ) ) {
 
 				$this->complete_step( 'pull_inventory' );

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1972,8 +1972,9 @@ class Manual_Synchronization extends Stepped_Job {
 		$catalog_objects_inventory_stats = array();
 
 		foreach ( $response_counts as $count ) {
-			// If catalog stats array already contains the catalog object marked as IN_STOCK, then continue.
-			if ( isset( $catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] ) && $catalog_objects_inventory_stats[ $count->getCatalogObjectId() ]['IN_STOCK'] ) {
+			// Only explicit IN_STOCK counts are usable data; other states are movements or
+			// purchase-order stages, and coercing them to zero wiped stock (SQUARE-7, SQUARE-145).
+			if ( 'IN_STOCK' !== $count->getState() ) {
 				continue;
 				// Else if the catalog object is IN_STOCK, then mark IN_STOCK as true and set the quantity for later use.
 			} elseif ( 'IN_STOCK' === $count->getState() ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2020,7 +2020,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 			$verified_zero_ids = array();
 		} else {
-			$this->clear_unverified_zero_count_attempts();
+			$this->clear_unverified_zero_count_attempts( 'pull_inventory' );
 		}
 
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2019,6 +2019,10 @@ class Manual_Synchronization extends Stepped_Job {
 			}
 
 			$verified_zero_ids = array();
+
+			// Hand the unverified objects to the shared retry list so a later poll re-checks them by
+			// id: without this their zeros would only be revisited if Square touched them again.
+			Helper::remember_unverified_zero_counts( $zero_object_ids );
 		} else {
 			$this->clear_unverified_zero_count_attempts( 'pull_inventory' );
 		}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2003,17 +2003,24 @@ class Manual_Synchronization extends Stepped_Job {
 		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 		if ( null === $verified_zero_ids ) {
-			// Verification unavailable: fail this step like any other API failure so the batch is
-			// retried; the processed marker must not advance past an unverified zero or a genuine
-			// sellout would be skipped forever. The queue attribute was already reduced by the
-			// batch slice above and these ids were never marked processed, so put them back or the
-			// retry would skip the whole batch.
-			$this->set_attr(
-				'pull_inventory_variation_ids',
-				array_values( array_unique( array_merge( (array) $this->get_attr( 'pull_inventory_variation_ids', array() ), $catalog_object_ids ) ) )
-			);
 
-			throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next run.' );
+			// Verification unavailable. Return WITHOUT marking anything processed so the step runs
+			// again; throwing here would fail the whole sync for one transient API error. The queue
+			// attribute was already reduced by the batch slice above and these ids were never
+			// marked processed, so put them back or the retry would skip the whole batch.
+			if ( $this->should_retry_unverified_zero_counts( 'pull_inventory' ) ) {
+
+				$this->set_attr(
+					'pull_inventory_variation_ids',
+					array_values( array_unique( array_merge( (array) $this->get_attr( 'pull_inventory_variation_ids', array() ), $catalog_object_ids ) ) )
+				);
+
+				return;
+			}
+
+			$verified_zero_ids = array();
+		} else {
+			$this->clear_unverified_zero_count_attempts();
 		}
 
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1976,22 +1976,25 @@ class Manual_Synchronization extends Stepped_Job {
 			// purchase-order stages, and coercing them to zero wiped stock (SQUARE-7, SQUARE-145).
 			if ( 'IN_STOCK' !== $count->getState() ) {
 				continue;
-				// Else if the catalog object is IN_STOCK, then mark IN_STOCK as true and set the quantity for later use.
-			} elseif ( 'IN_STOCK' === $count->getState() ) {
-				$catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] = array(
-					'IN_STOCK' => true,
-					'quantity' => $count->getQuantity(),
-				);
-				// Else if the catalog object doesn't have an IN_STOCK status, then mark IN_STOCK as false and set the quantity as 0 for later use.
-			} else {
-				$catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] = array(
-					'IN_STOCK' => false,
-					'quantity' => 0,
-				);
 			}
+
+			$catalog_objects_inventory_stats[ $count->getCatalogObjectId() ] = array(
+				'IN_STOCK' => true,
+				'quantity' => $count->getQuantity(),
+			);
 		}
 
 		$catalog_objects_tracking_stats = Helper::get_catalog_objects_tracking_stats( $catalog_object_ids );
+
+		// Verify zero counts against Square's inventory change history: a never-counted item
+		// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written.
+		$zero_object_ids = array();
+		foreach ( $catalog_objects_inventory_stats as $object_id => $stats ) {
+			if ( 0.0 === (float) $stats['quantity'] ) {
+				$zero_object_ids[] = $object_id;
+			}
+		}
+		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {
 			$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
@@ -2005,23 +2008,33 @@ class Manual_Synchronization extends Stepped_Job {
 
 			if ( $product instanceof \WC_Product ) {
 
-				/* If catalog object is tracked and has a quantity > 0 set in Square. */
-				if ( $is_tracking_inventory && isset( $catalog_objects_inventory_stats[ $catalog_object_id ] ) ) {
-					$product->set_stock_quantity( (float) $catalog_objects_inventory_stats[ $catalog_object_id ]['quantity'] );
-					$product->set_manage_stock( true );
-
-					/* If the catalog object is tracked but the quantity in Square is set to 0. */
-				} elseif ( $is_tracking_inventory ) {
-					$product->set_stock_quantity( 0 );
-					$product->set_manage_stock( true );
-
-					/* If the catalog object is not tracked in Square at all. */
-				} else {
-					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
-					$product->set_manage_stock( false );
+				// Respect the per-product "Sync with Square" setting on the pull side as well.
+				if ( ! Product::is_synced_with_square( $product ) ) {
+					$in_progress['processed_variation_ids'][] = $catalog_object_id;
+					continue;
 				}
 
-				$product->save();
+				if ( $is_tracking_inventory && isset( $catalog_objects_inventory_stats[ $catalog_object_id ] ) ) {
+
+					$changed = Helper::apply_square_inventory_count(
+						$product,
+						(float) $catalog_objects_inventory_stats[ $catalog_object_id ]['quantity'],
+						(bool) $sold_out,
+						in_array( $catalog_object_id, $verified_zero_ids, true )
+					);
+
+					if ( $changed ) {
+						$product->save();
+					}
+				} elseif ( ! $is_tracking_inventory ) {
+
+					// Not tracked in Square: reflect availability only; manage_stock is merchant
+					// intent and is not changed here.
+					$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+					$product->save();
+				}
+				// Tracked in Square but no IN_STOCK count returned: "no information", never a
+				// zero (SQUARE-145). The product is left untouched.
 
 				$in_progress['processed_variation_ids'][] = $catalog_object_id;
 			} else {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1994,37 +1994,21 @@ class Manual_Synchronization extends Stepped_Job {
 
 		// Verify zero counts against Square's inventory change history: a never-counted item
 		// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written.
-		$zero_object_ids = array();
-		foreach ( $catalog_objects_inventory_stats as $object_id => $stats ) {
-			if ( 0.0 === (float) $stats['quantity'] ) {
-				$zero_object_ids[] = $object_id;
-			}
-		}
-		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+		$zero_object_ids   = Helper::zero_count_object_ids( $catalog_objects_inventory_stats, 'quantity' );
+		$verified_zero_ids = $this->resolve_zero_count_verification( 'pull_inventory', $zero_object_ids );
 
 		if ( null === $verified_zero_ids ) {
 
-			// Verification unavailable. Return WITHOUT marking anything processed so the step runs
-			// again; throwing here would fail the whole sync for one transient API error. The queue
-			// attribute was already reduced by the batch slice above and these ids were never
+			// Verification unavailable and retries remain. Return WITHOUT marking anything processed
+			// so the step runs again; throwing would fail the whole sync for one transient error. The
+			// queue attribute was already reduced by the batch slice above and these ids were never
 			// marked processed, so put them back or the retry would skip the whole batch.
-			if ( $this->should_retry_unverified_zero_counts( 'pull_inventory' ) ) {
+			$this->set_attr(
+				'pull_inventory_variation_ids',
+				array_values( array_unique( array_merge( (array) $this->get_attr( 'pull_inventory_variation_ids', array() ), $catalog_object_ids ) ) )
+			);
 
-				$this->set_attr(
-					'pull_inventory_variation_ids',
-					array_values( array_unique( array_merge( (array) $this->get_attr( 'pull_inventory_variation_ids', array() ), $catalog_object_ids ) ) )
-				);
-
-				return;
-			}
-
-			$verified_zero_ids = array();
-
-			// Hand the unverified objects to the shared retry list so a later poll re-checks them by
-			// id: without this their zeros would only be revisited if Square touched them again.
-			Helper::remember_unverified_zero_counts( $zero_object_ids );
-		} else {
-			$this->clear_unverified_zero_count_attempts( 'pull_inventory' );
+			return;
 		}
 
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2165,7 +2165,10 @@ class Manual_Synchronization extends Stepped_Job {
 				// only handle product inventory if enabled
 				if ( wc_square()->get_settings_handler()->is_inventory_sync_enabled() ) {
 					$next_steps[] = 'push_inventory';
-					$next_steps[] = 'pull_inventory';
+					// pull_inventory is intentionally NOT queued when WooCommerce is the system of
+					// record: it only re-read the counts this same job just pushed, and Square's
+					// eventual consistency meant a not-yet-propagated count could come back as 0
+					// and overwrite the stock pushed moments earlier (SQUARE-145).
 				}
 			}
 		} elseif ( $this->is_system_of_record_square() ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1576,9 +1576,11 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( ! empty( $inventory_changes ) ) {
 
 			$inventory_changes = array_merge( ...$inventory_changes );
-			$this->remember_pushed_inventory_objects( $inventory_changes );
 			$idempotency_key   = wc_square()->get_idempotency_key( md5( serialize( $inventory_changes ) ) . '_change_inventory' );
 			$result            = wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_changes );
+
+			// Recorded after the push so pull_inventory() can skip reading these counts straight back.
+			$this->remember_pushed_inventory_objects( $inventory_changes );
 		}
 
 		$this->set_attr( 'inventory_push_product_ids', $product_ids );

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2000,7 +2000,9 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( null === $verified_zero_ids ) {
 
 			// Verification unavailable and retries remain. Return WITHOUT marking anything processed
-			// so the step runs again; throwing would fail the whole sync for one transient error. The
+			// so the step runs again; throwing would fail the whole sync for one transient error. Once
+			// the retries are spent the step proceeds writing no zeros and records an alert, and the
+			// interval poll picks those objects up again the next time Square reports a change. The
 			// queue attribute was already reduced by the batch slice above and these ids were never
 			// marked processed, so put them back or the retry would skip the whole batch.
 			$this->set_attr(

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2002,6 +2002,20 @@ class Manual_Synchronization extends Stepped_Job {
 		}
 		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
+		if ( null === $verified_zero_ids ) {
+			// Verification unavailable: fail this step like any other API failure so the batch is
+			// retried; the processed marker must not advance past an unverified zero or a genuine
+			// sellout would be skipped forever. The queue attribute was already reduced by the
+			// batch slice above and these ids were never marked processed, so put them back or the
+			// retry would skip the whole batch.
+			$this->set_attr(
+				'pull_inventory_variation_ids',
+				array_values( array_unique( array_merge( (array) $this->get_attr( 'pull_inventory_variation_ids', array() ), $catalog_object_ids ) ) )
+			);
+
+			throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next run.' );
+		}
+
 		foreach ( $catalog_objects_tracking_stats as $catalog_object_id => $inventory_data ) {
 			$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 			$sold_out              = $inventory_data['sold_out'] ?? false;

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1405,6 +1405,8 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$all_changes = array_merge( ...array_values( $inventory_changes ) );
 
+		$this->remember_pushed_inventory_objects( $all_changes );
+
 		// Chunk by the batch limit in case the set of products has many variations.
 		$chunks = array_chunk( $all_changes, self::BATCH_CHANGE_INVENTORY_LIMIT );
 
@@ -1574,6 +1576,7 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( ! empty( $inventory_changes ) ) {
 
 			$inventory_changes = array_merge( ...$inventory_changes );
+			$this->remember_pushed_inventory_objects( $inventory_changes );
 			$idempotency_key   = wc_square()->get_idempotency_key( md5( serialize( $inventory_changes ) ) . '_change_inventory' );
 			$result            = wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_changes );
 		}
@@ -1887,6 +1890,45 @@ class Manual_Synchronization extends Stepped_Job {
 
 
 	/**
+	 * Records the catalog objects whose inventory counts this job has pushed to Square.
+	 *
+	 * Used by pull_inventory() to avoid reading a count straight back after writing it. Square's
+	 * inventory is eventually consistent, so the read can still answer with the pre-push value, and
+	 * for an item that had never been counted it answers zero, which would undo the push.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Square\Models\InventoryChange[] $inventory_changes changes that were pushed
+	 */
+	protected function remember_pushed_inventory_objects( array $inventory_changes ) {
+
+		$object_ids = array();
+
+		foreach ( $inventory_changes as $change ) {
+
+			if ( ! $change->getPhysicalCount() ) {
+				continue;
+			}
+
+			$object_id = $change->getPhysicalCount()->getCatalogObjectId();
+
+			if ( $object_id ) {
+				$object_ids[] = $object_id;
+			}
+		}
+
+		if ( ! $object_ids ) {
+			return;
+		}
+
+		$this->set_attr(
+			'pushed_inventory_variation_ids',
+			array_values( array_unique( array_merge( (array) $this->get_attr( 'pushed_inventory_variation_ids', array() ), $object_ids ) ) )
+		);
+	}
+
+
+	/**
 	 * Pulls the latest inventory counts for the variation IDs in `pull_inventory_variation_ids`.
 	 *
 	 * @since 2.0.2
@@ -1922,6 +1964,27 @@ class Manual_Synchronization extends Stepped_Job {
 
 			// remove IDs that have already been processed
 			$square_variation_ids = array_diff( $square_variation_ids, $processed_ids );
+
+			// Never read back a count this same job pushed. Square's inventory is eventually
+			// consistent, so a freshly pushed count can still answer with the previous value, or with
+			// zero for an item that had none before, and writing that back would undo the push. Only
+			// objects this job pushed are skipped; everything else, which is every product that
+			// already existed in Square, is still pulled.
+			$pushed_ids = (array) $this->get_attr( 'pushed_inventory_variation_ids', array() );
+
+			if ( $pushed_ids ) {
+				$skipped              = array_intersect( $square_variation_ids, $pushed_ids );
+				$square_variation_ids = array_values( array_diff( $square_variation_ids, $pushed_ids ) );
+
+				if ( $skipped ) {
+					$this->set_attr(
+						'processed_square_variation_ids',
+						array_values( array_unique( array_merge( $processed_ids, $skipped ) ) )
+					);
+
+					wc_square()->log( sprintf( 'Skipped pulling inventory for %d catalog object(s) this job just pushed.', count( $skipped ) ) );
+				}
+			}
 
 			if ( empty( $square_variation_ids ) ) {
 
@@ -2182,10 +2245,18 @@ class Manual_Synchronization extends Stepped_Job {
 				// only handle product inventory if enabled
 				if ( wc_square()->get_settings_handler()->is_inventory_sync_enabled() ) {
 					$next_steps[] = 'push_inventory';
-					// pull_inventory is intentionally NOT queued when WooCommerce is the system of
-					// record: it only re-read the counts this same job just pushed, and Square's
-					// eventual consistency meant a not-yet-propagated count could come back as 0
-					// and overwrite the stock pushed moments earlier (SQUARE-145).
+
+					// Inventory is always fetched from Square as well, so that sales made on other
+					// channels are reflected, and for a product that already exists in Square this
+					// pull is the only thing that syncs its inventory during a manual sync.
+					//
+					// What it must NOT do is read back the counts this same job just pushed: Square's
+					// inventory is eventually consistent, so a count that has not propagated yet
+					// comes back as zero and would overwrite the stock pushed moments earlier
+					// (SQUARE-145). Those objects are excluded by id in pull_inventory() instead of
+					// dropping the step, which would leave existing products without an inventory
+					// sync at all.
+					$next_steps[] = 'pull_inventory';
 				}
 			}
 		} elseif ( $this->is_system_of_record_square() ) {

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -318,6 +318,7 @@ class Product_Import extends Stepped_Job {
 		if ( null === $verified_zero_ids ) {
 			// Verification unavailable and retries remain: return WITHOUT advancing the import cursor
 			// so the step runs again; throwing would fail the whole import for one transient error.
+			// Once the retries are spent the import proceeds writing no zeros and records an alert.
 			return;
 		}
 

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -354,9 +354,15 @@ class Product_Import extends Stepped_Job {
 						}
 					} elseif ( ! $is_tracking_inventory ) {
 
-						// Not tracked in Square: reflect availability only; manage_stock is
-						// merchant intent and is not changed here.
+						// Not tracked in Square: reflect availability. Stock management follows only
+						// when Square owns the setting; under WooCommerce SOR it is merchant intent
+						// and is left alone, so a Square side toggle cannot invert the system of
+						// record.
 						$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
+
+						if ( wc_square()->get_settings_handler()->is_system_of_record_square() ) {
+							$product->set_manage_stock( false );
+						}
 					} else {
 
 						// Tracked but no IN_STOCK count returned: "no information", never a zero.

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -309,6 +309,17 @@ class Product_Import extends Stepped_Job {
 			$inventory_hash[ $inventory_count->getCatalogObjectId() ] = $inventory_count->getQuantity();
 		}
 
+		// Verify zero counts against Square's inventory change history: a never-counted item
+		// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written
+		// (SQUARE-145).
+		$zero_object_ids = array();
+		foreach ( $inventory_hash as $object_id => $object_quantity ) {
+			if ( 0.0 === (float) $object_quantity ) {
+				$zero_object_ids[] = $object_id;
+			}
+		}
+		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+
 		foreach ( $objects as $catalog_object ) {
 
 			// all inventory should be tied to a variation, but check here just in case
@@ -317,24 +328,38 @@ class Product_Import extends Stepped_Job {
 				$product = Product::get_product_by_square_variation_id( $catalog_object->getId() );
 
 				if ( $product && $product instanceof \WC_Product ) {
+
+					// Freshly imported products are already marked synced by the import step;
+					// this only skips products whose "Sync with Square" was unticked or unlinked,
+					// consistent with the interval and manual pull gates (SQUARE-359).
+					if ( ! Product::is_synced_with_square( $product ) ) {
+						continue;
+					}
 					$inventory_data        = $catalog_objects_hash[ $catalog_object->getId() ] ?? array();
 					$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 					$sold_out              = $inventory_data['sold_out'] ?? false;
 
-					/* If catalog object is tracked and has a quantity > 0 set in Square. */
 					if ( $is_tracking_inventory && isset( $inventory_hash[ $catalog_object->getId() ] ) ) {
-						$product->set_stock_quantity( (float) $inventory_hash[ $catalog_object->getId() ] );
-						$product->set_manage_stock( true );
 
-						/* If the catalog object is tracked but the quantity in Square is set to 0. */
-					} elseif ( $is_tracking_inventory ) {
-						$product->set_stock_quantity( 0 );
-						$product->set_manage_stock( true );
+						$changed = Helper::apply_square_inventory_count(
+							$product,
+							(float) $inventory_hash[ $catalog_object->getId() ],
+							(bool) $sold_out,
+							in_array( $catalog_object->getId(), $verified_zero_ids, true )
+						);
 
-						/* If the catalog object is not tracked in Square at all. */
-					} else {
+						if ( ! $changed ) {
+							continue;
+						}
+					} elseif ( ! $is_tracking_inventory ) {
+
+						// Not tracked in Square: reflect availability only; manage_stock is
+						// merchant intent and is not changed here.
 						$product->set_stock_status( $sold_out ? 'outofstock' : 'instock' );
-						$product->set_manage_stock( false );
+					} else {
+
+						// Tracked but no IN_STOCK count returned: "no information", never a zero.
+						continue;
 					}
 
 					$product->save();

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -330,7 +330,7 @@ class Product_Import extends Stepped_Job {
 
 			$verified_zero_ids = array();
 		} else {
-			$this->clear_unverified_zero_count_attempts();
+			$this->clear_unverified_zero_count_attempts( 'import_inventory' );
 		}
 
 		foreach ( $objects as $catalog_object ) {

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -320,6 +320,12 @@ class Product_Import extends Stepped_Job {
 		}
 		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
+		if ( null === $verified_zero_ids ) {
+			// Verification unavailable: fail this step like any other API failure so the cursor
+			// does not advance past an unverified zero.
+			throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next run.' );
+		}
+
 		foreach ( $objects as $catalog_object ) {
 
 			// all inventory should be tied to a variation, but check here just in case

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -329,6 +329,10 @@ class Product_Import extends Stepped_Job {
 			}
 
 			$verified_zero_ids = array();
+
+			// Hand the unverified objects to the shared retry list so a later poll re-checks them by
+			// id rather than leaving them until Square touches them again.
+			Helper::remember_unverified_zero_counts( $zero_object_ids );
 		} else {
 			$this->clear_unverified_zero_count_attempts( 'import_inventory' );
 		}

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -312,29 +312,13 @@ class Product_Import extends Stepped_Job {
 		// Verify zero counts against Square's inventory change history: a never-counted item
 		// reports IN_STOCK 0 exactly like a real sellout, and only real zeros may be written
 		// (SQUARE-145).
-		$zero_object_ids = array();
-		foreach ( $inventory_hash as $object_id => $object_quantity ) {
-			if ( 0.0 === (float) $object_quantity ) {
-				$zero_object_ids[] = $object_id;
-			}
-		}
-		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+		$zero_object_ids   = Helper::zero_count_object_ids( $inventory_hash );
+		$verified_zero_ids = $this->resolve_zero_count_verification( 'import_inventory', $zero_object_ids );
 
 		if ( null === $verified_zero_ids ) {
-
-			// Verification unavailable. Return WITHOUT advancing the import cursor so the step runs
-			// again; throwing here would fail the whole import for one transient API error.
-			if ( $this->should_retry_unverified_zero_counts( 'import_inventory' ) ) {
-				return;
-			}
-
-			$verified_zero_ids = array();
-
-			// Hand the unverified objects to the shared retry list so a later poll re-checks them by
-			// id rather than leaving them until Square touches them again.
-			Helper::remember_unverified_zero_counts( $zero_object_ids );
-		} else {
-			$this->clear_unverified_zero_count_attempts( 'import_inventory' );
+			// Verification unavailable and retries remain: return WITHOUT advancing the import cursor
+			// so the step runs again; throwing would fail the whole import for one transient error.
+			return;
 		}
 
 		foreach ( $objects as $catalog_object ) {

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -342,12 +342,11 @@ class Product_Import extends Stepped_Job {
 
 				if ( $product && $product instanceof \WC_Product ) {
 
-					// Freshly imported products are already marked synced by the import step;
-					// this only skips products whose "Sync with Square" was unticked or unlinked,
-					// consistent with the interval and manual pull gates (SQUARE-359).
-					if ( ! Product::is_synced_with_square( $product ) ) {
-						continue;
-					}
+					// No "Sync with Square" gate here on purpose: an import is started by the
+					// merchant, so it belongs with the explicit fetch action rather than with the
+					// automatic pulls SQUARE-359 gates. Products matched and updated during an
+					// import also never receive the synced flag (it is only set for newly imported
+					// products), so gating here would silently skip their inventory.
 					$inventory_data        = $catalog_objects_hash[ $catalog_object->getId() ] ?? array();
 					$is_tracking_inventory = $inventory_data['track_inventory'] ?? false;
 					$sold_out              = $inventory_data['sold_out'] ?? false;

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -321,9 +321,16 @@ class Product_Import extends Stepped_Job {
 		$verified_zero_ids = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 		if ( null === $verified_zero_ids ) {
-			// Verification unavailable: fail this step like any other API failure so the cursor
-			// does not advance past an unverified zero.
-			throw new \Exception( 'Could not verify zero inventory counts against Square history; stock left unchanged until the next run.' );
+
+			// Verification unavailable. Return WITHOUT advancing the import cursor so the step runs
+			// again; throwing here would fail the whole import for one transient API error.
+			if ( $this->should_retry_unverified_zero_counts( 'import_inventory' ) ) {
+				return;
+			}
+
+			$verified_zero_ids = array();
+		} else {
+			$this->clear_unverified_zero_count_attempts();
 		}
 
 		foreach ( $objects as $catalog_object ) {

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -35,6 +35,10 @@ defined( 'ABSPATH' ) || exit;
 abstract class Stepped_Job extends Job {
 
 
+	/** @var int attempts a step makes to verify zero counts before it proceeds without them */
+	const MAX_ZERO_VERIFICATION_ATTEMPTS = 3;
+
+
 	/**
 	 * Executes the next step of this job.
 	 *
@@ -53,6 +57,61 @@ abstract class Stepped_Job extends Job {
 		$this->do_next_step();
 
 		return $this->job;
+	}
+
+
+	/**
+	 * Decides how a step should react when Square's inventory history could not be read.
+	 *
+	 * A zero count cannot be classified as a real sellout or as a never counted item without that
+	 * history, and writing it blind is the behavior SQUARE-145 fixed. The step therefore holds its
+	 * progress and retries on later cycles. Holding forever would keep a job alive without ever
+	 * finishing, so after a bounded number of attempts the step proceeds with no zero verified,
+	 * which skips only the zero writes, and records an alert so the outcome is never silent.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $step_name step name for the log and record messages
+	 * @return bool true when the caller should stop and retry later, false when it should proceed
+	 */
+	protected function should_retry_unverified_zero_counts( $step_name ) {
+
+		$attempts = (int) $this->get_attr( 'zero_verification_attempts', 0 );
+
+		if ( $attempts < self::MAX_ZERO_VERIFICATION_ATTEMPTS ) {
+
+			$this->set_attr( 'zero_verification_attempts', $attempts + 1 );
+
+			wc_square()->log( sprintf( 'Could not verify zero inventory counts during %1$s; holding progress and retrying (attempt %2$d).', $step_name, $attempts + 1 ) );
+
+			return true;
+		}
+
+		$this->set_attr( 'zero_verification_attempts', 0 );
+
+		Records::set_record(
+			array(
+				'type'    => 'alert',
+				'message' => esc_html__( 'Square could not confirm which products are genuinely sold out, so their stock was left unchanged and the sync continued. Stock will be updated on a later sync.', 'woocommerce-square' ),
+			)
+		);
+
+		wc_square()->log( sprintf( 'Could not verify zero inventory counts during %s after several attempts; continuing without writing any zero quantity.', $step_name ) );
+
+		return false;
+	}
+
+
+	/**
+	 * Clears the unverified zero count retry counter after a successful verification.
+	 *
+	 * @since x.x.x
+	 */
+	protected function clear_unverified_zero_count_attempts() {
+
+		if ( $this->get_attr( 'zero_verification_attempts', 0 ) ) {
+			$this->set_attr( 'zero_verification_attempts', 0 );
+		}
 	}
 
 
@@ -331,5 +390,4 @@ abstract class Stepped_Job extends Job {
 
 		return $update_data;
 	}
-
 }

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -93,11 +93,13 @@ abstract class Stepped_Job extends Job {
 
 		$this->set_attr( $attr, 0 );
 
-		// One alert per job: a long outage can exhaust the attempts once per batch, and the record
-		// list is capped, so repeating the same message would push other records out.
-		if ( ! $this->get_attr( 'zero_verification_alert_recorded', false ) ) {
+		// One alert per job AND at most one per window across jobs: interval polling creates a fresh
+		// job every cycle, so a job attribute alone would still add a record on every poll during a
+		// sustained outage and push other records out of the capped list.
+		if ( ! $this->get_attr( 'zero_verification_alert_recorded', false ) && ! get_transient( 'wc_square_zero_verification_alerted' ) ) {
 
 			$this->set_attr( 'zero_verification_alert_recorded', true );
+			set_transient( 'wc_square_zero_verification_alerted', 1, 6 * HOUR_IN_SECONDS );
 
 			Records::set_record(
 				array(

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -61,6 +61,48 @@ abstract class Stepped_Job extends Job {
 
 
 	/**
+	 * Verifies which zero counts are real, applying this class's shared retry policy when Square
+	 * cannot be asked.
+	 *
+	 * Wraps the three parts every step repeated: verify the zeros, hold and retry a bounded number of
+	 * times when verification is unavailable, then proceed with nothing verified and hand the ids to
+	 * the retry list. Progress markers stay with the caller, because each step holds something
+	 * different (a cursor, a watermark, a queue attribute) and flattening that in here would silently
+	 * drop work.
+	 *
+	 * The return has three meanings:
+	 * - ids: verified, so write zeros for these ids only.
+	 * - empty array: nothing could be verified and the attempts are spent, so write no zeros and carry
+	 *   on; the ids are already on the retry list.
+	 * - null: verification is unavailable and the caller must hold its own progress and return so the
+	 *   step runs again.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $step_name step name used for the attempt counters and messages
+	 * @param string[] $zero_object_ids catalog object ids reporting a zero count
+	 * @return string[]|null verified ids, or null when the caller should hold and retry
+	 */
+	protected function resolve_zero_count_verification( $step_name, array $zero_object_ids ) {
+
+		$verified = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
+
+		if ( null !== $verified ) {
+			$this->clear_unverified_zero_count_attempts( $step_name );
+			return $verified;
+		}
+
+		if ( $this->should_retry_unverified_zero_counts( $step_name ) ) {
+			return null;
+		}
+
+		Helper::remember_unverified_zero_counts( $zero_object_ids );
+
+		return array();
+	}
+
+
+	/**
 	 * Decides how a step should react when Square's inventory history could not be read.
 	 *
 	 * A zero count cannot be classified as a real sellout or as a never counted item without that

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -65,9 +65,12 @@ abstract class Stepped_Job extends Job {
 	 *
 	 * A zero count cannot be classified as a real sellout or as a never counted item without that
 	 * history, and writing it blind is the behavior SQUARE-145 fixed. The step therefore holds its
-	 * progress and retries on later cycles. Holding forever would keep a job alive without ever
-	 * finishing, so after a bounded number of attempts the step proceeds with no zero verified,
-	 * which skips only the zero writes, and records an alert so the outcome is never silent.
+	 * progress and is run again by the job loop. Those retries follow the job's own loopback timing,
+	 * so they are close together rather than spread over cycles: they cover a brief blip, not a long
+	 * outage. Holding forever would keep a job alive without ever finishing, so after a bounded
+	 * number of attempts the step proceeds with no zero verified, which skips only the zero writes,
+	 * and records an alert so the outcome is never silent. Steps that own a watermark should also
+	 * leave it alone on that path so the same window is read again later.
 	 *
 	 * @since x.x.x
 	 *
@@ -76,27 +79,28 @@ abstract class Stepped_Job extends Job {
 	 */
 	protected function should_retry_unverified_zero_counts( $step_name ) {
 
-		$attempts = (int) $this->get_attr( 'zero_verification_attempts', 0 );
+		$attr     = 'zero_verification_attempts_' . $step_name;
+		$attempts = (int) $this->get_attr( $attr, 0 );
 
 		if ( $attempts < self::MAX_ZERO_VERIFICATION_ATTEMPTS ) {
 
-			$this->set_attr( 'zero_verification_attempts', $attempts + 1 );
+			$this->set_attr( $attr, $attempts + 1 );
 
-			wc_square()->log( sprintf( 'Could not verify zero inventory counts during %1$s; holding progress and retrying (attempt %2$d).', $step_name, $attempts + 1 ) );
+			wc_square()->log( sprintf( 'Could not verify zero inventory counts during %1$s; holding this step and running it again (attempt %2$d of %3$d).', $step_name, $attempts + 1, self::MAX_ZERO_VERIFICATION_ATTEMPTS ) );
 
 			return true;
 		}
 
-		$this->set_attr( 'zero_verification_attempts', 0 );
+		$this->set_attr( $attr, 0 );
 
 		Records::set_record(
 			array(
 				'type'    => 'alert',
-				'message' => esc_html__( 'Square could not confirm which products are genuinely sold out, so their stock was left unchanged and the sync continued. Stock will be updated on a later sync.', 'woocommerce-square' ),
+				'message' => esc_html__( 'Square could not confirm which products are genuinely sold out, so their stock was left unchanged and the sync continued. Run the sync again once Square is responding normally.', 'woocommerce-square' ),
 			)
 		);
 
-		wc_square()->log( sprintf( 'Could not verify zero inventory counts during %s after several attempts; continuing without writing any zero quantity.', $step_name ) );
+		wc_square()->log( sprintf( 'Could not verify zero inventory counts during %s after %d attempts; continuing without writing any zero quantity.', $step_name, self::MAX_ZERO_VERIFICATION_ATTEMPTS ) );
 
 		return false;
 	}
@@ -107,10 +111,12 @@ abstract class Stepped_Job extends Job {
 	 *
 	 * @since x.x.x
 	 */
-	protected function clear_unverified_zero_count_attempts() {
+	protected function clear_unverified_zero_count_attempts( $step_name ) {
 
-		if ( $this->get_attr( 'zero_verification_attempts', 0 ) ) {
-			$this->set_attr( 'zero_verification_attempts', 0 );
+		$attr = 'zero_verification_attempts_' . $step_name;
+
+		if ( $this->get_attr( $attr, 0 ) ) {
+			$this->set_attr( $attr, 0 );
 		}
 	}
 

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -86,7 +86,7 @@ abstract class Stepped_Job extends Job {
 		$verified = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 		if ( null !== $verified ) {
-			$this->set_attr( 'zero_verification_exhausted_' . $step_name, false, false );
+			$this->set_attr( 'zero_verification_exhausted_' . $step_name, false );
 			$this->clear_unverified_zero_count_attempts( $step_name );
 			return $verified;
 		}
@@ -98,7 +98,10 @@ abstract class Stepped_Job extends Job {
 		// Attempts spent. Nothing is verified, so no zero may be written, and the caller is told so it
 		// can leave any watermark alone: re-reading the same window later is what stops a genuine
 		// sellout from being skipped permanently.
-		$this->set_attr( 'zero_verification_exhausted_' . $step_name, true, false );
+		// Persisted immediately rather than relying on a later attribute write to flush it: the
+		// watermark guard reads this, and a step that returns before its next set_attr() would
+		// otherwise leave the flag only in memory.
+		$this->set_attr( 'zero_verification_exhausted_' . $step_name, true );
 
 		return array();
 	}

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -64,18 +64,16 @@ abstract class Stepped_Job extends Job {
 	 * Verifies which zero counts are real, applying this class's shared retry policy when Square
 	 * cannot be asked.
 	 *
-	 * Wraps the three parts every step repeated: verify the zeros, hold and retry a bounded number of
-	 * times when verification is unavailable, then proceed with nothing verified and hand the ids to
-	 * the retry list. Progress markers stay with the caller, because each step holds something
-	 * different (a cursor, a watermark, a queue attribute) and flattening that in here would silently
-	 * drop work.
+	 * Wraps the two parts every step repeated: verify the zeros, and hold and retry a bounded number
+	 * of times when verification is unavailable. Progress markers stay with the caller, because each
+	 * step holds something different (a cursor, a watermark, a queue attribute) and flattening that in
+	 * here would silently drop work.
 	 *
-	 * The return has three meanings:
-	 * - ids: verified, so write zeros for these ids only.
-	 * - empty array: nothing could be verified and the attempts are spent, so write no zeros and carry
-	 *   on; the ids are already on the retry list.
-	 * - null: verification is unavailable and the caller must hold its own progress and return so the
-	 *   step runs again.
+	 * The return says which zeros may be written, and null says the caller must hold its own progress
+	 * and return so the step runs again. An empty array is NOT a signal of failure: it also means the
+	 * question was asked successfully and none of those zeros is real. A caller that needs to know the
+	 * attempts ran out (to keep a watermark from advancing over a window it could not verify) must ask
+	 * zero_verification_exhausted() rather than infer it from an empty array.
 	 *
 	 * @since x.x.x
 	 *
@@ -88,6 +86,7 @@ abstract class Stepped_Job extends Job {
 		$verified = Helper::get_catalog_objects_with_inventory_history( $zero_object_ids );
 
 		if ( null !== $verified ) {
+			$this->set_attr( 'zero_verification_exhausted_' . $step_name, false, false );
 			$this->clear_unverified_zero_count_attempts( $step_name );
 			return $verified;
 		}
@@ -96,9 +95,30 @@ abstract class Stepped_Job extends Job {
 			return null;
 		}
 
-		Helper::remember_unverified_zero_counts( $zero_object_ids );
+		// Attempts spent. Nothing is verified, so no zero may be written, and the caller is told so it
+		// can leave any watermark alone: re-reading the same window later is what stops a genuine
+		// sellout from being skipped permanently.
+		$this->set_attr( 'zero_verification_exhausted_' . $step_name, true, false );
 
 		return array();
+	}
+
+
+	/**
+	 * Whether the last verification attempt for a step ran out of retries without an answer.
+	 *
+	 * Steps that advance a watermark must not move it over a window whose zero counts they could not
+	 * verify, or a genuine sellout in that window is skipped for good. An empty verified list cannot
+	 * answer this, since it also means "asked, and none of them were real".
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $step_name step name used for the attempt counters
+	 * @return bool
+	 */
+	protected function zero_verification_exhausted( $step_name ) {
+
+		return (bool) $this->get_attr( 'zero_verification_exhausted_' . $step_name, false );
 	}
 
 

--- a/includes/Sync/Stepped_Job.php
+++ b/includes/Sync/Stepped_Job.php
@@ -93,12 +93,19 @@ abstract class Stepped_Job extends Job {
 
 		$this->set_attr( $attr, 0 );
 
-		Records::set_record(
-			array(
-				'type'    => 'alert',
-				'message' => esc_html__( 'Square could not confirm which products are genuinely sold out, so their stock was left unchanged and the sync continued. Run the sync again once Square is responding normally.', 'woocommerce-square' ),
-			)
-		);
+		// One alert per job: a long outage can exhaust the attempts once per batch, and the record
+		// list is capped, so repeating the same message would push other records out.
+		if ( ! $this->get_attr( 'zero_verification_alert_recorded', false ) ) {
+
+			$this->set_attr( 'zero_verification_alert_recorded', true );
+
+			Records::set_record(
+				array(
+					'type'    => 'alert',
+					'message' => esc_html__( 'Square could not confirm which products are genuinely sold out, so their stock was left unchanged and the sync continued. Run the sync again once Square is responding normally.', 'woocommerce-square' ),
+				)
+			);
+		}
 
 		wc_square()->log( sprintf( 'Could not verify zero inventory counts during %s after %d attempts; continuing without writing any zero quantity.', $step_name, self::MAX_ZERO_VERIFICATION_ATTEMPTS ) );
 

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -415,9 +415,24 @@ jQuery( document ).ready( ( $ ) => {
 							syncInventory
 					);
 
-					// "Manage stock" stays editable. Square no longer switches it off during a sync, so
-					// this is how a merchant mirrors turning inventory tracking off in Square, and
-					// blocking the click would leave them no way to do it.
+					// "Manage stock" stays editable when WooCommerce owns stock: Square no longer
+					// switches it off during a sync, so this is how a merchant mirrors turning
+					// inventory tracking off in Square, and blocking the click would leave them no
+					// way to do it.
+					//
+					// Under Square as the system of record the sync does own the setting and mirrors
+					// Square's tracking flag on every pull, so an edit here would be reverted by the
+					// next sync with no explanation. Block it instead of allowing that.
+					//
+					// Interaction is blocked rather than the input disabled on purpose: a disabled
+					// checkbox posts nothing, so the next save of the product would switch stock
+					// management off entirely.
+					if ( wc_square_admin_products.is_square_sor ) {
+						$manageInput.on( 'mousedown keydown click', () => {
+							return false;
+						} );
+						$manageInput.css( { opacity: '0.5' } );
+					}
 
 					// disable stock status radios.
 					$stockStatusInput.css({ opacity: 0.5 });
@@ -496,7 +511,7 @@ jQuery( document ).ready( ( $ ) => {
 				$( '.sync-stock-from-square' ).remove();
 				$stockInput.prop( 'readonly', false );
 				$manageDesc.html( manageDescOriginal );
-				$manageInput.off( 'click' );
+				$manageInput.off( 'mousedown keydown click' );
 				$manageInput.css( { opacity: 1 } );
 				$manageInput.prop( 'checked', manageStockOriginal );
 				$stockStatusInput.css({ opacity: 1 });

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -415,10 +415,9 @@ jQuery( document ).ready( ( $ ) => {
 							syncInventory
 					);
 
-					$manageInput.on('click', () => {
-						return false;
-					});
-					$manageInput.css({ opacity: '0.5' });
+					// "Manage stock" stays editable. Square no longer switches it off during a sync, so
+					// this is how a merchant mirrors turning inventory tracking off in Square, and
+					// blocking the click would leave them no way to do it.
 
 					// disable stock status radios.
 					$stockStatusInput.css({ opacity: 0.5 });
@@ -528,10 +527,8 @@ jQuery( document ).ready( ( $ ) => {
 				if ( useSquare ) {
 					// disable stock management inputs
 					$variationStockInput.prop( 'readonly', true );
-					$variationManageInput.on('click', () => {
-						return false;
-					});
-					$variationManageInput.css( { opacity: '0.5' } );
+					// Editable for the same reason as simple products: mirroring a tracking off change
+					// made in Square is the merchant's own call.
 					$variationStockStatusField.css( { opacity: 0.5 } );
 					$variationStockStatusField.on('mousedown keydown change', () => { return false; });
 

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -542,8 +542,20 @@ jQuery( document ).ready( ( $ ) => {
 				if ( useSquare ) {
 					// disable stock management inputs
 					$variationStockInput.prop( 'readonly', true );
-					// Editable for the same reason as simple products: mirroring a tracking off change
-					// made in Square is the merchant's own call.
+
+					// Editable under WooCommerce SOR for the same reason as simple products:
+					// mirroring a tracking off change made in Square is the merchant's own call.
+					// Under Square SOR the pull mirrors Square's tracking flag onto this setting, so
+					// an edit here would be reverted by the next sync. Blocked rather than disabled,
+					// because a disabled checkbox posts nothing and the next save would switch stock
+					// management off.
+					if ( wc_square_admin_products.is_square_sor ) {
+						$variationManageInput.on( 'mousedown keydown click', () => {
+							return false;
+						} );
+						$variationManageInput.css( { opacity: '0.5' } );
+					}
+
 					$variationStockStatusField.css( { opacity: 0.5 } );
 					$variationStockStatusField.on('mousedown keydown change', () => { return false; });
 
@@ -631,7 +643,7 @@ jQuery( document ).ready( ( $ ) => {
 				} else {
 					// restore WooCommerce stock when user chooses to disable Sync with Square checkbox.
 					$variationStockInput.prop( 'readonly', false );
-					$variationManageInput.off( 'click' );
+					$variationManageInput.off( 'mousedown keydown click' );
 					$variationManageInput.css( { opacity: 1 } );
 					$variationManageInput.next( '.description' ).remove();
 					$variationStockStatusField.css( { opacity: 1 } );

--- a/tests/php/Unit/Sync/Fixtures/Scripted_History_Helper.php
+++ b/tests/php/Unit/Sync/Fixtures/Scripted_History_Helper.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Test double for the Square inventory change history lookup.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync\Fixtures;
+
+use WooCommerce\Square\Sync\Helper;
+
+/**
+ * Helper with a scripted page fetch, so the zero verification logic can be exercised without the
+ * Square API.
+ *
+ * Helper::get_catalog_objects_with_inventory_history() reaches the page fetch through static::, so
+ * this override is what runs.
+ */
+class Scripted_History_Helper extends Helper {
+
+	/**
+	 * Pages to return, in order. Each entry is a page array or null for a failed request.
+	 *
+	 * @var array
+	 */
+	public static $pages = array();
+
+	/**
+	 * The ids asked about, one entry per request.
+	 *
+	 * @var array
+	 */
+	public static $asked = array();
+
+	/**
+	 * Arms the double with a script and clears the recorded requests.
+	 *
+	 * @param array $pages pages to return, in order.
+	 */
+	public static function reset( array $pages ) {
+		self::$pages = $pages;
+		self::$asked = array();
+	}
+
+	/**
+	 * Builds a page naming the given catalog object ids.
+	 *
+	 * @param array $object_ids ids named by the page.
+	 * @param bool  $has_more   whether Square reports a further page.
+	 * @return array
+	 */
+	public static function page( array $object_ids, $has_more = false ) {
+		return array(
+			'object_ids' => $object_ids,
+			'cursor'     => $has_more ? 'next-page-cursor' : null,
+		);
+	}
+
+	/**
+	 * Returns the next scripted page instead of calling Square.
+	 *
+	 * @param array $catalog_object_ids ids being asked about.
+	 * @return array|null
+	 */
+	protected static function fetch_inventory_changes_page( array $catalog_object_ids ) {
+		self::$asked[] = array_values( $catalog_object_ids );
+		return array_shift( self::$pages );
+	}
+}

--- a/tests/php/Unit/Sync/Fixtures/Zero_Verification_Policy_Job.php
+++ b/tests/php/Unit/Sync/Fixtures/Zero_Verification_Policy_Job.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Concrete Stepped_Job used to exercise the zero verification retry policy.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync\Fixtures;
+
+use WooCommerce\Square\Sync\Stepped_Job;
+
+/**
+ * Stepped_Job is abstract and its verification policy is protected, so this double supplies the one
+ * abstract method and exposes the policy for assertions. Nothing else is overridden: the attempt
+ * counting, the alert and the persistence all run as they do in production.
+ */
+class Zero_Verification_Policy_Job extends Stepped_Job {
+
+	/**
+	 * No steps are needed for policy tests.
+	 */
+	protected function assign_next_steps() {}
+
+	/**
+	 * @param string $step_name step name.
+	 * @return bool
+	 */
+	public function policy_should_retry( $step_name ) {
+		return $this->should_retry_unverified_zero_counts( $step_name );
+	}
+
+	/**
+	 * @param string $step_name step name.
+	 * @return bool
+	 */
+	public function policy_exhausted( $step_name ) {
+		return $this->zero_verification_exhausted( $step_name );
+	}
+
+	/**
+	 * @param string   $step_name       step name.
+	 * @param string[] $zero_object_ids ids reporting a zero count.
+	 * @return array|null
+	 */
+	public function policy_resolve( $step_name, array $zero_object_ids ) {
+		return $this->resolve_zero_count_verification( $step_name, $zero_object_ids );
+	}
+
+	/**
+	 * @param string $attr  attribute name.
+	 * @param mixed  $value attribute value.
+	 */
+	public function policy_set_attr( $attr, $value ) {
+		$this->set_attr( $attr, $value );
+	}
+
+	/**
+	 * @param string $attr attribute name.
+	 * @return mixed
+	 */
+	public function policy_get_attr( $attr ) {
+		return $this->get_attr( $attr );
+	}
+}

--- a/tests/php/Unit/Sync/HelperInventoryVerificationTest.php
+++ b/tests/php/Unit/Sync/HelperInventoryVerificationTest.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Tests for the zero inventory count verification in WooCommerce\Square\Sync\Helper.
+ *
+ * Square reports IN_STOCK 0 both for an item that genuinely sold out and for an item nobody has ever
+ * counted, so a zero may only be written to WooCommerce when the inventory change history proves it
+ * real. These tests pin that discriminator down, including the states that caused regressions during
+ * review: a failed lookup must never read as "no history", and a response is only proof for the ids it
+ * actually names.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync;
+
+use WP_UnitTestCase;
+use WooCommerce\Square\Sync\Helper;
+use WooCommerce\Square\Tests\Unit\Sync\Fixtures\Scripted_History_Helper;
+
+require_once __DIR__ . '/Fixtures/Scripted_History_Helper.php';
+
+class HelperInventoryVerificationTest extends WP_UnitTestCase {
+
+	public function tearDown(): void {
+		Scripted_History_Helper::reset( array() );
+		parent::tearDown();
+	}
+
+	/** A zero count is collected from a plain id to quantity map. */
+	public function test_zero_count_object_ids_reads_a_flat_map() {
+		$zeros = Helper::zero_count_object_ids(
+			array(
+				'SOLD_OUT'   => 0,
+				'IN_STOCK'   => 7,
+				'ALSO_ZERO'  => '0.0',
+				'FRACTIONAL' => '0.5',
+			)
+		);
+
+		$this->assertSame( array( 'SOLD_OUT', 'ALSO_ZERO' ), $zeros );
+	}
+
+	/** The polling and manual sync paths hold counts as arrays, so the quantity key form is accepted. */
+	public function test_zero_count_object_ids_reads_a_stats_map() {
+		$zeros = Helper::zero_count_object_ids(
+			array(
+				'SOLD_OUT' => array( 'quantity' => 0 ),
+				'IN_STOCK' => array( 'quantity' => 3 ),
+				'NO_KEY'   => array( 'IN_STOCK' => true ),
+			),
+			'quantity'
+		);
+
+		$this->assertSame( array( 'SOLD_OUT' ), $zeros, 'An entry without the quantity key is not a zero.' );
+	}
+
+	/** Nothing to verify means no API calls at all. */
+	public function test_no_ids_makes_no_requests() {
+		Scripted_History_Helper::reset( array() );
+
+		$this->assertSame( array(), Scripted_History_Helper::get_catalog_objects_with_inventory_history( array() ) );
+		$this->assertSame( array(), Scripted_History_Helper::$asked );
+	}
+
+	/** One page with no further pages settles the whole batch: named ids are real, the rest are phantoms. */
+	public function test_single_page_settles_the_batch() {
+		Scripted_History_Helper::reset( array( Scripted_History_Helper::page( array( 'REAL_SELLOUT' ) ) ) );
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history(
+			array( 'REAL_SELLOUT', 'NEVER_COUNTED', 'ALSO_NEVER_COUNTED' )
+		);
+
+		$this->assertSame( array( 'REAL_SELLOUT' ), $verified );
+		$this->assertCount( 1, Scripted_History_Helper::$asked, 'A conclusive first page needs no follow up.' );
+	}
+
+	/** The unresolved ids are re-asked as one group, not one request each. */
+	public function test_unresolved_ids_are_re_asked_as_a_group() {
+		Scripted_History_Helper::reset(
+			array(
+				Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ),
+				Scripted_History_Helper::page( array(), false ),
+			)
+		);
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history(
+			array( 'BUSY_ITEM', 'QUIET_A', 'QUIET_B' )
+		);
+
+		$this->assertSame( array( 'BUSY_ITEM' ), $verified );
+		$this->assertCount( 2, Scripted_History_Helper::$asked );
+		$this->assertSame( array( 'QUIET_A', 'QUIET_B' ), Scripted_History_Helper::$asked[1] );
+	}
+
+	/** Each group pass narrows the set until the remainder is proven empty. */
+	public function test_group_passes_narrow_until_settled() {
+		Scripted_History_Helper::reset(
+			array(
+				Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ),
+				Scripted_History_Helper::page( array( 'SECOND_REAL' ), true ),
+				Scripted_History_Helper::page( array(), false ),
+			)
+		);
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history(
+			array( 'BUSY_ITEM', 'SECOND_REAL', 'PHANTOM' )
+		);
+
+		sort( $verified );
+		$this->assertSame( array( 'BUSY_ITEM', 'SECOND_REAL' ), $verified );
+		$this->assertSame( array( 'PHANTOM' ), Scripted_History_Helper::$asked[2], 'The last pass narrows to the remainder.' );
+	}
+
+	/** A group pass that names none of the remaining ids falls back to one request per id. */
+	public function test_a_stalled_group_pass_falls_back_to_one_request_per_id() {
+		Scripted_History_Helper::reset(
+			array(
+				Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ),
+				Scripted_History_Helper::page( array(), true ),
+				Scripted_History_Helper::page( array( 'HAS_HISTORY' ), false ),
+				Scripted_History_Helper::page( array(), false ),
+			)
+		);
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history(
+			array( 'BUSY_ITEM', 'HAS_HISTORY', 'PHANTOM' )
+		);
+
+		sort( $verified );
+		$this->assertSame( array( 'BUSY_ITEM', 'HAS_HISTORY' ), $verified );
+		$this->assertCount( 1, Scripted_History_Helper::$asked[2], 'The fallback asks about a single id.' );
+		$this->assertCount( 1, Scripted_History_Helper::$asked[3] );
+	}
+
+	/**
+	 * A response is proof only for the ids it names.
+	 *
+	 * Square drops the catalog object id filter when none of the supplied ids exists, answering with
+	 * unrelated history. Reading a non empty response as proof wrote a phantom zero for products whose
+	 * Square mapping had gone stale, which is the bug this ticket exists to fix.
+	 */
+	public function test_a_response_naming_other_objects_is_not_proof() {
+		Scripted_History_Helper::reset(
+			array(
+				Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ),
+				Scripted_History_Helper::page( array(), true ),
+				Scripted_History_Helper::page( array( 'SOMEONE_ELSE' ), true ),
+			)
+		);
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history(
+			array( 'BUSY_ITEM', 'STALE_MAPPING' )
+		);
+
+		$this->assertNotContains( 'STALE_MAPPING', $verified );
+	}
+
+	/** A failed lookup is null, which is distinct from a verified empty history. */
+	public function test_a_failure_returns_null_rather_than_an_empty_verification() {
+		foreach ( array(
+			'on the first page'   => array( null ),
+			'during a group pass' => array( Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ), null ),
+			'during the fallback' => array(
+				Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ),
+				Scripted_History_Helper::page( array(), true ),
+				null,
+			),
+		) as $label => $pages ) {
+			Scripted_History_Helper::reset( $pages );
+
+			$this->assertNull(
+				Scripted_History_Helper::get_catalog_objects_with_inventory_history( array( 'BUSY_ITEM', 'UNKNOWN' ) ),
+				"A failure {$label} must return null."
+			);
+		}
+	}
+
+	/** Group narrowing is capped, then the remainder is settled one id at a time. */
+	public function test_group_narrowing_is_capped() {
+		$pages = array( Scripted_History_Helper::page( array( 'BUSY_ITEM' ), true ) );
+		$ids   = array( 'BUSY_ITEM' );
+
+		for ( $i = 1; $i <= Helper::MAX_HISTORY_NARROWING_PASSES; $i++ ) {
+			$ids[]   = "RESOLVES_{$i}";
+			$pages[] = Scripted_History_Helper::page( array( "RESOLVES_{$i}" ), true );
+		}
+		$ids[]   = 'LEFTOVER';
+		$pages[] = Scripted_History_Helper::page( array(), false );
+
+		Scripted_History_Helper::reset( $pages );
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history( $ids );
+
+		$this->assertNotContains( 'LEFTOVER', $verified, 'The leftover id has no history.' );
+		$this->assertSame(
+			array( 'LEFTOVER' ),
+			end( Scripted_History_Helper::$asked ),
+			'After the cap the remainder is asked about one id at a time.'
+		);
+		$this->assertCount(
+			Helper::MAX_HISTORY_NARROWING_PASSES + 2,
+			Scripted_History_Helper::$asked,
+			'One first page, the capped group passes, then the per id fallback.'
+		);
+	}
+
+	/** Ids are chunked so a large set of zeros cannot exceed the API limit in one request. */
+	public function test_ids_are_chunked_at_one_hundred_per_request() {
+		$ids = array();
+		for ( $i = 1; $i <= 150; $i++ ) {
+			$ids[] = 'OBJECT_' . $i;
+		}
+
+		Scripted_History_Helper::reset(
+			array(
+				Scripted_History_Helper::page( array( 'OBJECT_1' ) ),
+				Scripted_History_Helper::page( array( 'OBJECT_101' ) ),
+			)
+		);
+
+		$verified = Scripted_History_Helper::get_catalog_objects_with_inventory_history( $ids );
+
+		sort( $verified );
+		$this->assertSame( array( 'OBJECT_1', 'OBJECT_101' ), $verified );
+		$this->assertCount( 2, Scripted_History_Helper::$asked );
+		$this->assertCount( 100, Scripted_History_Helper::$asked[0] );
+		$this->assertCount( 50, Scripted_History_Helper::$asked[1] );
+	}
+}

--- a/tests/php/Unit/Sync/HelperInventoryWritePolicyTest.php
+++ b/tests/php/Unit/Sync/HelperInventoryWritePolicyTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests for the stock write policy in WooCommerce\Square\Sync\Helper::apply_square_inventory_count().
+ *
+ * This is the decision that wiped a merchant's catalogue: what a Square count is allowed to change on
+ * a WooCommerce product. Every branch is pinned here, in particular the ones where the correct answer
+ * is to change nothing at all.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync;
+
+use WP_UnitTestCase;
+use WooCommerce\Square\Sync\Helper;
+
+class HelperInventoryWritePolicyTest extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( '\WC_Product_Simple' ) ) {
+			$this->markTestSkipped( 'WooCommerce is required for the stock write policy tests.' );
+		}
+	}
+
+	/**
+	 * Builds a saved simple product.
+	 *
+	 * @param bool     $manage_stock whether the product manages its own stock.
+	 * @param int|null $quantity     starting quantity, when managed.
+	 * @param string   $status       starting stock status.
+	 * @return \WC_Product_Simple
+	 */
+	private function make_product( $manage_stock, $quantity = null, $status = 'instock' ) {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'Write policy product' );
+		$product->set_regular_price( '10' );
+		$product->set_manage_stock( $manage_stock );
+
+		if ( null !== $quantity ) {
+			$product->set_stock_quantity( $quantity );
+		}
+
+		$product->set_stock_status( $status );
+		$product->save();
+
+		return $product;
+	}
+
+	/** A positive count is written, and turns stock management on. */
+	public function test_a_positive_count_is_written() {
+		$product = $this->make_product( true, 4 );
+
+		$this->assertTrue( Helper::apply_square_inventory_count( $product, 9, false, false ) );
+		$this->assertEquals( 9, $product->get_stock_quantity() );
+		$this->assertTrue( $product->get_manage_stock() );
+	}
+
+	/** A zero backed by inventory history is a real sellout, so it is written. */
+	public function test_a_verified_zero_is_written_to_a_managed_product() {
+		$product = $this->make_product( true, 12 );
+
+		$this->assertTrue( Helper::apply_square_inventory_count( $product, 0, true, true ) );
+		$this->assertEquals( 0, $product->get_stock_quantity() );
+	}
+
+	/**
+	 * The reported bug. An unverified zero comes from an item Square never counted, so the product is
+	 * left exactly as the merchant left it.
+	 */
+	public function test_an_unverified_zero_leaves_a_managed_product_untouched() {
+		$product = $this->make_product( true, 12 );
+
+		$this->assertFalse( Helper::apply_square_inventory_count( $product, 0, true, false ) );
+		$this->assertEquals( 12, $product->get_stock_quantity(), 'An unproven zero must not overwrite the quantity.' );
+		$this->assertTrue( $product->get_manage_stock(), 'An unproven zero must not switch stock management off.' );
+	}
+
+	/** A product that does not manage stock gets availability only, never a quantity. */
+	public function test_a_verified_zero_marks_an_unmanaged_product_out_of_stock() {
+		$product = $this->make_product( false );
+
+		$this->assertTrue( Helper::apply_square_inventory_count( $product, 0, true, true ) );
+		$this->assertSame( 'outofstock', $product->get_stock_status() );
+		$this->assertFalse( $product->get_manage_stock(), 'Availability changes must not turn stock management on.' );
+		$this->assertNull( $product->get_stock_quantity() );
+	}
+
+	/** An unproven zero must not push an unmanaged product out of stock either: that is lost sales. */
+	public function test_an_unverified_zero_leaves_an_unmanaged_product_in_stock() {
+		$product = $this->make_product( false );
+
+		$this->assertFalse( Helper::apply_square_inventory_count( $product, 0, true, false ) );
+		$this->assertSame( 'instock', $product->get_stock_status() );
+	}
+
+	/**
+	 * A variation inheriting the parent's pooled stock is skipped for every count, since a per
+	 * variation write is either invisible or would convert it to its own stock management.
+	 */
+	public function test_a_pooled_variation_is_skipped_for_every_count() {
+		$variable = new \WC_Product_Variable();
+		$variable->set_name( 'Pooled parent' );
+		$variable->set_manage_stock( true );
+		$variable->set_stock_quantity( 50 );
+		$variable->save();
+
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $variable->get_id() );
+		$variation->set_regular_price( '10' );
+		$variation->set_manage_stock( false );
+		$variation->save();
+
+		// A variation reports 'parent' only once it is read back with the parent's data attached: the
+		// value is derived from the parent managing stock while the variation does not.
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertSame( 'parent', $variation->get_manage_stock(), 'Fixture must actually inherit the pool.' );
+
+		foreach ( array( 6, 0, -2 ) as $count ) {
+			$this->assertFalse(
+				Helper::apply_square_inventory_count( $variation, $count, false, true ),
+				"A pooled variation must be skipped for a count of {$count}."
+			);
+			$this->assertSame( 'parent', $variation->get_manage_stock() );
+		}
+
+		$this->assertEquals( 50, wc_get_product( $variable->get_id() )->get_stock_quantity(), 'The pool must be untouched.' );
+	}
+
+	/** WooCommerce holds negative stock as backorder depth, and Square cannot, so it is passed through. */
+	public function test_a_negative_count_is_passed_through_for_a_managed_product() {
+		$product = $this->make_product( true, 4 );
+
+		$this->assertTrue( Helper::apply_square_inventory_count( $product, -3, false, false ) );
+		$this->assertEquals( -3, $product->get_stock_quantity(), 'Clamping a negative to zero loses backorder depth.' );
+	}
+
+	/** A negative count needs no history check, because a never counted item reads exactly zero. */
+	public function test_a_negative_count_marks_an_unmanaged_product_out_of_stock() {
+		$product = $this->make_product( false );
+
+		$this->assertTrue( Helper::apply_square_inventory_count( $product, -1, false, false ) );
+		$this->assertSame( 'outofstock', $product->get_stock_status() );
+	}
+}

--- a/tests/php/Unit/Sync/HelperInventoryWritePolicyTest.php
+++ b/tests/php/Unit/Sync/HelperInventoryWritePolicyTest.php
@@ -22,6 +22,26 @@ class HelperInventoryWritePolicyTest extends WP_UnitTestCase {
 		if ( ! class_exists( '\WC_Product_Simple' ) ) {
 			$this->markTestSkipped( 'WooCommerce is required for the stock write policy tests.' );
 		}
+
+		$this->set_system_of_record( 'woocommerce' );
+	}
+
+	public function tearDown(): void {
+		$this->set_system_of_record( 'woocommerce' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Pins the system of record for a test.
+	 *
+	 * Written through the settings handler rather than the option row, because the handler caches
+	 * its settings for the life of the process and would otherwise keep answering with the old value.
+	 *
+	 * @param string $value 'woocommerce' or 'square'.
+	 */
+	private function set_system_of_record( $value ) {
+		wc_square()->get_settings_handler()->update_option( 'system_of_record', $value );
 	}
 
 	/**
@@ -96,10 +116,11 @@ class HelperInventoryWritePolicyTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A variation inheriting the parent's pooled stock is skipped for every count, since a per
-	 * variation write is either invisible or would convert it to its own stock management.
+	 * Under WooCommerce as the system of record the pool is merchant intent, so a variation
+	 * inheriting it is skipped for every count: a per variation write is either invisible or would
+	 * convert the variation to its own stock management.
 	 */
-	public function test_a_pooled_variation_is_skipped_for_every_count() {
+	public function test_a_pooled_variation_is_skipped_for_every_count_under_woocommerce_system_of_record() {
 		$variable = new \WC_Product_Variable();
 		$variable->set_name( 'Pooled parent' );
 		$variable->set_manage_stock( true );
@@ -127,6 +148,57 @@ class HelperInventoryWritePolicyTest extends WP_UnitTestCase {
 		}
 
 		$this->assertEquals( 50, wc_get_product( $variable->get_id() )->get_stock_quantity(), 'The pool must be untouched.' );
+	}
+
+	/**
+	 * Under Square as the system of record the authority is reversed, so a positive count is applied
+	 * and the variation takes over its own stock, which is what the plugin did before this changeset.
+	 * A zero or negative count is still refused, because writing one into a pool would move stock
+	 * shared with sibling variations on one variation's reading.
+	 */
+	public function test_a_pooled_variation_takes_over_its_stock_for_a_positive_count_under_square_system_of_record() {
+		$this->set_system_of_record( 'square' );
+
+		$variable = new \WC_Product_Variable();
+		$variable->set_name( 'Pooled parent under Square SOR' );
+		$variable->set_manage_stock( true );
+		$variable->set_stock_quantity( 50 );
+		$variable->save();
+
+		$variation = new \WC_Product_Variation();
+		$variation->set_parent_id( $variable->get_id() );
+		$variation->set_regular_price( '10' );
+		$variation->set_manage_stock( false );
+		$variation->save();
+
+		$variation = wc_get_product( $variation->get_id() );
+
+		$this->assertSame( 'parent', $variation->get_manage_stock(), 'Fixture must actually inherit the pool.' );
+
+		$this->assertTrue(
+			Helper::apply_square_inventory_count( $variation, 6, false, true ),
+			'A positive count must be applied under Square SOR.'
+		);
+		$this->assertTrue( $variation->get_manage_stock(), 'The variation must take over its own stock management.' );
+		$this->assertEquals( 6, $variation->get_stock_quantity() );
+		$this->assertEquals( 50, wc_get_product( $variable->get_id() )->get_stock_quantity(), 'The parent pool must be left as it was.' );
+
+		// A fresh pooled variation, to prove the non positive counts are still refused.
+		$pooled = new \WC_Product_Variation();
+		$pooled->set_parent_id( $variable->get_id() );
+		$pooled->set_regular_price( '10' );
+		$pooled->set_manage_stock( false );
+		$pooled->save();
+
+		$pooled = wc_get_product( $pooled->get_id() );
+
+		foreach ( array( 0, -2 ) as $count ) {
+			$this->assertFalse(
+				Helper::apply_square_inventory_count( $pooled, $count, false, true ),
+				"A pooled variation must still be skipped for a count of {$count} under Square SOR."
+			);
+			$this->assertSame( 'parent', $pooled->get_manage_stock() );
+		}
 	}
 
 	/** WooCommerce holds negative stock as backorder depth, and Square cannot, so it is passed through. */

--- a/tests/php/Unit/Sync/SteppedJobZeroVerificationPolicyTest.php
+++ b/tests/php/Unit/Sync/SteppedJobZeroVerificationPolicyTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Tests for the zero verification retry policy shared by every sync step.
+ *
+ * When Square's inventory history cannot be read, a step holds its progress and runs again a bounded
+ * number of times, and once those attempts are spent it proceeds writing no zeros and says so. That
+ * "says so" is what stops the interval poll advancing its window over a period it could not verify, so
+ * the flag and the attempt counting are pinned here.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync;
+
+use WP_UnitTestCase;
+use WooCommerce\Square\Sync\Records;
+use WooCommerce\Square\Sync\Stepped_Job;
+use WooCommerce\Square\Tests\Unit\Sync\Fixtures\Zero_Verification_Policy_Job;
+
+require_once __DIR__ . '/Fixtures/Zero_Verification_Policy_Job.php';
+
+class SteppedJobZeroVerificationPolicyTest extends WP_UnitTestCase {
+
+	/** @var string */
+	private $step = 'update_inventory_counts';
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! function_exists( 'wc_square' ) || ! wc_square() ) {
+			$this->markTestSkipped( 'The plugin instance is required for the policy tests.' );
+		}
+
+		delete_transient( 'wc_square_zero_verification_alerted' );
+		delete_option( 'wc_square_sync_records' );
+	}
+
+	public function tearDown(): void {
+		delete_transient( 'wc_square_zero_verification_alerted' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Builds a job backed by a real background job row, so attribute writes persist as in production.
+	 *
+	 * @return Zero_Verification_Policy_Job
+	 */
+	private function make_job() {
+		$job = wc_square()->get_background_job_handler()->create_job( array( 'action' => 'poll' ) );
+
+		return new Zero_Verification_Policy_Job( $job );
+	}
+
+	/** The step is held for a bounded number of attempts, then told to proceed. */
+	public function test_the_step_is_held_for_a_bounded_number_of_attempts() {
+		$job = $this->make_job();
+
+		for ( $attempt = 1; $attempt <= Stepped_Job::MAX_ZERO_VERIFICATION_ATTEMPTS; $attempt++ ) {
+			$this->assertTrue(
+				$job->policy_should_retry( $this->step ),
+				"Attempt {$attempt} should hold the step and run it again."
+			);
+		}
+
+		$this->assertFalse(
+			$job->policy_should_retry( $this->step ),
+			'Once the attempts are spent the step must proceed rather than hold forever.'
+		);
+	}
+
+	/** Exhaustion is reported separately, because an empty verified list does not mean failure. */
+	public function test_exhaustion_is_reported_so_a_watermark_can_be_held() {
+		$job = $this->make_job();
+
+		$this->assertFalse( $job->policy_exhausted( $this->step ), 'A fresh job has verified nothing yet.' );
+
+		$job->policy_set_attr( 'zero_verification_exhausted_' . $this->step, true );
+
+		$this->assertTrue( $job->policy_exhausted( $this->step ) );
+	}
+
+	/**
+	 * A successful verification clears both the flag and the attempt counter, so a later window is
+	 * judged on its own answer rather than an earlier outage.
+	 */
+	public function test_a_successful_verification_clears_the_exhaustion_flag() {
+		$job = $this->make_job();
+
+		$job->policy_set_attr( 'zero_verification_exhausted_' . $this->step, true );
+		$job->policy_set_attr( 'zero_verification_attempts_' . $this->step, 2 );
+
+		// An empty id list is answered without asking Square, which is a successful verification of
+		// nothing. The failure path itself is covered by the live outage run.
+		$verified = $job->policy_resolve( $this->step, array() );
+
+		$this->assertSame( array(), $verified );
+		$this->assertFalse( $job->policy_exhausted( $this->step ) );
+		$this->assertSame( 0, (int) $job->policy_get_attr( 'zero_verification_attempts_' . $this->step ) );
+	}
+
+	/** The merchant gets one alert per window, not one per batch during a sustained outage. */
+	public function test_exhaustion_records_one_merchant_alert_per_window() {
+		$first = $this->make_job();
+
+		for ( $attempt = 1; $attempt <= Stepped_Job::MAX_ZERO_VERIFICATION_ATTEMPTS; $attempt++ ) {
+			$first->policy_should_retry( $this->step );
+		}
+		$first->policy_should_retry( $this->step );
+
+		$alerts = array_filter(
+			Records::get_records(),
+			static function ( $record ) {
+				return false !== strpos( $record->get_message(), 'could not confirm which products are genuinely sold out' );
+			}
+		);
+
+		$this->assertCount( 1, $alerts, 'Exhausting the attempts must tell the merchant once.' );
+
+		// A second job in the same window must not add another record, or a sustained outage would
+		// push every other sync record out of the capped list.
+		$second = $this->make_job();
+		for ( $attempt = 1; $attempt <= Stepped_Job::MAX_ZERO_VERIFICATION_ATTEMPTS + 1; $attempt++ ) {
+			$second->policy_should_retry( $this->step );
+		}
+
+		$alerts_after = array_filter(
+			Records::get_records(),
+			static function ( $record ) {
+				return false !== strpos( $record->get_message(), 'could not confirm which products are genuinely sold out' );
+			}
+		);
+
+		$this->assertCount( 1, $alerts_after, 'A second job in the same window must not duplicate the alert.' );
+	}
+}

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -141,7 +141,25 @@ class WooCommerce_Square_Loader {
 		$loader = require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
 		// register plugin namespace with autoloader
-		$loader->addPsr4( 'WooCommerce\\Square\\', __DIR__ . '/includes' );
+		if ( is_object( $loader ) && method_exists( $loader, 'addPsr4' ) ) {
+			$loader->addPsr4( 'WooCommerce\\Square\\', __DIR__ . '/includes' );
+		} else {
+			// require_once returns true rather than the ClassLoader when something loaded the same
+			// autoloader first, which is what happens under PHPUnit. Register the namespace directly
+			// so the plugin still resolves its own classes instead of fataling here.
+			spl_autoload_register(
+				static function ( $class_name ) {
+					$prefix = 'WooCommerce\\Square\\';
+					if ( 0 !== strncmp( $class_name, $prefix, strlen( $prefix ) ) ) {
+						return;
+					}
+					$file = __DIR__ . '/includes/' . str_replace( '\\', '/', substr( $class_name, strlen( $prefix ) ) ) . '.php';
+					if ( file_exists( $file ) ) {
+						require_once $file;
+					}
+				}
+			);
+		}
 
 		require_once plugin_dir_path( __FILE__ ) . 'includes/Functions.php';
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [x] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

The short version: _treat **"Square says zero"** as a question, not an answer, and go find out whether that zero has a history behind it._

Merchants have repeatedly reported WooCommerce stock being wiped to zero by the Square inventory sync, including stores where WooCommerce is the system of record. The root cause is that Square reports a tracked item that has never had a count recorded as "0 in stock", which is byte for byte identical to a genuine sellout. Every pull path treated that ambiguous zero as real data, wrote it to the product and switched stock management on. A single shopper adding an item to their basket could trigger it.

This change introduces one shared write policy for every Square to WooCommerce inventory write:

1. A positive count is always trusted and written, keeping the existing behavior of mirroring Square tracking into stock management.
2. A zero count never changes the product's stock management setting. For a stock managed product, the zero is written only when Square's inventory change history proves a real count was ever recorded for that item. A never counted item has an empty history, so its phantom zero is skipped and logged. No new meta is introduced; Square's own history is the source of truth.
3. A product that does not manage stock is never given a quantity by a zero or a negative count. It is marked out of stock only when the zero is proven to be a real sellout, and a zero is never a reason to force it back in stock, so an unproven zero leaves such a product exactly as the merchant left it. A positive count still mirrors Square as it does on trunk, writing the quantity and switching stock management on; whether that should instead defer to a merchant who deliberately turned stock management off is a separate policy question, deferred with the tracking off follow up.
4. A variation that inherits the parent product's shared stock pool is skipped for every count, positive or zero, since a per variation count must not alter stock shared with its sibling variations or convert the variation to its own stock management.
5. A negative count needs no history check, because an item that was never counted reads exactly zero, so a negative can only come from real movement. It is written through rather than flattened, which keeps the oversell depth a store using backorders relies on.
6. A response that contains no usable IN_STOCK count for an item means "no information" and never a zero. Non IN_STOCK states such as purchase order stages are ignored as well, which also resolves the purchase order zeroing report.

On the push side, the count builder now decides from the product's state: a managed product with an unresolved quantity is skipped and logged instead of pushing a fabricated zero, a product without stock management that is out of stock pushes an explicit zero so Square marks it sold out, and one that is in stock pushes nothing.

The automatic pulls (hourly polling, the manual sync pull, and the add to basket stock refresh) now also honor the per product "Sync with Square" setting, so unticking it or using Unlink genuinely stops Square from updating that product. Two paths stay deliberately ungated because the merchant asked for them directly: the "Fetch stock from Square" button, and the product import, which additionally cannot use that flag because it is only set for newly imported products, so gating it would silently skip inventory for products the import matched and updated.

If Square genuinely sold out (say an in person sale) and our verification call fails, this path leaves WooCommerce holding the older quantity rather than writing the 0. Stock stays stale until a later trigger or the next poll writes it. That is a deliberate trade: a brief oversell window that already existed because of the poll interval, versus zeroing live products under shoppers.

**Cost of the history check:** it runs only for items reporting zero, so a store with normal stock levels pays nothing. Ids are asked about in batches of 100, and any id still unresolved after the first page is re-asked as a group with the already answered ids removed, so a batch of never counted items is normally settled in one extra request and a single high activity item cannot drag a whole batch through its entire history just to prove a quiet item empty. Only if that group pass stops making progress does it fall back to one request per id, and the number of group passes is capped.

**When Square cannot be asked:** the history lookup is the one new dependency, so its failure is handled explicitly rather than guessed at. A failed lookup is reported distinctly from a verified empty history, and nothing is written on it. A step holds its progress and runs again a bounded number of times, and it never throws, because the job runner fails a job on any exception other than a rate limit, which would abort an entire import or manual sync for one transient error.

Recovery after those attempts differs by path, because the paths read Square differently, and there is deliberately no separate retry mechanism for it. Interval polling reads counts by `updated_after`, so every object whose zero it could not verify was inside that window by definition: when the attempts run out it keeps the window instead of advancing it, and the next poll reads the same window and finds those exact objects again. The manual sync and the import read counts by id rather than by window, so their recovery is to run the sync again, which re-checks exactly those objects. Both paths record one merchant visible alert rather than one per batch, telling the merchant to run the sync again once Square is responding normally. The dedupe is a job attribute plus a six hour transient (`wc_square_zero_verification_alerted`), so a store polling hourly gets at most one alert every six hours rather than one per window. Nothing anywhere writes a zero it could not confirm.

**Square API limitation worth knowing:** the sold out flag on a Square location override is effectively read only. Square only marks an item sold out through inventory tracking with a count of zero, and an override carrying sold out without tracking is silently dropped. That is why the sync must keep enabling tracking for out of stock products that do not manage stock. This change therefore fixes the zeroing on the pull side and also releases the sold out state when such a product comes back in stock, which previously stayed sold out in Square forever.

**A second Square API behaviour worth knowing:** the inventory endpoints honor the catalog object id filter only while at least one of the supplied ids still exists in Square. If none of them exists, Square silently answers as though no filter had been sent, returning the whole location's history or counts. A non empty response is therefore not proof that the id you asked about has any history. The verification now requires a response to name the id it asked about, and reads an unfiltered answer as a conclusive "none of these ids exist in Square", which also means none of them can have sold out. To be precise about the impact, since an earlier revision of this description overstated it: I could not reach a stock write through that path, because the refresh iterates the catalog objects Square returns and an id Square no longer knows returns none. So this is defensive correctness, plus saving up to five plus N wasted requests for a chunk of dead ids, rather than a demonstrated data loss fix.

**Deliberate behavior changes to call out in release notes:**
* When WooCommerce is the system of record, the manual sync still pulls inventory, but it no longer reads back the counts the same job just pushed. Those catalog objects are excluded by id, because Square's inventory is eventually consistent and a count that has not propagated yet answers zero, which would overwrite the stock pushed moments earlier. Products that already existed in Square are still pulled, which is what keeps sales made on other channels reflected and is the only thing that syncs their inventory during a manual sync.
* The documented "Square updates WooCommerce stock hourly regardless of system of record" behavior now respects the per product sync setting and the write policy above.

**Holding the read window has no cap, deliberately:** while verification is unavailable the poll keeps its inventory window rather than advancing, so during a sustained outage the window grows with every poll and the reads get larger, until Square answers again and it advances, at which point the cost disappears. An earlier revision capped consecutive holds and advanced anyway, which was only safe while a separate retry list re-checked the skipped objects by id. That list is gone, so a cap would now advance past a window nothing revisits, which is the silent loss this ticket exists to prevent.

**Opting a product out, and mirroring a tracking change:** unticking "Sync with Square", or using Unlink, stops Square touching a product at all, and this change makes that effective on every automatic pull, since all four pull paths now check it. Separately, "Manage stock" is editable again on a synced product, so a merchant can mirror turning inventory tracking off in Square: with tracking off there, the sync reflects availability only and leaves the flag alone. Verified live, the untick survives a poll with the quantity cleared and the product left in stock. What it is not is a way to diverge from Square: if Square is still tracking the item, a positive count mirrors as it always has and switches stock management back on, also verified live. Whether that divergence should be permitted is the deferred question in point 3.

**What the test numbers in these threads mean:** the repository's PHPUnit suite is 54 tests, 23 of them added here, covering the zero discriminator, the write policy and the retry policy, and each was checked by reverting the corresponding part of the fix and confirming the test fails. Figures quoted in review threads come from scripted runs against a live Square sandbox rather than unit tests: a seven scenario behaviour suite (phantom, genuine sellout, unmanaged product, pooled variation, unticked product, proven unmanaged sellout, negative count), a sixteen case discriminator suite driven by scripted API pages, and end to end runs through the real job runner including an injected Square outage at the SDK boundary.

**Known limits and how this was verified:** all of the behavior above was exercised against a live Square sandbox through the real sync paths, by walking the manual scenarios below and by scripted runs of the same paths, including an injected Square outage at the API boundary to cover the failure branches. It is also covered by unit tests now, described below. The Square system of record import path is covered by the shared policy but has not been exercised end to end at scale in this round of dev-testing, purchase order state behavior is inferred from Square documentation since a Square Retail account is required to generate those states, and the remaining place a zero can be delayed is a manual sync or an import whose history lookups stay unreadable: those proceed with the alert rather than failing, and re-running the sync is what re-checks them.

**Unit tests:** 24 tests were added under `tests/php/Unit/Sync`, runnable with `composer test-unit`. They cover the discriminator (an id is only proven by a response that names it, a failed lookup is distinct from a verified empty history, the group narrowing and its per id fallback, the request chunking), the write policy (positive counts, verified and unverified zeros for managed and unmanaged products, pooled variations skipped for every count under WooCommerce SOR and converted by a positive count under Square SOR, negatives passed through), and the retry policy (the step is held for a bounded number of attempts, exhaustion is reported so a watermark can be held, a success clears it, and the merchant is alerted at most once every six hours). Each of them was checked by reverting the corresponding part of the fix and confirming the test fails, so they are regression tests rather than descriptions. Note that the repository has no PHPUnit job in CI, so these run locally.

**One change outside the sync code, and why it is here:** the plugin's main file assigned the return of `require_once vendor/autoload.php` and called `addPsr4()` on it. That return is the Composer ClassLoader on first load and simply `true` afterwards, so as soon as anything had already loaded the same autoloader, that line fataled. PHPUnit does exactly that through phpunit-polyfills, which is why WooCommerce could not be loaded into the test harness at all and why 28 of the repository's existing tests were skipping. The call is now guarded, with a direct namespace registration as a fallback so registration still happens rather than being silently skipped. Behaviour on the normal WordPress path is unchanged, since the first load still returns the ClassLoader, and it was verified on a live connected site: admin, both Square settings screens and the products list load without fatals and the plugin resolves its own classes. With it in place the suite goes from 42 tests with 28 skipped to 54 with 1 skipped, and the write policy and retry policy tests above become possible, since those need real WooCommerce product objects.

Closes https://linear.app/a8c/issue/SQUARE-145/square-zero-ing-out-inventory
Closes https://linear.app/a8c/issue/SQUARE-359/interval-inventory-sync-overwrites-products-whose-sync-with-square-is

### Steps to test the changes in this Pull Request:

> [!Note]
> This is a big change; I'd recommend doing a random QA before proceeding with the following instructions. Just make sure the sync process works as expected, especially when Woo is SOR. Try with different QTY and Manage Stock, Inventory Sync On/Off combinations and make sure all work as expected.

Setup once: connect the site to a Square sandbox, set System of Record to WooCommerce, and keep the Square sandbox Dashboard open in another tab. Every scenario below is done through the normal admin and shop screens, no tools involved. "Run a sync" means WooCommerce > Settings > Square > Update > Sync now, and "trigger a stock refresh" means adding the product to the basket on the shop front end, which is the automatic path a shopper takes.

**Scenario A. The reported bug: stock wiped by a meaningless zero**

1. In WooCommerce > Settings > Square, turn "Sync inventory" OFF.
1. Create a simple product with a unique SKU, tick "Manage stock", set the quantity to 20, tick "Sync with Square" in the Inventory tab, and update.
1. Run a sync and wait for it to finish. The item now exists in Square but has never had a stock count recorded there.
1. Turn "Sync inventory" ON and save.
1. Trigger a stock refresh for that product.
1. Open the product's Inventory tab. On trunk the stock data is destroyed even though nobody bought anything: either the quantity becomes 0 and the product goes out of stock, or "Manage stock" is switched off and the quantity disappears, leaving the product sellable with no stock control. On this branch nothing changes: "Manage stock" stays ticked and the quantity stays 20.

**Scenario B. A genuine Square sellout must still reach WooCommerce**

1. With "Sync inventory" ON, create a managed product with quantity 5, tick "Sync with Square", run a sync, and confirm in the Square Dashboard that the item shows 5 in stock.
1. In the Square Dashboard set that item's stock to 0.
1. Trigger a stock refresh, then check the product: the quantity is 0 and the product is out of stock. This must behave the same on trunk and on this branch.

**Scenario C. An unproven zero must not touch a product that does not manage stock**

1. Turn "Sync inventory" OFF. Create a product with "Manage stock" unticked and stock status "In stock", tick "Sync with Square", and run a sync.
1. Turn "Sync inventory" ON, then trigger a stock refresh.
1. Reopen the product. On this branch nothing at all has changed: "Manage stock" is still unticked, no quantity has appeared, and the product is still in stock. Square never proved a sellout, so it does not get to stop the product selling.

**Scenario D. A proven sellout does stop such a product selling**

1. Take the product from scenario C. In the Square Dashboard, enable inventory tracking for that item and set its stock to 5, then set it to 0.
1. Trigger a stock refresh and reopen the product: it now shows out of stock, "Manage stock" is still unticked, and no quantity has been written.

**Scenario E. Turning tracking off in Square must not switch off Manage stock in WooCommerce**

1. Take any synced product with "Manage stock" ticked and a quantity.
1. In the Square Dashboard, turn inventory tracking OFF for that item.
1. Trigger a stock refresh and reopen the product: "Manage stock" is still ticked and the quantity is unchanged. Stock management is the merchant's setting, so the pull reflects availability but never edits that checkbox. On trunk this switched Manage stock off (on the customer database export from SQUARE-364, a single poll did that to 4,903 products).

**Scenario F. Unticking "Sync with Square" must really exclude the product**

1. Take a synced managed product with stock, untick "Sync with Square" in its Inventory tab, and update.
1. In the Square Dashboard set that item's stock to 0.
1. Trigger a stock refresh: the WooCommerce quantity is unchanged. Square no longer touches this product.

**Scenario G. A variation sharing the parent product's stock must be protected**

1. Create a variable product, tick "Manage stock" on the parent, set the parent quantity to 50, and add a variation that leaves "Manage stock" unticked so it uses the parent's stock.
1. Tick "Sync with Square", run a sync, and confirm the variation exists in Square.
1. In the Square Dashboard set that variation's stock to 0.
1. Trigger a stock refresh and reopen the product: the parent quantity is still 50 and the variation still uses the parent's stock. One variation's Square count must not spend stock shared with its siblings.

**Scenario H. Push side: a product without stock management that goes out of stock**

1. Create a product with "Manage stock" unticked and stock status "Out of stock", tick "Sync with Square", run a sync.
1. In the Square Dashboard the item shows as sold out.
1. Set the same product back to "In stock" in WooCommerce and run a sync again: the item is no longer sold out in Square. On trunk it stayed sold out.

**Scenario I. An order placed after inventory sync is enabled**

1. Using scenario A's product, place an order for 1 through the shop.
1. WooCommerce reduces the quantity, and the Square Dashboard records the sale for that item.
1. Run a sync: Square is set back to WooCommerce's absolute quantity, so both sides agree. Note that immediately after the order the Square figure can be lower than WooCommerce's (it may even be negative for an item that never had a count), and the sync reconciles it.

**Scenario J. Square as the system of record: import**

1. Switch System of Record to Square, and in the import options allow existing products to be updated.
1. Run an import and check a product that already existed in WooCommerce and was matched by the import: its stock reflects Square. On this branch inventory is applied to matched products too, not only to newly created ones.

**Optional, for two shapes that are impractical by hand**

A single file QA tool can create the fixtures for the remaining shapes, which need a Square item to be oversold or need a specific pooled setup: https://gist.github.com/faisal-alvi/db2d5f0cffa0cf2ebd336134898e3733 (drop it in wp-content/mu-plugins/, then Tools > Square Stock Zeroing QA, and use button 8 to clean up). The one worth running is test 7, an item oversold at the till: Square reports minus three and WooCommerce must record minus three rather than flattening it to zero, which is what a store using backorders relies on.

Behaviour that only appears when the Square API itself is failing (the bounded retries, the held inventory sync window, and the guarantee that a failing history lookup never fails an import or a manual sync) cannot be produced from the admin, so it was verified during development by injecting a Square outage at the API boundary. It is described in the section above rather than left implicit.

### Review pass 2026-08-25

Three behaviours were changed after review feedback, all of them narrowing this PR to the mode the bug is actually in.

**`manage_stock` is mirrored on every pull path, and only when Square is the system of record.** Trunk switched stock management off in both modes, which is how 4,903 products on the reported store were left sellable with no stock control. This branch keeps that behaviour for Square SOR, where Square owns the setting, and removes it for WooCommerce SOR, where it is merchant intent. It was previously applied at two of the six places that write stock from Square; it is now applied at all six: `Product::update_stock_from_square()`, `Product::update_products_stock_from_square()` (the add to cart refresh), both interval poll steps, `Manual_Synchronization::pull_inventory()` and `Product_Import::import_inventory()`.

**A variation inheriting its parent's pooled stock follows the same rule.** Under WooCommerce SOR a per variation Square count is skipped, because writing it is either invisible (reads come from the parent) or would convert the variation to its own stock management as a side effect of an inventory read. Under Square SOR a positive count is applied and the variation takes over its own stock, which is what the plugin did before this changeset. A zero or negative count is skipped in both modes, since writing one into a pool would move stock shared with sibling variations on one variation's reading. Both outcomes are logged.

**The interval poll no longer resaves products it has nothing to change.** Its skip check compared Square's tracking flag against `manage_stock`, which only settles once something makes them agree. Trunk made them agree by switching stock management off; this branch does not do that under WooCommerce SOR, so a product tracked off in Square with Manage stock on in WooCommerce failed that check on every run and was saved every hour indefinitely. On the reported store's shape that is roughly 4,900 saves per poll. The tracking comparison now applies only under Square SOR, where the poll can still change the setting; under WooCommerce SOR availability is the only thing the poll writes, so it is the only thing compared.

Known and deliberately left as follow ups: the order path performs a Square inventory history lookup during checkout to establish a baseline for an item Square never counted, which should become a cached per product flag; and a push releases inventory tracking on any pre-existing location override at the configured location, including one that exists only for a location specific price.

### Changelog entry

> Fix - Stop Square inventory pulls from writing zero stock for items Square has no real count for, never change a product's stock management setting on a zero, and honor the per product Sync with Square setting on all automatic pulls.