### PR TITLE
Prevent duplicate Square card field when a checkout update lands during form initialization

### DIFF
--- a/src/js/frontend/wc-square.js
+++ b/src/js/frontend/wc-square.js
@@ -51,6 +51,12 @@ jQuery( document ).ready( ( $ ) => {
 				args.is_change_payment_method_request;
 			this.metrics = {};
 
+			// Whether a payment form build is currently in flight.
+			this.settingUp = false;
+
+			// Whether a checkout update landed while a build was in flight.
+			this.pending_refresh = false;
+
 			if ( $( 'form.checkout' ).length ) {
 				this.form = $( 'form.checkout' );
 				this.handle_checkout_page();
@@ -200,6 +206,14 @@ jQuery( document ).ready( ( $ ) => {
 		 * @since 2.0.0
 		 */
 		set_payment_fields() {
+			// A build is already in flight. `this.payment_form` isn't assigned until it settles, so
+			// carrying on here would skip the guards below and attach a second card to the container.
+			// Queue a single refresh instead - it's flushed once the build completes.
+			if ( this.settingUp ) {
+				this.pending_refresh = true;
+				return;
+			}
+
 			if ( this.payment_form ) {
 				// Don't re-initialize the payment form if it's already been initialized and exist in DOM.
 				if (
@@ -215,10 +229,13 @@ jQuery( document ).ready( ( $ ) => {
 
 				// Destroy the payment form and re-initialize it.
 				this.log( 'Destroying payment form' );
-				this.payment_form.destroy().then( () => {
-					this.log( 'Re-building payment form' );
-					this.initializeCard( this.payments );
-				} );
+
+				const previous_payment_form = this.payment_form;
+
+				// Drop the reference before awaiting, so a checkout update landing mid-destroy
+				// can't tear the same form down twice.
+				this.payment_form = null;
+				this.rebuild_payment_form( previous_payment_form );
 				return;
 			}
 
@@ -231,27 +248,75 @@ jQuery( document ).ready( ( $ ) => {
 		}
 
 		/**
+		 * Tears down the current payment form and builds a fresh one in its place.
+		 *
+		 * @param {Object} previous_payment_form The payment form to destroy.
+		 */
+		async rebuild_payment_form( previous_payment_form ) {
+			// Flag the rebuild synchronously so a checkout update arriving before the teardown
+			// resolves is queued rather than starting a competing build.
+			this.settingUp = true;
+
+			try {
+				await previous_payment_form.destroy();
+				this.log( 'Re-building payment form' );
+			} catch ( error ) {
+				this.log( 'Could not destroy the payment form: ' + error, 'error' );
+			}
+
+			// Build regardless of how the teardown went - the customer still needs a card field.
+			// `initializeCard()` keeps the flag raised and clears it when the build settles.
+			this.initializeCard( this.payments );
+		}
+
+		/**
 		 * Initialises the Credit Card field with defaults (if any)
 		 *
 		 * @param {object} payments The Square payment object.
 		 */
-		initializeCard( payments ) {
+		async initializeCard( payments ) {
+			// Flag the build synchronously - `payments.card()` and `card.attach()` are both async,
+			// and `this.payment_form` stays unset until they resolve.
+			this.settingUp = true;
+
 			let defaultPostalCode = $( '#billing_postcode' ).val();
 			defaultPostalCode = defaultPostalCode || '';
 
-			payments.card( {
-				postalCode: defaultPostalCode, // Default postal code value.
-			} ).then( ( card ) => {
-				if ( ! document.getElementById( 'wc-square-credit-card-container' ) ) {
-					this.end( 'initialize_payment_form', true );
-					return;
-				}
+			try {
+				const card = await payments.card( {
+					postalCode: defaultPostalCode, // Default postal code value.
+				} );
 
-				card.attach( '#wc-square-credit-card-container' );
-				this.payment_form = card;
-				this.log( 'Payment form loaded' );
-				this.end( 'initialize_payment_form' );
-			} );
+				const container = document.getElementById( 'wc-square-credit-card-container' );
+
+				if ( ! container ) {
+					await card.destroy();
+					this.end( 'initialize_payment_form', true );
+				} else {
+					// The container is rendered empty server-side, so anything inside it was left
+					// behind by an earlier attach. Clear it rather than mounting a second card alongside.
+					$( container ).empty();
+
+					// Await the attach so `this.payment_form` is only exposed once the card is
+					// mounted and ready to tokenize.
+					await card.attach( '#wc-square-credit-card-container' );
+
+					this.payment_form = card;
+					this.log( 'Payment form loaded' );
+					this.end( 'initialize_payment_form' );
+				}
+			} catch ( error ) {
+				this.log( 'Could not build the payment form: ' + error, 'error' );
+				this.end( 'initialize_payment_form', true );
+			} finally {
+				this.settingUp = false;
+
+				// Apply any checkout update that was queued while the form was building.
+				if ( this.pending_refresh ) {
+					this.pending_refresh = false;
+					this.set_payment_fields();
+				}
+			}
 		}
 
 		/**

--- a/tests/e2e/specs/a94.duplicate-credit-card-field.spec.js
+++ b/tests/e2e/specs/a94.duplicate-credit-card-field.spec.js
@@ -1,0 +1,108 @@
+import { chromium } from 'playwright';
+import { test, expect } from '@playwright/test';
+import { addOneOrMoreProductToCart } from '@woocommerce/e2e-utils-playwright';
+
+import {
+	clearCart,
+	createProduct,
+	doesProductExist,
+	fillAddressFields,
+	fillCreditCardFields,
+	placeOrder,
+	visitCheckout,
+} from '../utils/helper';
+
+const CARD_IFRAME = '#wc-square-credit-card-container iframe.sq-card-component';
+
+/**
+ * Re-triggers `update_checkout` from inside the first `updated_checkout`.
+ *
+ * This is what third-party checkout plugins (delivery date pickers and the like) do on page
+ * load, and it lands the second refresh while Square's `payments.card()` promise is still
+ * pending - the window in which the payment form used to attach a second card to the
+ * container. Registered via `addInitScript` so it is in place before WooCommerce fires its
+ * first checkout update.
+ */
+function queueCheckoutRaceTrigger( page ) {
+	return page.addInitScript( () => {
+		document.addEventListener( 'DOMContentLoaded', () => {
+			if ( ! window.jQuery ) {
+				return;
+			}
+
+			window.jQuery( ( $ ) => {
+				$( document.body ).one( 'updated_checkout', () => {
+					$( document.body ).trigger( 'update_checkout' );
+				} );
+			} );
+		} );
+	} );
+}
+
+test.beforeAll( 'Setup', async ( { baseURL } ) => {
+	const browser = await chromium.launch();
+	const page = await browser.newPage();
+
+	if ( ! ( await doesProductExist( baseURL, 'simple-product' ) ) ) {
+		await createProduct( page, {
+			name: 'Simple Product',
+			regularPrice: '14.99',
+			sku: 'simple-product',
+		} );
+
+		await expect( page.getByText( 'Product published' ) ).toBeVisible();
+	}
+
+	await clearCart( page );
+	await browser.close();
+} );
+
+test.afterAll( async () => {
+	const browser = await chromium.launch();
+	const page = await browser.newPage();
+
+	await clearCart( page );
+	await browser.close();
+} );
+
+test( '[non-Block]: Credit card field is not duplicated by a checkout update during form init @general', async ( {
+	page,
+} ) => {
+	await addOneOrMoreProductToCart( page, 'simple-product' );
+	await queueCheckoutRaceTrigger( page );
+	await visitCheckout( page, false );
+
+	await page.locator( CARD_IFRAME ).first().waitFor( { state: 'attached' } );
+
+	// Let the second checkout update settle before counting.
+	await page.waitForTimeout( 3000 );
+
+	await expect( page.locator( CARD_IFRAME ) ).toHaveCount( 1 );
+	await expect(
+		page.locator( '#wc-square-credit-card-container .sq-card-wrapper' )
+	).toHaveCount( 1 );
+} );
+
+test( '[non-Block]: Order can be placed after a checkout update during form init @general', async ( {
+	page,
+} ) => {
+	await addOneOrMoreProductToCart( page, 'simple-product' );
+	await queueCheckoutRaceTrigger( page );
+	await visitCheckout( page, false );
+
+	await page.locator( CARD_IFRAME ).first().waitFor( { state: 'attached' } );
+	await page.waitForTimeout( 3000 );
+
+	await expect( page.locator( CARD_IFRAME ) ).toHaveCount( 1 );
+
+	// The surviving card must still be the one the handler tokenizes with.
+	await fillAddressFields( page, false );
+	await fillCreditCardFields( page, true, false );
+	await placeOrder( page, false );
+
+	await expect(
+		page.locator( '.woocommerce-thankyou-order-received' )
+	).toHaveText( 'Thank you. Your order has been received.', {
+		timeout: 30000,
+	} );
+} );

--- a/tests/e2e/specs/a94.duplicate-credit-card-field.spec.js
+++ b/tests/e2e/specs/a94.duplicate-credit-card-field.spec.js
@@ -25,18 +25,57 @@ const CARD_IFRAME = '#wc-square-credit-card-container iframe.sq-card-component';
  */
 function queueCheckoutRaceTrigger( page ) {
 	return page.addInitScript( () => {
+		window.__squareUpdatedCheckoutCount = 0;
+
 		document.addEventListener( 'DOMContentLoaded', () => {
 			if ( ! window.jQuery ) {
 				return;
 			}
 
 			window.jQuery( ( $ ) => {
+				$( document.body ).on( 'updated_checkout', () => {
+					window.__squareUpdatedCheckoutCount++;
+				} );
+
 				$( document.body ).one( 'updated_checkout', () => {
 					$( document.body ).trigger( 'update_checkout' );
 				} );
 			} );
 		} );
 	} );
+}
+
+/**
+ * Waits for both checkout cycles to finish, then counts the mounted card fields.
+ *
+ * The count is taken as a single non-retrying snapshot: a retrying matcher would pass the
+ * instant the count reached 1, which on a duplicating build is true for a moment before the
+ * second card attaches.
+ *
+ * @param {Object} page Playwright page object.
+ * @return {Promise<Object>} Card iframe and wrapper counts.
+ */
+async function countCardFields( page ) {
+	// Both the initial update and the one the trigger queued must have completed.
+	await page.waitForFunction(
+		() => window.__squareUpdatedCheckoutCount >= 2,
+		null,
+		{ timeout: 30000 }
+	);
+
+	await page.locator( CARD_IFRAME ).first().waitFor( { state: 'attached' } );
+
+	// Let any further attach settle so the snapshot below is of the final DOM.
+	await page.waitForTimeout( 3000 );
+
+	return page.evaluate( () => ( {
+		iframes: document.querySelectorAll(
+			'#wc-square-credit-card-container iframe.sq-card-component'
+		).length,
+		wrappers: document.querySelectorAll(
+			'#wc-square-credit-card-container .sq-card-wrapper'
+		).length,
+	} ) );
 }
 
 test.beforeAll( 'Setup', async ( { baseURL } ) => {
@@ -72,15 +111,10 @@ test( '[non-Block]: Credit card field is not duplicated by a checkout update dur
 	await queueCheckoutRaceTrigger( page );
 	await visitCheckout( page, false );
 
-	await page.locator( CARD_IFRAME ).first().waitFor( { state: 'attached' } );
+	const counts = await countCardFields( page );
 
-	// Let the second checkout update settle before counting.
-	await page.waitForTimeout( 3000 );
-
-	await expect( page.locator( CARD_IFRAME ) ).toHaveCount( 1 );
-	await expect(
-		page.locator( '#wc-square-credit-card-container .sq-card-wrapper' )
-	).toHaveCount( 1 );
+	expect( counts.iframes ).toBe( 1 );
+	expect( counts.wrappers ).toBe( 1 );
 } );
 
 test( '[non-Block]: Order can be placed after a checkout update during form init @general', async ( {
@@ -90,10 +124,8 @@ test( '[non-Block]: Order can be placed after a checkout update during form init
 	await queueCheckoutRaceTrigger( page );
 	await visitCheckout( page, false );
 
-	await page.locator( CARD_IFRAME ).first().waitFor( { state: 'attached' } );
-	await page.waitForTimeout( 3000 );
-
-	await expect( page.locator( CARD_IFRAME ) ).toHaveCount( 1 );
+	const counts = await countCardFields( page );
+	expect( counts.iframes ).toBe( 1 );
 
 	// The surviving card must still be the one the handler tokenizes with.
 	await fillAddressFields( page, false );


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

> The new E2E spec is written but has **not** been run locally — it needs the wp-env environment plus Square sandbox credentials. Relying on CI for that. The fix itself was verified headlessly against the compiled bundle (see below).

---

### Changes proposed in this Pull Request:

Fixes a race condition in `set_payment_fields()` that renders the Square credit card field **twice** on classic (shortcode) checkout, blocking checkout for affected shoppers.

**Root cause.** `set_payment_fields()` guards all of its teardown/reuse logic on `this.payment_form`, but that property is only assigned *inside* the async `payments.card()` promise, after `attach()`. Between the first call and that promise resolving, `this.payment_form` is `undefined`. A second `updated_checkout` landing in that window falls straight past the guard, skips the destroy, and calls `initializeCard()` again — attaching a second card iframe into the same `#wc-square-credit-card-container`.

Any plugin that fires one `update_checkout` on page load triggers it (confirmed on the reporting merchant's site: CodeRockz "Woo Delivery"; also reported publicly against Order Delivery Date for WooCommerce Lite). Despite the issue title, this is **not** Chrome-specific — it is page-load timing, and "Chrome but not incognito/Edge/Firefox" are proxies for load speed.

Three related holes in the same lifecycle are closed too:

1. **`attach()` was not awaited.** `this.payment_form` was published before the iframe mounted, leaving a second window where the "already initialized" guard is false while `payment_form` is truthy — which pushes a concurrent update into the *destroy* branch.
2. **The destroy branch had the same re-entrancy hole.** `this.payment_form` was never cleared while `destroy()` was in flight, so a further update would destroy an already-destroyed form and re-initialize — another double-attach path.
3. **`payments.card()` had no rejection handler.** An SDK failure produced an unhandled promise rejection, left the perf metric open, and gave the shopper no card field and no recovery path. This is a plausible cause of the "payment nonce is missing / invalid card on first attempt, retry succeeds" reports in Zendesk #11475839.

**The fix** (`src/js/frontend/wc-square.js`):

- A `settingUp` re-entrancy flag, set **synchronously** before `payments.card()` and cleared in a `finally`. A checkout update arriving mid-build sets `pending_refresh` and returns rather than starting a competing build. Mirrors the existing `this.settingUp` pattern in `wc-square-cash-app-pay.js`.
- `pending_refresh` is flushed once the build settles, so a postcode or total change that landed during the window is still applied (it re-enters and hits the cheap `configure()` branch).
- `await card.attach()` before assigning `this.payment_form`, so the handler is never exposed pointing at an unmounted card.
- New `rebuild_payment_form()` nulls `this.payment_form` before awaiting `destroy()`.
- The container is emptied before attaching — a defensive second layer that also covers any other double-attach path. Safe because `includes/Gateway/Payment_Form.php:147` renders the div empty; it is a pure mount point.
- The whole build is wrapped in `try/catch/finally`, so a failed build logs and recovers instead of latching the flag.

Blocks checkout is unaffected (separate React path in `src/blocks/credit-card/`).

Closes SQUARE-355 — https://linear.app/a8c/issue/SQUARE-355/duplicate-credit-card-field-rendered-on-checkout-in-chrome-classic

### Steps to test the changes in this Pull Request:

Deterministic reproduction, from the investigation on the Linear issue — drop this into Code Snippets (PHP, "Run everywhere") on a store with classic shortcode checkout and Square enabled. It is opt-in by query param, so checkout behaves normally without one:

```php
add_action( 'wp_footer', function () {
	if ( ! function_exists( 'is_checkout' ) || ! is_checkout() ) {
		return;
	}
	if ( ! isset( $_GET['ted_mode'] ) ) {
		return;
	}
	?>
	<script>
	jQuery( function ( $ ) {
		$( document.body ).one( 'updated_checkout', function () {
			$( document.body ).trigger( 'update_checkout' );
		} );
	} );
	</script>
	<?php
}, 100 );
```

1. Add a product to the cart and visit the **classic shortcode** checkout with `?ted_mode=onupdate`.
2. Select Square Credit Card. In the console, run `document.querySelectorAll('#wc-square-credit-card-container iframe.sq-card-component').length`.
   * On `trunk` this returns **2** and two card fields are visible.
   * On this branch it returns **1**.
3. Reload without the query param (control) — still exactly one field, and it renders normally.
4. Change the shipping method or country a few times to force several `updated_checkout` cycles — still exactly one field each time.
5. Complete the order with test card `4111 1111 1111 1111`. It should tokenize and place the order with no errors.
6. Repeat in Firefox, Safari and Edge to confirm nothing regressed.

Alternatively, the staging site from the Linear investigation reproduces on `trunk` without any setup:
`https://squarefeten.mystagingwebsite.com/checkout/?ted_mode=onupdate`

### Verification already done

The compiled bundle was driven headlessly in jsdom against a stubbed Square SDK, modelling classic checkout's payment-box replacement. Both bundles built from the same webpack config:

| Scenario | `trunk` | This branch |
| --- | --- | --- |
| Control — single checkout update | 1 iframe | 1 iframe |
| Race — refresh during card build | **2 iframes, 2 wrappers** | 1 iframe |
| Burst — 4 refreshes, 25 ms apart | **3 iframes** | 1 iframe |
| Sequential — 3 settled refreshes | 1 iframe | 1 iframe |
| SDK rejects the first build | **unhandled rejection, no recovery** | recovers, 1 iframe |

A sweep across five `payments.card()` delays duplicated **4/5 on `trunk` and 0/5 on this branch**, and in the racing cases only *one* card object is ever created — the redundant build is prevented, not merely cleaned up afterwards. In every passing case `payment_form` ends up set and attached, which is what `handleSubmission()` needs in order to tokenize.

Two caveats on that evidence:

* The burst case duplicates in the harness but the browser-based investigation on the Linear issue found bursts *suppress* the bug in a real browser. Not a contradiction — the harness does not model WooCommerce aborting in-flight `update_order_review` XHRs, which is what collapses a real burst into a single late update. It is a harsher variant, not a refutation.
* The harness is a scratch tool and is not committed.

### Follow-ups (not in this PR)

* **SQUARE-301** is the same *class* of bug (duplication across `updated_checkout` cycles) on the gift card path.
* `src/blocks/credit-card/square-web-payments-form.js` has a narrower version of the same pattern — `card` state is set after the `await`, and `postalCode` is an effect dependency. React-guarded and not what was reported, but worth its own ticket.
* The issue title and description should drop "in Chrome"; it misdirects.

### Changelog entry

> Fix - Prevent a second Square credit card field from being rendered when a checkout update is triggered while the payment form is still initializing.
