### PR TITLE
Update php_codesniffer to 3.13.6 and woocommerce-sniffs to 1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 		"apimatic/core": "0.3.14"
 	},
 	"require-dev": {
-		"woocommerce/woocommerce-sniffs": "1.0.0",
+		"woocommerce/woocommerce-sniffs": "^1.0.1",
 		"sirbrillig/phpcs-changed": "^2.11.1",
 		"phpunit/phpunit": "^9.6",
 		"yoast/phpunit-polyfills": "^2.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e85dabac71439e27ac0fb3b2298194c8",
+    "content-hash": "9d098c2cefd8b6869c4ebf66b57da2c8",
     "packages": [
         {
             "name": "apimatic/core",
@@ -2673,16 +2673,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.5",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
-                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -2748,7 +2748,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-04T16:30:35+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2802,16 +2802,16 @@
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
-                "reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8"
+                "reference": "e6da0c372573724806b270ec1d5d94988b8aec52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
-                "reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/e6da0c372573724806b270ec1d5d94988b8aec52",
+                "reference": "e6da0c372573724806b270ec1d5d94988b8aec52",
                 "shasum": ""
             },
             "require": {
@@ -2835,9 +2835,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
-                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/1.0.0"
+                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/1.0.1"
             },
-            "time": "2023-09-29T13:52:33+00:00"
+            "time": "2025-09-03T13:34:27+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2979,5 +2979,5 @@
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Bumps the `squizlabs/php_codesniffer` dev dependency from **3.13.5** to **3.13.6** to pick up the fix for security advisory [GHSA-hmqg-cxww-wqhq](https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg-cxww-wqhq) (CVSS 7.3 – command injection in the `Gitblame`/`Hgblame`/`Svnblame` report formatters when scanning filenames that contain shell metacharacters).

- Bumps `woocommerce/woocommerce-sniffs` from **1.0.0** to **1.0.1**.
- `php_codesniffer` is a transitive `require-dev` dependency (pulled via `woocommerce/woocommerce-sniffs` and the `phpcsstandards/*` packages), so no `composer.json` constraint change is needed. Composer already resolves to the highest patched 3.x release.
- **No runtime or backward-compatibility impact.** This is a development-only tool, not part of the distributed plugin build. The plugin ships nothing from `vendor/` dev dependencies.

Closes #

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Check out this branch and run `composer install`.
1. Confirm the patched version is installed: `./vendor/bin/phpcs --version` → reports `3.13.6`.
1. Confirm no vulnerabilities remain: `composer audit` → "No security vulnerability advisories found."
1. Confirm linting still works with the project ruleset: `./vendor/bin/phpcs --standard=phpcs.xml.dist <file>` runs without ruleset/config errors.
1. Confirm `composer validate --strict --no-check-all` passes.

### Changelog entry

> Dev - Update PHP_CodeSniffer to 3.13.6 and WooCommerce Sniffs to 1.0.1.

Closes #533