### PR TITLE
Compatibility testing with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic
 Tags: credit card, square, woocommerce, inventory sync
 Requires at least: 6.9
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 5.4.3
 License: GPL-3.0-or-later

--- a/src/js/admin/wc-square-admin-products.js
+++ b/src/js/admin/wc-square-admin-products.js
@@ -67,7 +67,7 @@ jQuery( document ).ready( ( $ ) => {
 		// when clicking the quick edit button fetch the default Synced with Square checkbox
 		$( '#the-list' ).on( 'click', '.editinline', ( e ) => {
 			const $row = $( e.target ).closest( 'tr' );
-			const postID = $row.find( 'th.check-column input' ).val();
+			const postID = $row.find( '.check-column input' ).val();
 			const data = {
 				action: 'wc_square_get_quick_edit_product_details',
 				security: wc_square_admin_products.get_quick_edit_product_details_nonce,

--- a/tests/e2e/specs/d9.order-sync-fulfillment.spec.js
+++ b/tests/e2e/specs/d9.order-sync-fulfillment.spec.js
@@ -111,6 +111,7 @@ test.describe('Order Sync and Fulfillment Tests @sync', () => {
 		// Step 9: Update the order state and fulfillment states to completed using API.
 		await page.goto('/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending');
 		if (squareOrderId && process.env.SQUARE_ACCESS_TOKEN) {
+			await page.waitForTimeout( 2000 );
 			try {
 				// To update the order state, Square API requires the 'version' field in the order object.
 				// All fulfillments must have a state of COMPLETED, CANCELED, or FAILED before the order can be completed.
@@ -172,6 +173,7 @@ test.describe('Order Sync and Fulfillment Tests @sync', () => {
 		// Step 10: Run the Square sync action.
 		if (squareOrderId) {
 			try {
+				await page.waitForTimeout( 2000 );
 				await runScheduledAction(page, 'wc_square_sync_orders');
 				console.log('Successfully ran Square sync action');
 			} catch (error) {
@@ -180,10 +182,20 @@ test.describe('Order Sync and Fulfillment Tests @sync', () => {
 		}
 
 		// Step 11: Verify the order status is completed.
-		await gotoOrderEditPage( page, orderId );
-		const updatedOrderStatus = await page.locator('#order_status').inputValue();
-		expect(updatedOrderStatus).toBe('wc-completed');
-		console.log(`Order status is (expected: wc-completed): ${updatedOrderStatus}`);
+		let count = 0;
+		let updatedOrderStatus = null;
+		while ( updatedOrderStatus !== 'wc-completed' && count < 5 ) {
+			await page.waitForTimeout( 1000 );
+			await gotoOrderEditPage( page, orderId );
+			updatedOrderStatus = await page
+				.locator( '#order_status' )
+				.inputValue();
+			count++;
+		}
+		expect( updatedOrderStatus ).toBe( 'wc-completed' );
+		console.log(
+			`Order status is (expected: wc-completed): ${ updatedOrderStatus }`
+		);
 
 		console.log('PASSED: Action Scheduler and sync infrastructure verified');
 	});

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -684,7 +684,7 @@ export async function completePreOrder(page, orderId) {
 	await page.goto(`/wp-admin/admin.php?page=wc_pre_orders`);
 	await page
 		.locator(
-			`#the-list th.check-column input[name="order_id[]"][value="${orderId}"]`
+			`#the-list .check-column input[name="order_id[]"][value="${orderId}"]`
 		)
 		.check();
 	await page.locator('#bulk-action-selector-top').selectOption('complete');

--- a/tests/e2e/utils/helper.js
+++ b/tests/e2e/utils/helper.js
@@ -783,7 +783,7 @@ export async function runScheduledAction(
 		'wp-admin/tools.php?page=action-scheduler&status=pending&s=' + action
 	);
 
-	const actionLocator = page.getByRole( 'cell', { name: action } ).first();
+	const actionLocator = page.getByRole( 'rowheader', { name: action } ).first();
 	if ( ! ( await actionLocator.isVisible() ) ) {
 		return;
 	}

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -5,7 +5,7 @@
  * Version: 5.4.3
  * Plugin URI: https://woocommerce.com/products/square/
  * Requires at least: 6.9
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * Requires PHP: 7.4
  * PHP tested up to: 8.4
  *


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [ ] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://linear.app/a8c/issue/SQUARE-378/compatibility-testing-with-wordpress-71-rc

### Steps to test the changes in this Pull Request:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Run the e2e test using GitHub action to test this PR.
2. Overall plugin functionality


### Changelog entry
<!-- 
Each line should start with change type prefix`(Add|Fix|Dev) - `.
If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.
Add the `changelog: none` label if no changelog entry is needed.
-->

> Dev- Bump WordPress "Tested up to" to 7.1