### PR TITLE
Prevent product sync from getting stuck when a product set to sync with Square is deleted.

### DIFF
--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1034,13 +1034,6 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$result = $this->upsert_catalog_objects( $catalog_objects, true );
 
-		// Track products that no longer resolve to a WC_Product (deleted mid-sync). They are already
-		// recorded with a dedicated "excluded from sync" alert inside upsert_catalog_objects(), so
-		// accumulate them across batches and keep them out of the "could not be updated" report below
-		// - a deletion should not be surfaced as an update failure.
-		$missing_product_ids = array_values( array_unique( array_merge( $this->get_attr( 'upsert_missing_product_ids', array() ), $result['missing'] ?? array() ) ) );
-		$this->set_attr( 'upsert_missing_product_ids', $missing_product_ids );
-
 		// Push inventory inline immediately after each upsert batch when inventory sync is enabled.
 		// This ensures products don't sit in Square with zero inventory if the sync fails before
 		// the deferred push_inventory step runs. Only IDs whose inline push failed are queued for
@@ -1067,6 +1060,7 @@ class Manual_Synchronization extends Stepped_Job {
 			// at this point, log a failure for any products that weren't processed. Products deleted
 			// mid-sync are excluded - they already have their own "excluded from sync" alert and were
 			// never processable, so reporting them as update failures would be misleading.
+			$missing_product_ids = $this->get_attr( 'upsert_missing_product_ids', array() );
 			foreach ( array_diff( $all_product_ids, $processed_product_ids, $missing_product_ids ) as $product_id ) {
 				Records::set_record(
 					array(
@@ -1115,7 +1109,6 @@ class Manual_Synchronization extends Stepped_Job {
 			'in_progress_upsert_catalog_objects',
 			array(
 				'staged_product_ids'                => array(),
-				'missing_product_ids'               => array(),
 				'unprocessed_upsert_response'       => null,
 				'mapped_client_item_ids'            => array(),
 				'processed_remote_catalog_item_ids' => array(),
@@ -1123,10 +1116,11 @@ class Manual_Synchronization extends Stepped_Job {
 		);
 
 		// Product IDs that no longer resolve to a WC_Product (e.g. permanently deleted mid-sync).
-		// Tracked so they can be dropped from the unprocessed set below, otherwise they would be
-		// re-queued forever and the sync step would never complete. Restored from in-progress data
-		// so a resumed run (which skips the staging loop) still excludes them.
-		$missing_product_ids = $in_progress['missing_product_ids'] ?? array();
+		// Tracked in a job-level attribute so they can be dropped from the unprocessed set below,
+		// otherwise they would be re-queued forever and the sync step would never complete. The set
+		// is cumulative across batches, sync steps (update_matched_products, search_matched_products,
+		// upsert_new_products), retries, and resumed runs, so each product is handled exactly once.
+		$missing_product_ids = $this->get_attr( 'upsert_missing_product_ids', array() );
 
 		$upsert_response = null;
 		if ( ! empty( $in_progress['unprocessed_upsert_response'] ) ) {
@@ -1148,11 +1142,14 @@ class Manual_Synchronization extends Stepped_Job {
 				$product = wc_get_product( $product_id );
 
 				if ( ! $product instanceof \WC_Product ) {
-					// Product is gone (e.g. permanently deleted mid-sync). Mark it missing so it drops
-					// out of the unprocessed set and the step can complete rather than re-queueing it
-					// forever. Logged and recorded once per product (and not repeated on a resumed run).
+					// Product is gone (e.g. permanently deleted mid-sync). Record it in the job-level
+					// missing set so it drops out of the unprocessed set and the step can complete rather
+					// than re-queueing it forever. The set is persisted and cumulative, so the guard also
+					// ensures the log entry and merchant-facing alert fire exactly once per product per
+					// job even if it is encountered again in a later step, a retried batch, or a resume.
 					if ( ! in_array( $product_id, $missing_product_ids, true ) ) {
 						$missing_product_ids[] = $product_id;
+						$this->set_attr( 'upsert_missing_product_ids', $missing_product_ids );
 
 						wc_square()->log( 'Skipping product #' . $product_id . ' during upsert - it no longer exists (may have been deleted).' );
 
@@ -1237,7 +1234,6 @@ class Manual_Synchronization extends Stepped_Job {
 			}
 
 			$in_progress['staged_product_ids']          = $staged_product_ids;
-			$in_progress['missing_product_ids']         = $missing_product_ids;
 			$in_progress['unprocessed_upsert_response'] = wp_json_encode( $upsert_response, JSON_PRETTY_PRINT );
 			$this->set_attr( 'in_progress_upsert_catalog_objects', $in_progress );
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -109,6 +109,16 @@ class Manual_Synchronization extends Stepped_Job {
 			foreach ( $unsupported_product_ids as $matched_product_id ) {
 				$product = wc_get_product( $matched_product_id );
 				if ( ! $product instanceof \WC_Product ) {
+					Records::set_record(
+						array(
+							'type'    => 'alert',
+							'message' => sprintf(
+								/* translators: %1$s - Product ID. */
+								__( 'Product ID (%1$s) is excluded from sync as the product not found.', 'woocommerce-square' ),
+								$matched_product_id,
+							),
+						)
+					);
 					continue;
 				}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1102,7 +1102,6 @@ class Manual_Synchronization extends Stepped_Job {
 		$result                    = array(
 			'processed'   => array(),
 			'unprocessed' => $product_ids,
-			'missing'     => array(),
 		);
 
 		$in_progress = $this->get_attr(
@@ -1192,7 +1191,6 @@ class Manual_Synchronization extends Stepped_Job {
 				$this->set_attr( 'in_progress_upsert_catalog_objects', null );
 
 				$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );
-				$result['missing']     = $missing_product_ids;
 
 				return $result;
 			}
@@ -1375,10 +1373,9 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$result['processed'] = $staged_product_ids;
 		// Exclude missing products (deleted mid-sync) from unprocessed so callers do not re-queue
-		// them indefinitely, which would keep the sync step from ever completing. They are also
-		// returned so callers can tell "deleted" apart from "failed to update".
+		// them indefinitely, which would keep the sync step from ever completing. The IDs themselves
+		// are tracked in the upsert_missing_product_ids job attribute for callers that need them.
 		$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );
-		$result['missing']     = $missing_product_ids;
 
 		return $result;
 	}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1105,11 +1105,18 @@ class Manual_Synchronization extends Stepped_Job {
 			'in_progress_upsert_catalog_objects',
 			array(
 				'staged_product_ids'                => array(),
+				'missing_product_ids'               => array(),
 				'unprocessed_upsert_response'       => null,
 				'mapped_client_item_ids'            => array(),
 				'processed_remote_catalog_item_ids' => array(),
 			)
 		);
+
+		// Product IDs that no longer resolve to a WC_Product (e.g. permanently deleted mid-sync).
+		// Tracked so they can be dropped from the unprocessed set below, otherwise they would be
+		// re-queued forever and the sync step would never complete. Restored from in-progress data
+		// so a resumed run (which skips the staging loop) still excludes them.
+		$missing_product_ids = $in_progress['missing_product_ids'] ?? array();
 
 		$upsert_response = null;
 		if ( ! empty( $in_progress['unprocessed_upsert_response'] ) ) {
@@ -1131,6 +1138,14 @@ class Manual_Synchronization extends Stepped_Job {
 				$product = wc_get_product( $product_id );
 
 				if ( ! $product instanceof \WC_Product ) {
+					// Product is gone (e.g. permanently deleted mid-sync). Mark it missing so it drops
+					// out of the unprocessed set and the step can complete rather than re-queueing it
+					// forever. Logged once per product (and not re-logged on a resumed run).
+					if ( ! in_array( $product_id, $missing_product_ids, true ) ) {
+						$missing_product_ids[] = $product_id;
+
+						wc_square()->log( 'Skipping product #' . $product_id . ' during upsert - it no longer exists (may have been deleted).' );
+					}
 					continue;
 				}
 
@@ -1147,6 +1162,18 @@ class Manual_Synchronization extends Stepped_Job {
 				} else {
 					break;
 				}
+			}
+
+			// If nothing could be staged (e.g. every product in this batch was deleted mid-sync),
+			// there is nothing to send to Square. Clear progress and return early so the missing IDs
+			// are excluded from unprocessed and the step can complete instead of looping on an empty
+			// upsert request.
+			if ( empty( $batches ) ) {
+				$this->set_attr( 'in_progress_upsert_catalog_objects', null );
+
+				$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );
+
+				return $result;
 			}
 
 			try {
@@ -1186,6 +1213,7 @@ class Manual_Synchronization extends Stepped_Job {
 			}
 
 			$in_progress['staged_product_ids']          = $staged_product_ids;
+			$in_progress['missing_product_ids']         = $missing_product_ids;
 			$in_progress['unprocessed_upsert_response'] = wp_json_encode( $upsert_response, JSON_PRETTY_PRINT );
 			$this->set_attr( 'in_progress_upsert_catalog_objects', $in_progress );
 
@@ -1326,7 +1354,9 @@ class Manual_Synchronization extends Stepped_Job {
 		$this->set_attr( 'in_progress_upsert_catalog_objects', null );
 
 		$result['processed']   = $staged_product_ids;
-		$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids );
+		// Exclude missing products (deleted mid-sync) from unprocessed so callers do not re-queue
+		// them indefinitely, which would keep the sync step from ever completing.
+		$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );
 
 		return $result;
 	}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -114,7 +114,7 @@ class Manual_Synchronization extends Stepped_Job {
 							'type'    => 'alert',
 							'message' => sprintf(
 								/* translators: %1$s - Product ID. */
-								__( 'Product ID (%1$s) is excluded from sync as the product not found.', 'woocommerce-square' ),
+								__( 'Product ID (%1$s) is excluded from sync because the product could not be found.', 'woocommerce-square' ),
 								$matched_product_id,
 							),
 						)
@@ -1353,7 +1353,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$this->set_attr( 'in_progress_upsert_catalog_objects', null );
 
-		$result['processed']   = $staged_product_ids;
+		$result['processed'] = $staged_product_ids;
 		// Exclude missing products (deleted mid-sync) from unprocessed so callers do not re-queue
 		// them indefinitely, which would keep the sync step from ever completing.
 		$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -108,7 +108,11 @@ class Manual_Synchronization extends Stepped_Job {
 
 			foreach ( $unsupported_product_ids as $matched_product_id ) {
 				$product = wc_get_product( $matched_product_id );
-				$type    = $product->get_type();
+				if ( ! $product instanceof \WC_Product ) {
+					continue;
+				}
+
+				$type = $product->get_type();
 
 				Records::set_record(
 					array(
@@ -1114,7 +1118,12 @@ class Manual_Synchronization extends Stepped_Job {
 					$object = $this->convert_to_catalog_object( $object );
 				}
 
-				$product                                  = wc_get_product( $product_id );
+				$product = wc_get_product( $product_id );
+
+				if ( ! $product instanceof \WC_Product ) {
+					continue;
+				}
+
 				$original_square_image_ids[ $product_id ] = $product->get_meta( '_square_item_image_id' );
 
 				$catalog_item = new Catalog_Item( $product, $is_delete_action );

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1034,6 +1034,13 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$result = $this->upsert_catalog_objects( $catalog_objects, true );
 
+		// Track products that no longer resolve to a WC_Product (deleted mid-sync). They are already
+		// recorded with a dedicated "excluded from sync" alert inside upsert_catalog_objects(), so
+		// accumulate them across batches and keep them out of the "could not be updated" report below
+		// - a deletion should not be surfaced as an update failure.
+		$missing_product_ids = array_values( array_unique( array_merge( $this->get_attr( 'upsert_missing_product_ids', array() ), $result['missing'] ?? array() ) ) );
+		$this->set_attr( 'upsert_missing_product_ids', $missing_product_ids );
+
 		// Push inventory inline immediately after each upsert batch when inventory sync is enabled.
 		// This ensures products don't sit in Square with zero inventory if the sync fails before
 		// the deferred push_inventory step runs. Only IDs whose inline push failed are queued for
@@ -1057,8 +1064,10 @@ class Manual_Synchronization extends Stepped_Job {
 		// if all products were processed, move on.
 		if ( empty( $updated_product_ids ) ) {
 			$all_product_ids = $this->get_attr( 'validated_product_ids', array() );
-			// at this point, log a failure for any products that weren't processed.
-			foreach ( array_diff( $all_product_ids, $processed_product_ids ) as $product_id ) {
+			// at this point, log a failure for any products that weren't processed. Products deleted
+			// mid-sync are excluded - they already have their own "excluded from sync" alert and were
+			// never processable, so reporting them as update failures would be misleading.
+			foreach ( array_diff( $all_product_ids, $processed_product_ids, $missing_product_ids ) as $product_id ) {
 				Records::set_record(
 					array(
 						'type'       => 'info',
@@ -1099,6 +1108,7 @@ class Manual_Synchronization extends Stepped_Job {
 		$result                    = array(
 			'processed'   => array(),
 			'unprocessed' => $product_ids,
+			'missing'     => array(),
 		);
 
 		$in_progress = $this->get_attr(
@@ -1140,11 +1150,24 @@ class Manual_Synchronization extends Stepped_Job {
 				if ( ! $product instanceof \WC_Product ) {
 					// Product is gone (e.g. permanently deleted mid-sync). Mark it missing so it drops
 					// out of the unprocessed set and the step can complete rather than re-queueing it
-					// forever. Logged once per product (and not re-logged on a resumed run).
+					// forever. Logged and recorded once per product (and not repeated on a resumed run).
 					if ( ! in_array( $product_id, $missing_product_ids, true ) ) {
 						$missing_product_ids[] = $product_id;
 
 						wc_square()->log( 'Skipping product #' . $product_id . ' during upsert - it no longer exists (may have been deleted).' );
+
+						// No product_id on the record: the post is gone, so a product-scoped record would
+						// render an empty edit link. Reuses the validate path's translation entry.
+						Records::set_record(
+							array(
+								'type'    => 'alert',
+								'message' => sprintf(
+									/* translators: %1$s - Product ID. */
+									__( 'Product ID (%1$s) is excluded from sync because the product could not be found.', 'woocommerce-square' ),
+									$product_id
+								),
+							)
+						);
 					}
 					continue;
 				}
@@ -1172,6 +1195,7 @@ class Manual_Synchronization extends Stepped_Job {
 				$this->set_attr( 'in_progress_upsert_catalog_objects', null );
 
 				$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );
+				$result['missing']     = $missing_product_ids;
 
 				return $result;
 			}
@@ -1355,8 +1379,10 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$result['processed'] = $staged_product_ids;
 		// Exclude missing products (deleted mid-sync) from unprocessed so callers do not re-queue
-		// them indefinitely, which would keep the sync step from ever completing.
+		// them indefinitely, which would keep the sync step from ever completing. They are also
+		// returned so callers can tell "deleted" apart from "failed to update".
 		$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids, $missing_product_ids );
+		$result['missing']     = $missing_product_ids;
 
 		return $result;
 	}


### PR DESCRIPTION
### All Submissions:

<!-- Mark completed items with an [x] -->
* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:
Product sync could fatal and get stuck when a product set to sync with Square no longer exists. When the sync job processed an ID that `wc_get_product()` could not resolve, the code called methods on the result (`get_type()`, `get_meta()`), causing a fatal error that halted the job and blocked the sync queue.

This handles the missing-product case at both points where it can occur:

- **`validate_products()`** — covers a product that is already gone when the sync starts. The ID is skipped (with a merchant-facing alert) instead of reading its type.
- **`upsert_catalog_objects()`** — covers a product that still existed at validation time but is permanently deleted **while a long sync is running** (the job is stepped/batched across many background runs, so there is a real window between validating an ID and upserting it). Because `upsert_new_products()` builds its batch from the validated IDs without re-fetching, this is where a mid-sync deletion surfaces.

Rather than only skipping the missing product in `upsert_catalog_objects()` (which would leave it in the "unprocessed" set forever and keep the sync step from ever completing), the missing IDs are tracked and excluded from the unprocessed set so the step can finish. The tracking is stored with the in-progress upsert data so a resumed run still excludes them, and an empty batch (every product in it deleted) is short-circuited instead of sending an empty request to Square. Each skipped product is logged once for troubleshooting.

**Backward compatibility:** No BC impact — the changes are internal guards and bookkeeping inside two `protected` methods; no public signature, hook, template, option, or REST contract is affected.

### Steps to test the changes in this Pull Request:

**A. Product already deleted before sync (validate path)**
1. Connect the store to Square with product sync enabled (WooCommerce as the system of record).
1. Create/sync a product so it is set to sync with Square, then permanently delete it (Trash → Delete permanently).
1. Confirm the sync completes without a fatal error and the queue is not stuck, and an alert appears on the sync screen noting the product was excluded because it no longer exists. (Currently sync get stuck on `trunk` branch).

**B. Product deleted while a sync is running (upsert path)**
1. With product sync enabled, start a sync by clicking a "Sync now"(a larger batch makes the window easier to hit).
1. While the sync is in progress, permanently delete one of the products being synced.
1. Let the sync run to completion.
1. Confirm the sync finishes without a fatal error and the remaining products sync successfully — rather than the sync stalling or re-running the same step indefinitely. The skipped product is noted once in the Square debug log (WooCommerce → Status → Logs, `wc-square` handle).

### Changelog entry

> Fix - Prevent product sync from getting stuck when a product set to sync with Square is deleted.

Closes #539