### PR TITLE
Skip products that Square rejects so one product cannot fail the whole sync

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -662,6 +662,31 @@ class API extends Base {
 	}
 
 	/**
+	 * Determines whether an option creation failure means the cached options data is stale.
+	 *
+	 * Only a rejection saying the option or its value already exists in Square is worth replaying
+	 * the job for, because that is the one cause a refetch of the options data resolves. The
+	 * message is matched rather than the error code, since Square answers both the stale cache case
+	 * and a permanently invalid payload with the same INVALID_VALUE and BAD_REQUEST codes.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $message the message Square returned
+	 * @return bool
+	 */
+	protected function is_stale_options_cache_error( $message ) {
+
+		foreach ( array( 'already exists', 'existing item option' ) as $needle ) {
+			if ( false !== stripos( $message, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+	/**
 	 * Create options and values in Square.
 	 *
 	 * @since 4.9.0
@@ -747,16 +772,27 @@ class API extends Base {
 
 		} catch ( \Exception $e ) {
 			/**
-			 * if we encounter an error, mostly it would be because Option or its Value
-			 * already exists in Square. In such case, we need to refetch the latest data
-			 * and restart the Runner Job using `woocommerce_square_refresh_sync_cycle` option.
-			 * This is required to reactivate `fetch_all_options` step to get the latest data.
+			 * Replaying the whole job only helps when Square rejected this because the option or
+			 * value already exists, which means the cached options data is stale: refetching it and
+			 * running the cycle again resolves it.
+			 *
+			 * Any other rejection is permanent. An option payload Square considers invalid, such as
+			 * a value with no name because a variation attribute has no values selected, fails
+			 * identically on every replay, so asking for one burns the retry budget and then fails
+			 * the whole sync over one product. Leaving the flag alone lets the caller's own error
+			 * handling skip that product and carry on.
 			 */
-			update_option( 'woocommerce_square_refresh_sync_cycle', true );
+			if ( $this->is_stale_options_cache_error( $e->getMessage() ) ) {
+				update_option( 'woocommerce_square_refresh_sync_cycle', true );
+
+				wc_square()->log( sprintf( 'Resetting the Sync Job. Failed to create option in Square: %s. The system will refetch latest Options from Square.', $e->getMessage() ) );
+			} else {
+				wc_square()->log( sprintf( 'Failed to create option in Square: %s. Not replaying the job: this does not indicate stale options data.', $e->getMessage() ) );
+			}
+
+			// Refetched next time round either way, since the cache may be incomplete.
 			delete_transient( 'wc_square_options_data' );
 
-			// Log the error and throw it.
-			wc_square()->log( sprintf( 'Resetting the Sync Job. Failed to create option in Square: %s. The system will refetch latest Options from Square.', $e->getMessage() ) );
 			throw $e;
 		}
 

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -35,12 +35,13 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 	 * @param CatalogObject $catalog_object Square SDK catalog object
 	 * @param \WC_Product $product WooCommerce product
 	 * @return CatalogObject
-	 * @throws \Exception
+	 * @throws \InvalidArgumentException when the catalog object is not an ITEM
+	 * @throws \Exception on Square API failures while resolving item options
 	 */
 	public static function update_catalog_item( CatalogObject $catalog_object, \WC_Product $product ) {
 
 		if ( 'ITEM' !== $catalog_object->getType() || ! $catalog_object->getItemData() ) {
-			throw new \Exception( 'Type of $catalog_object must be an ITEM' );
+			throw new \InvalidArgumentException( 'Type of $catalog_object must be an ITEM' );
 		}
 
 		// ensure the product meta is persisted
@@ -261,12 +262,13 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 	 * @param array         $options_ids    Array of options IDs
 	 *
 	 * @return CatalogObject
-	 * @throws \Exception
+	 * @throws \InvalidArgumentException when the catalog object is not an ITEM_VARIATION
+	 * @throws \Exception on Square API failures while resolving item options
 	 */
 	public static function update_catalog_variation( CatalogObject $catalog_object, \WC_Product $product, $options_ids = array() ) {
 
 		if ( 'ITEM_VARIATION' !== $catalog_object->getType() || ! $catalog_object->getItemVariationData() ) {
-			throw new \Exception( 'Type of $catalog_object must be an ITEM_VARIATION' );
+			throw new \InvalidArgumentException( 'Type of $catalog_object must be an ITEM_VARIATION' );
 		}
 
 		// ensure the variation meta is persisted

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -347,7 +347,9 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 
 					$option_id       = '';
 					$option_value_id = '';
-					if ( isset( $options_data[ $options_ids[ $variation_index ] ] ) ) {
+					// $options_ids is short, or empty, whenever an option could not be created for this
+					// product. Guarding the index keeps that from emitting a warning per variation.
+					if ( isset( $options_ids[ $variation_index ], $options_data[ $options_ids[ $variation_index ] ] ) ) {
 						$option_id = $options_ids[ $variation_index ];
 
 						foreach ( $options_data[ $options_ids[ $variation_index ] ]['value_ids'] as $value_id => $value_name ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -52,6 +52,52 @@ class Manual_Synchronization extends Stepped_Job {
 	/** @var int the limit for how many inventory changes can be made in a single request */
 	const BATCH_CHANGE_INVENTORY_LIMIT = 100;
 
+	/**
+	 * Square error codes that mean "this object's own data is invalid", and nothing else.
+	 *
+	 * Skipping an object has to be opted into by a known data error, never assumed: anything not
+	 * listed here fails the job instead, because a server error, timeout or permission problem may
+	 * have applied the write already and re-sending would duplicate it in Square. Codes come from
+	 * \Square\Models\ErrorCode. Filterable via wc_square_isolatable_error_codes.
+	 *
+	 * Before removing a code from this list because it produced a bad skip: some codes are
+	 * deliberately listed here and narrowed by a second gate at the call site, because Square
+	 * reuses one code for both an object level problem and a job level one. Removing the code
+	 * disables the object level handling and does not fix the job level case.
+	 *
+	 * - NOT_FOUND is both a stale catalog mapping and a location that does not belong to the
+	 *   account. push_inventory_changes_isolated() drops nothing unless Square named an object
+	 *   present in the chunk.
+	 * - INVALID_VALUE is both bad product data and an item option name collision, which
+	 *   API::create_options_and_values() turns into a whole job replay. The staging catch in
+	 *   upsert_catalog_objects() snapshots woocommerce_square_refresh_sync_cycle and rethrows
+	 *   when it changed.
+	 *
+	 * @var string[]
+	 */
+	const ISOLATABLE_ERROR_CODES = array(
+		'BAD_REQUEST',
+		'MISSING_REQUIRED_PARAMETER',
+		'INCORRECT_TYPE',
+		'INVALID_VALUE',
+		'INVALID_ENUM_VALUE',
+		'INVALID_ARRAY_VALUE',
+		'INVALID_TIME',
+		'VALUE_EMPTY',
+		'VALUE_TOO_LONG',
+		'VALUE_TOO_SHORT',
+		'VALUE_TOO_LOW',
+		'VALUE_TOO_HIGH',
+		'VALUE_REGEX_MISMATCH',
+		'ARRAY_EMPTY',
+		'ARRAY_LENGTH_TOO_LONG',
+		'ARRAY_LENGTH_TOO_SHORT',
+		'UNPROCESSABLE_ENTITY',
+		'REQUEST_ENTITY_TOO_LARGE', // the combined request was too big; one object per request is the fix.
+		'NOT_FOUND',
+		'CONFLICT',
+	);
+
 	/** @var int max SKU-based lookups per push_inventory step to avoid rate limits */
 	const MAX_SKU_LOOKUPS_PER_PUSH_STEP = 20;
 
@@ -1311,6 +1357,85 @@ class Manual_Synchronization extends Stepped_Job {
 
 		return $result;
 	}
+
+	/**
+	 * Determines whether an exception message carries a Square API error code.
+	 *
+	 * Plugin level validation failures (an invalid product, a catalog object of the wrong type)
+	 * carry no code; anything Square rejected does, because
+	 * API::do_post_parse_response_validation() formats every error as "[CODE] detail".
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Exception $exception the caught exception
+	 * @return bool
+	 */
+	protected function has_square_error_code( \Exception $exception ) {
+
+		return (bool) preg_match( '/(^|\| )\[[A-Z][A-Z0-9_]*\]/', $exception->getMessage() );
+	}
+
+
+	/**
+	 * Classifies a sync exception to decide how the sync should react to it.
+	 *
+	 * - rate_limited: throttling, safe to retry the same request unchanged (existing behavior).
+	 * - isolatable: Square understood the request and rejected this object because its data is
+	 *   invalid. The same request will keep failing, so the object can be skipped and the sync can
+	 *   continue without it (SQUARE-143 / SQUARE-31).
+	 * - fatal: anything else. The write may or may not have been applied, so the job must fail
+	 *   loudly instead of isolating: re-sending the staged objects under fresh temporary IDs would
+	 *   create duplicate catalog items in Square.
+	 *
+	 * Skipping an object has to be opted into by a known data error, never assumed. A deny list
+	 * would classify server errors, timeouts and permission problems as bad product data.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Exception $exception the caught exception
+	 * @return string rate_limited|isolatable|fatal
+	 */
+	protected function classify_sync_error( \Exception $exception ) {
+
+		/**
+		 * Filters the Square error codes that allow one object to be skipped so the sync continues.
+		 *
+		 * Adding a code here makes the sync skip the offending product or category on that error
+		 * instead of failing the job. Only add codes that mean the object's own data is invalid:
+		 * on anything else the write may already have been applied, and retrying the objects
+		 * individually would create duplicates in Square.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string[] $codes Square error codes treated as an object level data problem
+		 * @param \Exception $exception the exception being classified
+		 */
+		$isolatable_codes = (array) apply_filters( 'wc_square_isolatable_error_codes', self::ISOLATABLE_ERROR_CODES, $exception );
+
+		// API::do_post_parse_response_validation() builds the message as "[CODE] detail" per error,
+		// joined with " | ", so a code only ever appears at the start of a segment. Anchoring there
+		// keeps bracketed text inside a detail out of the classification, whether that is a JSON
+		// path Square wrote ("Value at `variations[0].sku`") or a merchant's own product name.
+		$codes = array();
+		foreach ( explode( ' | ', $exception->getMessage() ) as $segment ) {
+			if ( preg_match( '/^\[([A-Z][A-Z0-9_]*)\]/', trim( $segment ), $matches ) ) {
+				$codes[] = $matches[1];
+			}
+		}
+
+		if ( in_array( 'RATE_LIMITED', $codes, true ) ) {
+			return 'rate_limited';
+		}
+
+		// Every reported code must be a known data error before the object is skipped: a response
+		// mixing a data error with a server error may still have been partly applied.
+		if ( ! empty( $codes ) && ! array_diff( $codes, $isolatable_codes ) ) {
+			return 'isolatable';
+		}
+
+		return 'fatal';
+	}
+
 
 	/**
 	 * Converts object data to an instance of CatalogObject.

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1135,11 +1135,16 @@ class Manual_Synchronization extends Stepped_Job {
 		// This ensures products don't sit in Square with zero inventory if the sync fails before
 		// the deferred push_inventory step runs. Only IDs whose inline push failed are queued for
 		// the deferred step - successful pushes are not re-queued to avoid double-counting.
-		if ( wc_square()->get_settings_handler()->is_inventory_sync_enabled() && ! empty( $result['processed'] ) ) {
-			$failed_inventory_ids       = $this->push_inventory_for_products( $result['processed'] );
+		// Skipped products are consumed but were not upserted, so they are excluded here: pushing
+		// inventory for one would write stock against a stale mapping for a product whose catalog
+		// data Square just rejected, and would risk a second alert for the same product.
+		$upserted_product_ids = array_values( array_diff( $result['processed'], $result['skipped'] ?? array() ) );
+
+		if ( wc_square()->get_settings_handler()->is_inventory_sync_enabled() && ! empty( $upserted_product_ids ) ) {
+			$failed_inventory_ids       = $this->push_inventory_for_products( $upserted_product_ids );
 			$inventory_push_product_ids = array_merge( $failed_inventory_ids, $inventory_push_product_ids );
 		} else {
-			$inventory_push_product_ids = array_merge( $result['processed'], $inventory_push_product_ids );
+			$inventory_push_product_ids = array_merge( $upserted_product_ids, $inventory_push_product_ids );
 		}
 		$this->set_attr( 'inventory_push_product_ids', $inventory_push_product_ids );
 
@@ -1196,6 +1201,7 @@ class Manual_Synchronization extends Stepped_Job {
 		$result                    = array(
 			'processed'   => array(),
 			'unprocessed' => $product_ids,
+			'skipped'     => array(),
 		);
 		$isolated_fail_ids         = array();
 		$partial_error_detail      = '';
@@ -1346,6 +1352,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 				$result['processed']   = $staged_product_ids;
 				$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids );
+				$result['skipped']     = $isolated_fail_ids;
 
 				return $result;
 			}
@@ -1588,8 +1595,12 @@ class Manual_Synchronization extends Stepped_Job {
 
 		$this->set_attr( 'in_progress_upsert_catalog_objects', null );
 
+		// processed means consumed by this cycle, which includes the skipped products so the step
+		// queue advances past them. skipped is reported separately because a skipped product has no
+		// usable Square mapping from this cycle and must not be treated as successfully upserted.
 		$result['processed']   = $staged_product_ids;
 		$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids );
+		$result['skipped']     = $isolated_fail_ids;
 
 		return $result;
 	}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -519,6 +519,8 @@ class Manual_Synchronization extends Stepped_Job {
 							),
 						)
 					);
+					wc_square()->log( 'Skipped category "' . $term_name . '": ' . $category_exception->getMessage() );
+
 					// Deferred like record_skipped_product(); complete_step() below persists it.
 					$this->set_attr( 'sync_error_count', (int) $this->get_attr( 'sync_error_count', 0 ) + 1, false );
 				}

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -471,40 +471,102 @@ class Manual_Synchronization extends Stepped_Job {
 			$batches[] = new \Square\Models\CatalogObjectBatch( array( $catalog_object ) );
 		}
 
-		foreach ( array_chunk( $batches, $this->get_max_objects_per_upsert() ) as $batch ) {
-			$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $batch ) . $this->get_attr( 'id' ) ) . '_upsert_categories' );
-			$result          = wc_square()->get_api()->batch_upsert_catalog_objects( $idempotency_key, $batch );
+		foreach ( array_chunk( $batches, $this->get_max_objects_per_upsert() ) as $chunk ) {
 
-			if ( ! $result->get_data() instanceof BatchUpsertCatalogObjectsResponse ) {
-				throw new \Exception( 'Response data is invalid' );
-			}
+			try {
+				$this->upsert_category_batches( $chunk, $reverse_map );
+				continue;
+			} catch ( \Exception $chunk_exception ) {
 
-			$id_mappings = $result->get_data()->getIdMappings(); // new entries to Square will return in the ID Mapping.
-
-			if ( ! empty( $id_mappings ) ) {
-				foreach ( $id_mappings as $id_mapping ) {
-					$client_object_id = $id_mapping->getClientObjectId();
-					$remote_object_id = $id_mapping->getObjectId();
-
-					if ( isset( $reverse_map[ $client_object_id ] ) ) {
-						$reverse_map[ $remote_object_id ] = $reverse_map[ $client_object_id ];
-						unset( $reverse_map[ $client_object_id ] );
-					}
+				if ( 'isolatable' !== $this->classify_sync_error( $chunk_exception ) ) {
+					throw $chunk_exception;
 				}
+
+				// Each batch holds exactly one category, so a failing chunk can be isolated by
+				// retrying every batch on its own: the broken category is recorded and skipped,
+				// the rest sync normally (SQUARE-143 / SQUARE-31).
+				wc_square()->log( 'Category chunk upsert failed (' . $chunk_exception->getMessage() . '); retrying each category individually.' );
 			}
 
-			foreach ( $result->get_data()->getObjects() as $upserted_category ) {
-				$id      = $upserted_category->getId();
-				$version = $upserted_category->getVersion();
+			foreach ( $chunk as $single_batch ) {
+				try {
+					$this->upsert_category_batches( array( $single_batch ), $reverse_map );
+				} catch ( \Exception $category_exception ) {
 
-				if ( isset( $reverse_map[ $id ] ) ) {
-					Category::update_mapping( $reverse_map[ $id ], $id, $version );
-					unset( $reverse_map[ $id ] );
+					// Only a data level error is the category's own fault; auth fails the job and
+					// a rate limit bubbles to the existing job level retry and backoff.
+					if ( 'isolatable' !== $this->classify_sync_error( $category_exception ) ) {
+						throw $category_exception;
+					}
+
+					$term_name = __( 'unknown category', 'woocommerce-square' );
+					$objects   = $single_batch->getObjects();
+					if ( is_array( $objects ) && isset( $objects[0] ) && $objects[0]->getCategoryData() ) {
+						$term_name = $objects[0]->getCategoryData()->getName();
+					}
+
+					Records::set_record(
+						array(
+							'type'    => 'alert',
+							'message' => sprintf(
+								/* translators: Placeholders: %1$s - category name, %2$s - failure reason */
+								esc_html__( 'Category "%1$s" was skipped so the sync could continue. Reason: %2$s', 'woocommerce-square' ),
+								esc_html( $term_name ),
+								esc_html( $category_exception->getMessage() )
+							),
+						)
+					);
+					// Deferred like record_skipped_product(); complete_step() below persists it.
+					$this->set_attr( 'sync_error_count', (int) $this->get_attr( 'sync_error_count', 0 ) + 1, false );
 				}
 			}
 		}
 
 		$this->complete_step( 'upsert_categories' );
+	}
+
+	/**
+	 * Sends a set of category batches to Square and applies the returned mappings.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Square\Models\CatalogObjectBatch[] $category_batches batches to send (one category each)
+	 * @param array $reverse_map square id keyed map to local term ids, updated in place
+	 * @throws \Exception on API failure or invalid response
+	 */
+	protected function upsert_category_batches( array $category_batches, array &$reverse_map ) {
+
+		$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $category_batches ) . $this->get_attr( 'id' ) ) . '_upsert_categories' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$result          = wc_square()->get_api()->batch_upsert_catalog_objects( $idempotency_key, $category_batches );
+
+		if ( ! $result->get_data() instanceof BatchUpsertCatalogObjectsResponse ) {
+			throw new \Exception( 'Response data is invalid' );
+		}
+
+		$id_mappings = $result->get_data()->getIdMappings(); // new entries to Square will return in the ID Mapping.
+
+		if ( ! empty( $id_mappings ) ) {
+			foreach ( $id_mappings as $id_mapping ) {
+				$client_object_id = $id_mapping->getClientObjectId();
+				$remote_object_id = $id_mapping->getObjectId();
+
+				if ( isset( $reverse_map[ $client_object_id ] ) ) {
+					$reverse_map[ $remote_object_id ] = $reverse_map[ $client_object_id ];
+					unset( $reverse_map[ $client_object_id ] );
+				}
+			}
+		}
+
+		// null when the request produced no objects; never fatal on it
+		foreach ( is_array( $result->get_data()->getObjects() ) ? $result->get_data()->getObjects() : array() as $upserted_category ) {
+			$id      = $upserted_category->getId();
+			$version = $upserted_category->getVersion();
+
+			if ( isset( $reverse_map[ $id ] ) ) {
+				Category::update_mapping( $reverse_map[ $id ], $id, $version );
+				unset( $reverse_map[ $id ] );
+			}
+		}
 	}
 
 	/**

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1505,7 +1505,7 @@ class Manual_Synchronization extends Stepped_Job {
 			// If there is a local image which is different from the last uploaded image
 			// Or if the remote square image id has changed
 			if ( ( $local_image_id && $local_image_id !== $product->get_meta( '_square_uploaded_image_id' ) ) ||
-				( ! ( $original_square_image_ids[ $product_id ] && $original_square_image_ids[ $product_id ] === $product->get_meta( '_square_item_image_id' ) ) ) ) {
+				( ! ( ( $original_square_image_ids[ $product_id ] ?? '' ) && ( $original_square_image_ids[ $product_id ] ?? '' ) === $product->get_meta( '_square_item_image_id' ) ) ) ) {
 				// there is no batch image endpoint
 				$this->push_product_image( $product );
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -53,7 +53,10 @@ class Manual_Synchronization extends Stepped_Job {
 	const BATCH_CHANGE_INVENTORY_LIMIT = 100;
 
 	/** @var int maximum per product fallback upserts attempted within one step cycle */
-	const MAX_ISOLATED_UPSERTS_PER_CYCLE = 20;
+	const MAX_ISOLATED_UPSERTS_PER_CYCLE = 5;
+
+	/** @var int maximum rounds of dropping named objects from one inventory chunk before giving up */
+	const MAX_INVENTORY_ISOLATION_ROUNDS = 5;
 
 	/**
 	 * Square error codes that mean "this object's own data is invalid", and nothing else.
@@ -2201,8 +2204,11 @@ class Manual_Synchronization extends Stepped_Job {
 
 		foreach ( array_chunk( $inventory_changes, self::BATCH_CHANGE_INVENTORY_LIMIT ) as $chunk ) {
 
-			// A dropped dead object shrinks the chunk by one each round, so this terminates.
-			$attempts_left = count( $chunk ) + 1;
+			// Every round drops at least one change, so this terminates on its own. The round cap
+			// bounds the request count regardless: Square normally names every offending object in
+			// one response, so a chunk that needs more rounds than this is not behaving as expected
+			// and must not spend a whole step cycle discovering one object at a time.
+			$attempts_left = min( count( $chunk ) + 1, self::MAX_INVENTORY_ISOLATION_ROUNDS );
 
 			while ( ! empty( $chunk ) && $attempts_left > 0 ) {
 
@@ -2211,6 +2217,8 @@ class Manual_Synchronization extends Stepped_Job {
 				try {
 					$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $chunk ) ) . '_change_inventory' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 					wc_square()->get_api()->batch_change_inventory( $idempotency_key, $chunk );
+
+					$chunk = array(); // sent, so nothing in this chunk is left unaccounted for
 					break;
 				} catch ( \Exception $exception ) {
 
@@ -2265,6 +2273,16 @@ class Manual_Synchronization extends Stepped_Job {
 				}
 			}
 
+			// Rounds ran out with changes still unsent. Dropping them silently would lose real
+			// inventory updates for products Square never named as the problem, so fail loudly.
+			if ( ! empty( $chunk ) ) {
+				throw new \Exception(
+					esc_html(
+						'Gave up isolating inventory changes after ' . self::MAX_INVENTORY_ISOLATION_ROUNDS
+						. ' rounds with ' . count( $chunk ) . ' changes still unsent.'
+					)
+				);
+			}
 		}
 	}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2102,8 +2102,7 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( ! empty( $inventory_changes ) ) {
 
 			$inventory_changes = array_merge( ...$inventory_changes );
-			$idempotency_key   = wc_square()->get_idempotency_key( md5( serialize( $inventory_changes ) ) . '_change_inventory' );
-			$result            = wc_square()->get_api()->batch_change_inventory( $idempotency_key, $inventory_changes );
+			$this->push_inventory_changes_isolated( $inventory_changes );
 		}
 
 		$this->set_attr( 'inventory_push_product_ids', $product_ids );
@@ -2112,6 +2111,95 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( empty( $product_ids ) ) {
 
 			$this->complete_step( 'push_inventory' );
+		}
+	}
+
+	/**
+	 * Sends inventory changes to Square with per change isolation of dead catalog objects.
+	 *
+	 * A single change referencing a Square object that no longer exists (a stale local mapping
+	 * after a Square side catalog wipe) rejects the whole batch with NOT_FOUND, silently dropping
+	 * inventory for every other product in it. Square names the offending object in the error, so
+	 * the changes it names are removed, recorded, and the remainder is retried. Unattributable
+	 * failures skip only their own chunk and the sync continues (SQUARE-143 / SQUARE-31).
+	 *
+	 * The offending IDs are found by testing the chunk's own catalog object IDs against the error
+	 * text rather than by parsing an ID out of it. Square does not guarantee any particular
+	 * formatting and frequently quotes the JSON field path instead of the value, so parsing would
+	 * either extract a field name that matches nothing in the chunk, and drop up to 100 good
+	 * inventory updates, or extract nothing at all.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Square\Models\InventoryChange[] $inventory_changes the changes to push
+	 */
+	protected function push_inventory_changes_isolated( array $inventory_changes ) {
+
+		foreach ( array_chunk( $inventory_changes, self::BATCH_CHANGE_INVENTORY_LIMIT ) as $chunk ) {
+
+			// Every round drops at least one change, so this terminates.
+			$attempts_left = count( $chunk ) + 1;
+
+			while ( ! empty( $chunk ) && $attempts_left > 0 ) {
+
+				--$attempts_left;
+
+				try {
+					$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $chunk ) ) . '_change_inventory' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+					wc_square()->get_api()->batch_change_inventory( $idempotency_key, $chunk );
+					break;
+				} catch ( \Exception $exception ) {
+
+					if ( 'isolatable' !== $this->classify_sync_error( $exception ) ) {
+						throw $exception;
+					}
+
+					$error_message = $exception->getMessage();
+
+					// Keep every change Square did not name, and drop all of the ones it did in a
+					// single round rather than one per round.
+					$remaining = array();
+					$dropped   = array();
+
+					foreach ( $chunk as $change ) {
+
+						$change_object_id = $change->getPhysicalCount() ? $change->getPhysicalCount()->getCatalogObjectId() : null;
+
+						if ( $change_object_id && false !== strpos( $error_message, $change_object_id ) ) {
+							$dropped[ $change_object_id ] = true;
+							continue;
+						}
+
+						$remaining[] = $change;
+					}
+
+					if ( empty( $dropped ) ) {
+						// Square named none of this chunk's objects, so nothing here is known to be
+						// at fault. NOT_FOUND for example is also what Square returns when the
+						// configured location does not belong to the account, which no amount of
+						// skipping fixes. Silently dropping up to a hundred inventory updates on a
+						// failure we cannot attribute would hide that, so fail loudly instead.
+						throw $exception;
+					}
+
+					foreach ( array_keys( $dropped ) as $dead_object_id ) {
+
+						$product    = Product::get_product_by_square_variation_id( $dead_object_id );
+						$product_id = $product instanceof \WC_Product ? $product->get_id() : 0;
+
+						$this->record_skipped_product(
+							$product_id,
+							sprintf(
+								/* translators: Placeholder: %s - Square catalog object ID */
+								__( 'its saved Square mapping (%s) is no longer usable in Square', 'woocommerce-square' ),
+								$dead_object_id
+							)
+						);
+					}
+
+					$chunk = $remaining;
+				}
+			}
 		}
 	}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1237,22 +1237,48 @@ class Manual_Synchronization extends Stepped_Job {
 
 				$product = wc_get_product( $product_id );
 
-				// Building the catalog payload can fail on a single product's local data (for
-				// example a product Catalog_Item rejects as invalid, or an object Woo_SOR refuses
-				// because it is not of type ITEM): record and skip that product instead of letting
-				// the exception end the whole sync (SQUARE-143 / SQUARE-31).
+				// Building the payload happens in two stages that differ in what a failure can mean,
+				// so they are caught separately rather than distinguished after the fact.
+				//
+				// Catalog_Item's constructor only validates local product data and never reaches
+				// Square, so a failure here is definitively this product's own problem. A product
+				// that no longer resolves also lands here, which keeps a deleted product a skip
+				// rather than a job failure.
+				try {
+					$catalog_item = new Catalog_Item( $product, $is_delete_action );
+				} catch ( \Exception $local_exception ) {
+					$this->record_skipped_product( $product_id, $local_exception->getMessage() );
+					$isolated_fail_ids[]  = $product_id;
+					$staged_product_ids[] = $product_id; // consumed, so the step queue advances past it
+					continue;
+				}
+
+				$original_square_image_ids[ $product_id ] = $product->get_meta( '_square_item_image_id' );
+
+				// get_batch() is not local work: for a variable product it reaches Square to look up
+				// and create item options, so a failure here can just as easily be infrastructure.
 				$refresh_requested_before = get_option( 'woocommerce_square_refresh_sync_cycle', false );
 
 				try {
-					if ( ! $product instanceof \WC_Product ) {
-						throw new \Exception( __( 'the product no longer exists locally', 'woocommerce-square' ) );
-					}
-
-					$original_square_image_ids[ $product_id ] = $product->get_meta( '_square_item_image_id' );
-
-					$catalog_item = new Catalog_Item( $product, $is_delete_action );
 					$batch        = $catalog_item->get_batch( $object );
 					$object_count = $catalog_item->get_batch_object_count();
+
+				} catch ( \InvalidArgumentException $shape_exception ) {
+
+					// The payload builders reject an object of the wrong type with this specific
+					// exception, matching the guards in Handlers\Product. It is a local shape
+					// problem for this one product and never an API failure, so it is safe to skip
+					// even though it carries no Square error code.
+					//
+					// This is checked before the replay sentinel below on purpose: both shape guards
+					// run at the top of their builder, before any Square call, so a shape failure
+					// cannot coincide with a replay request. If a guard ever moves after an API call
+					// that assumption breaks and the sentinel has to be checked here too.
+					$this->record_skipped_product( $product_id, $shape_exception->getMessage() );
+					$isolated_fail_ids[]  = $product_id;
+					$staged_product_ids[] = $product_id; // consumed, so the step queue advances past it
+					continue;
+
 				} catch ( \Exception $staging_exception ) {
 
 					// A failure that asked for the job to restart is never this product's fault.
@@ -1264,12 +1290,11 @@ class Manual_Synchronization extends Stepped_Job {
 						throw $staging_exception;
 					}
 
-					// get_batch() reaches the Square API for variable products (it creates item
-					// options), so a failure here is not necessarily this product's data. Only a
-					// plugin level validation error, which carries no Square error code, or a
-					// genuine data error may be turned into a skip.
-					if ( $this->has_square_error_code( $staging_exception )
-						&& 'isolatable' !== $this->classify_sync_error( $staging_exception ) ) {
+					// Only a Square error naming this object's own data may become a skip. An
+					// exception carrying no Square error code that reaches this point is a transport
+					// failure from the option lookups above, not bad product data, so it must fail
+					// the job loudly instead of stranding a valid product.
+					if ( 'isolatable' !== $this->classify_sync_error( $staging_exception ) ) {
 						throw $staging_exception;
 					}
 
@@ -1520,21 +1545,45 @@ class Manual_Synchronization extends Stepped_Job {
 
 		wc_square()->log( 'Stored Square data to ' . count( $staged_product_ids ) . ' products in ' . $duration . 's' );
 
-		// log any failed products (isolation failures were already recorded with their reason)
-		foreach ( array_diff( $staged_product_ids, $successful_product_ids, $isolated_fail_ids ) as $product_id ) {
+		$unreturned_product_ids = array_values( array_diff( $staged_product_ids, $successful_product_ids, $isolated_fail_ids ) );
 
-			// Square names no product against these errors, so the reason is worded as the set of
-			// errors the request returned rather than as this product's own confirmed cause.
-			$this->record_skipped_product(
-				$product_id,
-				'' !== $partial_error_detail
-					? sprintf(
-						/* translators: Placeholder: %s - one or more error messages returned by Square */
-						__( 'Square did not return the product in the upsert response. Errors returned by the request: %s', 'woocommerce-square' ),
-						$partial_error_detail
-					)
-					: __( 'Square did not return the product in the upsert response', 'woocommerce-square' )
+		// A 200 response can still carry errors, and they get the same treatment as a thrown one:
+		// only a data error means these products are themselves at fault. On a server, auth or rate
+		// limit error the write may yet succeed, so those products must not be reported as skipped.
+		// They are left unconsumed instead, which retries them on the next cycle while the products
+		// this response did return keep the mappings they just earned. Re-throwing here would
+		// discard those mappings and re-send the successful products under a fresh key, creating
+		// duplicates in Square for anything newly created.
+		$partial_error_is_isolatable = '' === $partial_error_detail
+			|| 'isolatable' === $this->classify_sync_error( new \Exception( $partial_error_detail ) );
+
+		if ( ! empty( $unreturned_product_ids ) && ! $partial_error_is_isolatable ) {
+
+			wc_square()->log(
+				'Leaving ' . count( $unreturned_product_ids ) . ' products unprocessed for the next cycle: the upsert response'
+				. ' carried an error that is not the products\' own data (' . $partial_error_detail . ').'
 			);
+
+			$staged_product_ids = array_values( array_diff( $staged_product_ids, $unreturned_product_ids ) );
+
+		} else {
+
+			// log any failed products (isolation failures were already recorded with their reason)
+			foreach ( $unreturned_product_ids as $product_id ) {
+
+				// Square names no product against these errors, so the reason is worded as the set of
+				// errors the request returned rather than as this product's own confirmed cause.
+				$this->record_skipped_product(
+					$product_id,
+					'' !== $partial_error_detail
+						? sprintf(
+							/* translators: Placeholder: %s - one or more error messages returned by Square */
+							__( 'Square did not return the product in the upsert response. Errors returned by the request: %s', 'woocommerce-square' ),
+							$partial_error_detail
+						)
+						: __( 'Square did not return the product in the upsert response', 'woocommerce-square' )
+				);
+			}
 		}
 
 		$this->set_attr( 'in_progress_upsert_catalog_objects', null );
@@ -1578,24 +1627,6 @@ class Manual_Synchronization extends Stepped_Job {
 		}
 
 		return parent::complete();
-	}
-
-
-	/**
-	 * Determines whether an exception message carries a Square API error code.
-	 *
-	 * Plugin level validation failures (an invalid product, a catalog object of the wrong type)
-	 * carry no code; anything Square rejected does, because
-	 * API::do_post_parse_response_validation() formats every error as "[CODE] detail".
-	 *
-	 * @since x.x.x
-	 *
-	 * @param \Exception $exception the caught exception
-	 * @return bool
-	 */
-	protected function has_square_error_code( \Exception $exception ) {
-
-		return (bool) preg_match( '/(^|\| )\[[A-Z][A-Z0-9_]*\]/', $exception->getMessage() );
 	}
 
 
@@ -1798,6 +1829,21 @@ class Manual_Synchronization extends Stepped_Job {
 					throw new \Exception( 'API response data is missing' );
 				}
 
+				// A single product request can also answer 200 while carrying errors. Rethrowing
+				// them in the API layer's own "[CODE] detail" shape hands them to the catch below,
+				// so one policy decides the outcome and the merchant gets Square's actual reason
+				// rather than a generic "not returned in the response".
+				if ( is_array( $response_data->getErrors() ) && ! empty( $response_data->getErrors() ) ) {
+
+					$product_error_details = array();
+
+					foreach ( $response_data->getErrors() as $response_error ) {
+						$product_error_details[] = trim( ( $response_error->getCode() ? '[' . $response_error->getCode() . '] ' : '' ) . ( $response_error->getDetail() ?? '' ) );
+					}
+
+					throw new \Exception( esc_html( implode( ' | ', array_filter( array_unique( $product_error_details ) ) ) ) );
+				}
+
 				if ( is_array( $response_data->getObjects() ) ) {
 					$merged_objects = array_merge( $merged_objects, $response_data->getObjects() );
 				}
@@ -1809,22 +1855,27 @@ class Manual_Synchronization extends Stepped_Job {
 
 				$classification = $this->classify_sync_error( $product_exception );
 
-				// Not this product's data: either nothing will succeed (auth, permissions) or the
-				// write may already have been applied (server error, timeout). Recording a skip
-				// would be wrong in both cases, so fail the job. The job level retry re-sends this
-				// product under the same deterministic key, which Square deduplicates.
-				if ( 'fatal' === $classification ) {
-					throw $product_exception;
-				}
+				// Anything that is not this product's own data ends the slice rather than marking a
+				// product skipped: a rate limit, an auth failure or a server error says nothing about
+				// the product, and on a server error the write may yet have landed.
+				//
+				// Progress already made is kept rather than discarded, so the products that did
+				// succeed get their Square IDs mapped instead of being re-sent from scratch. That is
+				// safe because each isolated request uses a key derived only from the job, the
+				// product and the body, so re-sending an unattempted or half applied product next
+				// cycle reuses the same key and Square deduplicates it. With no progress at all
+				// there is nothing worth keeping, so the exception bubbles to the job level retry
+				// and backoff, which is also what fails the job on an auth error.
+				if ( 'isolatable' !== $classification ) {
 
-				// Rate limited mid slice: stop here. Progress made so far is kept and the
-				// remaining products are staged again next cycle; with no progress at all the
-				// exception bubbles to the job level retry and backoff.
-				if ( 'rate_limited' === $classification ) {
 					if ( empty( $done_ids ) && empty( $failed_ids ) ) {
 						throw $product_exception;
 					}
-					wc_square()->log( 'Rate limited during isolated upserts; pausing the fallback with ' . count( $done_ids ) . ' done, the rest resume next cycle.' );
+
+					wc_square()->log(
+						'Stopping the isolated upsert fallback after a ' . $classification . ' error (' . $product_exception->getMessage() . '); '
+						. count( $done_ids ) . ' done, the rest resume next cycle.'
+					);
 					break;
 				}
 
@@ -2137,7 +2188,7 @@ class Manual_Synchronization extends Stepped_Job {
 
 		foreach ( array_chunk( $inventory_changes, self::BATCH_CHANGE_INVENTORY_LIMIT ) as $chunk ) {
 
-			// Every round drops at least one change, so this terminates.
+			// A dropped dead object shrinks the chunk by one each round, so this terminates.
 			$attempts_left = count( $chunk ) + 1;
 
 			while ( ! empty( $chunk ) && $attempts_left > 0 ) {
@@ -2200,6 +2251,7 @@ class Manual_Synchronization extends Stepped_Job {
 					$chunk = $remaining;
 				}
 			}
+
 		}
 	}
 

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1438,6 +1438,82 @@ class Manual_Synchronization extends Stepped_Job {
 
 
 	/**
+	 * Records a product skipped by the sync, with the reason, and tracks the error counters.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $product_id the skipped product ID
+	 * @param string $reason the failure reason (Square error message or local validation detail)
+	 */
+	protected function record_skipped_product( $product_id, $reason ) {
+
+		$product = $product_id ? wc_get_product( $product_id ) : false;
+		$label   = (string) $product_id;
+
+		if ( $product instanceof \WC_Product ) {
+			$label = $product->get_name();
+			if ( $product->get_sku() ) {
+				$label .= ' (SKU ' . $product->get_sku() . ')';
+			}
+		}
+
+		// A skip can be recorded with no product ID: push_inventory_changes_isolated() passes 0
+		// when Square names a catalog object that no local product claims any more. There is no
+		// subject to name in that case, so it gets its own sentence rather than being forced into
+		// the product one, which would read "Product unknown product was skipped".
+		if ( $product_id ) {
+
+			$edit_link = get_edit_post_link( $product_id );
+			$subject   = $edit_link
+				? '<a href="' . esc_url( $edit_link ) . '">' . esc_html( $label ) . '</a>'
+				: esc_html( $label );
+
+			$message = sprintf(
+				/* translators: Placeholders: %1$s - product name/SKU (possibly linked), %2$s - failure reason */
+				esc_html__( 'Product %1$s was skipped so the sync could continue. Reason: %2$s', 'woocommerce-square' ),
+				$subject,
+				esc_html( $reason )
+			);
+
+		} else {
+
+			$message = sprintf(
+				/* translators: Placeholder: %s - failure reason */
+				esc_html__( 'A Square item with no matching WooCommerce product was skipped so the sync could continue. Reason: %s', 'woocommerce-square' ),
+				esc_html( $reason )
+			);
+		}
+
+		Records::set_record(
+			array(
+				'type'       => 'alert',
+				'product_id' => $product_id,
+				'message'    => $message,
+			)
+		);
+
+		// Records retain only the most recent entries, so the log is the complete list a merchant
+		// or support can go back to after a sync that skipped more products than that.
+		wc_square()->log(
+			$product_id
+				? 'Skipped product #' . $product_id . ' (' . $label . '): ' . $reason
+				: 'Skipped a Square item with no matching WooCommerce product: ' . $reason
+		);
+
+		if ( $product_id ) {
+			$failed_ids   = (array) $this->get_attr( 'failed_product_ids', array() );
+			$failed_ids[] = (int) $product_id;
+			$this->set_attr( 'failed_product_ids', array_values( array_unique( $failed_ids ) ), false );
+		}
+
+		// Deferred write: Records::set_record() already wrote an option for this skip, and a step
+		// that skips many products would otherwise double that cost with a full job write per
+		// product. Both counters reach the option on the next persisting set_attr() in the cycle.
+		$this->set_attr( 'sync_error_count', (int) $this->get_attr( 'sync_error_count', 0 ) + 1, false );
+	}
+
+
+	/**
 	 * Converts object data to an instance of CatalogObject.
 	 *
 	 * @since 2.0.0

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -1359,6 +1359,42 @@ class Manual_Synchronization extends Stepped_Job {
 	}
 
 	/**
+	 * Completes the job, reporting a completed with errors outcome when products were skipped.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \stdClass the job object
+	 */
+	protected function complete() {
+
+		$error_count = (int) $this->get_attr( 'sync_error_count', 0 );
+
+		if ( $error_count > 0 ) {
+
+			$this->set_attr( 'completed_with_errors', true, false );
+
+			$failed_ids = (array) $this->get_attr( 'failed_product_ids', array() );
+
+			// Only the most recent records are retained, so the notice must not promise an alert
+			// for every skipped product: a large sync evicts the earliest ones.
+			Records::set_record(
+				array(
+					'type'    => 'notice',
+					'message' => sprintf(
+						/* translators: Placeholders: %1$d - number of errors, %2$d - number of skipped products */
+						esc_html__( 'Sync completed with %1$d errors. %2$d products were skipped; the most recent alerts above give the product and reason for each, and the full list is in the Square logs.', 'woocommerce-square' ),
+						$error_count,
+						count( $failed_ids )
+					),
+				)
+			);
+		}
+
+		return parent::complete();
+	}
+
+
+	/**
 	 * Determines whether an exception message carries a Square API error code.
 	 *
 	 * Plugin level validation failures (an invalid product, a catalog object of the wrong type)

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2182,6 +2182,49 @@ class Manual_Synchronization extends Stepped_Job {
 	}
 
 	/**
+	 * Splits a failed inventory chunk into the objects Square named in the error and the rest.
+	 *
+	 * The chunk's own catalog object IDs are tested against the error text rather than parsing an
+	 * ID out of it. Square does not guarantee any particular formatting and frequently quotes the
+	 * JSON field path instead of the value, so parsing either extracts a field name that matches
+	 * nothing in the chunk, and discards up to a hundred good inventory updates, or extracts
+	 * nothing at all.
+	 *
+	 * An empty named set means the failure cannot be attributed to anything in this chunk. The
+	 * caller treats that as fatal, because the same code Square returns for a dead catalog object
+	 * is also what it returns for a location the account does not own.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \Square\Models\InventoryChange[] $chunk changes sent in the request that failed
+	 * @param string $error_message the message Square returned
+	 * @return array {named: string[], remaining: \Square\Models\InventoryChange[]}
+	 */
+	protected function partition_inventory_changes_by_error( array $chunk, $error_message ) {
+
+		$remaining = array();
+		$named     = array();
+
+		foreach ( $chunk as $change ) {
+
+			$change_object_id = $change->getPhysicalCount() ? $change->getPhysicalCount()->getCatalogObjectId() : null;
+
+			if ( $change_object_id && false !== strpos( $error_message, $change_object_id ) ) {
+				$named[ $change_object_id ] = true;
+				continue;
+			}
+
+			$remaining[] = $change;
+		}
+
+		return array(
+			'named'     => array_keys( $named ),
+			'remaining' => $remaining,
+		);
+	}
+
+
+	/**
 	 * Sends inventory changes to Square with per change isolation of dead catalog objects.
 	 *
 	 * A single change referencing a Square object that no longer exists (a stale local mapping
@@ -2230,20 +2273,9 @@ class Manual_Synchronization extends Stepped_Job {
 
 					// Keep every change Square did not name, and drop all of the ones it did in a
 					// single round rather than one per round.
-					$remaining = array();
-					$dropped   = array();
-
-					foreach ( $chunk as $change ) {
-
-						$change_object_id = $change->getPhysicalCount() ? $change->getPhysicalCount()->getCatalogObjectId() : null;
-
-						if ( $change_object_id && false !== strpos( $error_message, $change_object_id ) ) {
-							$dropped[ $change_object_id ] = true;
-							continue;
-						}
-
-						$remaining[] = $change;
-					}
+					$partition = $this->partition_inventory_changes_by_error( $chunk, $error_message );
+					$remaining = $partition['remaining'];
+					$dropped   = $partition['named'];
 
 					if ( empty( $dropped ) ) {
 						// Square named none of this chunk's objects, so nothing here is known to be
@@ -2254,7 +2286,7 @@ class Manual_Synchronization extends Stepped_Job {
 						throw $exception;
 					}
 
-					foreach ( array_keys( $dropped ) as $dead_object_id ) {
+					foreach ( $dropped as $dead_object_id ) {
 
 						$product    = Product::get_product_by_square_variation_id( $dead_object_id );
 						$product_id = $product instanceof \WC_Product ? $product->get_id() : 0;

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -52,6 +52,9 @@ class Manual_Synchronization extends Stepped_Job {
 	/** @var int the limit for how many inventory changes can be made in a single request */
 	const BATCH_CHANGE_INVENTORY_LIMIT = 100;
 
+	/** @var int maximum per product fallback upserts attempted within one step cycle */
+	const MAX_ISOLATED_UPSERTS_PER_CYCLE = 20;
+
 	/**
 	 * Square error codes that mean "this object's own data is invalid", and nothing else.
 	 *
@@ -1194,6 +1197,8 @@ class Manual_Synchronization extends Stepped_Job {
 			'processed'   => array(),
 			'unprocessed' => $product_ids,
 		);
+		$isolated_fail_ids         = array();
+		$partial_error_detail      = '';
 
 		$in_progress = $this->get_attr(
 			'in_progress_upsert_catalog_objects',
@@ -1202,6 +1207,8 @@ class Manual_Synchronization extends Stepped_Job {
 				'unprocessed_upsert_response'       => null,
 				'mapped_client_item_ids'            => array(),
 				'processed_remote_catalog_item_ids' => array(),
+				'isolated_fail_ids'                 => array(),
+				'partial_error_detail'              => '',
 			)
 		);
 
@@ -1209,6 +1216,12 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( ! empty( $in_progress['unprocessed_upsert_response'] ) ) {
 			$staged_product_ids = $in_progress['staged_product_ids'] ?? array();
 			$upsert_response    = ApiHelper::getJsonHelper()->mapClass( json_decode( $in_progress['unprocessed_upsert_response'] ), 'Square\\Models\\BatchUpsertCatalogObjectsResponse' );
+
+			// Restored alongside staged_product_ids: without them a cycle resumed after the
+			// response was persisted would no longer recognise the already recorded skips and
+			// would raise a second alert and a second error count for every one of them.
+			$isolated_fail_ids    = (array) ( $in_progress['isolated_fail_ids'] ?? array() );
+			$partial_error_detail = (string) ( $in_progress['partial_error_detail'] ?? '' );
 		}
 
 		if ( empty( $upsert_response ) || ! $upsert_response instanceof BatchUpsertCatalogObjectsResponse ) {
@@ -1222,25 +1235,103 @@ class Manual_Synchronization extends Stepped_Job {
 					$object = $this->convert_to_catalog_object( $object );
 				}
 
-				$product                                  = wc_get_product( $product_id );
-				$original_square_image_ids[ $product_id ] = $product->get_meta( '_square_item_image_id' );
+				$product = wc_get_product( $product_id );
 
-				$catalog_item = new Catalog_Item( $product, $is_delete_action );
-				$batch        = $catalog_item->get_batch( $object );
-				$object_count = $catalog_item->get_batch_object_count();
+				// Building the catalog payload can fail on a single product's local data (for
+				// example a product Catalog_Item rejects as invalid, or an object Woo_SOR refuses
+				// because it is not of type ITEM): record and skip that product instead of letting
+				// the exception end the whole sync (SQUARE-143 / SQUARE-31).
+				$refresh_requested_before = get_option( 'woocommerce_square_refresh_sync_cycle', false );
+
+				try {
+					if ( ! $product instanceof \WC_Product ) {
+						throw new \Exception( __( 'the product no longer exists locally', 'woocommerce-square' ) );
+					}
+
+					$original_square_image_ids[ $product_id ] = $product->get_meta( '_square_item_image_id' );
+
+					$catalog_item = new Catalog_Item( $product, $is_delete_action );
+					$batch        = $catalog_item->get_batch( $object );
+					$object_count = $catalog_item->get_batch_object_count();
+				} catch ( \Exception $staging_exception ) {
+
+					// A failure that asked for the job to restart is never this product's fault.
+					// API::create_options_and_values() sets woocommerce_square_refresh_sync_cycle
+					// and clears the cached options data when Square rejects an item option, so
+					// that run() refetches the options and replays the cycle. Recording a skip here
+					// would strand a perfectly good product that the replay would have synced.
+					if ( get_option( 'woocommerce_square_refresh_sync_cycle', false ) !== $refresh_requested_before ) {
+						throw $staging_exception;
+					}
+
+					// get_batch() reaches the Square API for variable products (it creates item
+					// options), so a failure here is not necessarily this product's data. Only a
+					// plugin level validation error, which carries no Square error code, or a
+					// genuine data error may be turned into a skip.
+					if ( $this->has_square_error_code( $staging_exception )
+						&& 'isolatable' !== $this->classify_sync_error( $staging_exception ) ) {
+						throw $staging_exception;
+					}
+
+					$this->record_skipped_product( $product_id, $staging_exception->getMessage() );
+					$isolated_fail_ids[]  = $product_id;
+					$staged_product_ids[] = $product_id; // consumed, so the step queue advances past it
+					continue;
+				}
 
 				if ( $this->get_max_objects_total() >= $object_count + $total_object_count ) {
-					$batches[]            = $batch;
-					$total_object_count  += $object_count;
-					$staged_product_ids[] = $product_id;
+					// Keyed by product so the per product fallback can reuse the batch built here
+					// instead of building it a second time. Never rely on position: the skip
+					// branches below advance $staged_product_ids without adding a batch.
+					$batches[ $product_id ] = $batch;
+					$total_object_count    += $object_count;
+					$staged_product_ids[]   = $product_id;
+				} elseif ( empty( $batches ) ) {
+
+					// This single product alone exceeds the per request object limit, so no cycle
+					// will ever be able to stage it. Without this it is retried forever: nothing is
+					// staged, so nothing is reported as processed and the step repeats unchanged.
+					$this->record_skipped_product(
+						$product_id,
+						sprintf(
+							/* translators: Placeholders: %1$d - number of Square objects the product needs, %2$d - the per request limit */
+							__( 'it needs %1$d Square objects, more than the %2$d a single request allows', 'woocommerce-square' ),
+							$object_count,
+							$this->get_max_objects_total()
+						)
+					);
+					$isolated_fail_ids[]  = $product_id;
+					$staged_product_ids[] = $product_id; // consumed, so the step queue advances past it
+					continue;
+
 				} else {
 					break;
 				}
 			}
 
+			// Every product in this cycle was skipped while staging, so there is nothing to send.
+			// An empty request would be rejected and would turn a handled set of skips back into a
+			// failed job.
+			if ( empty( $batches ) ) {
+
+				wc_square()->log( 'Nothing left to upsert this cycle: all ' . count( $staged_product_ids ) . ' staged products were skipped.' );
+
+				// Persists this cycle's skip records counters along with clearing the resume state.
+				$this->set_attr( 'in_progress_upsert_catalog_objects', null );
+
+				$result['processed']   = $staged_product_ids;
+				$result['unprocessed'] = array_diff( $product_ids, $staged_product_ids );
+
+				return $result;
+			}
+
+			// The SDK takes a plain list. Hashing that list rather than the product keyed map keeps
+			// the idempotency key identical to what this step has always produced.
+			$batch_list = array_values( $batches );
+
 			try {
 				$start           = microtime( true );
-				$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $batches ) ) . time() . '_upsert_products' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+				$idempotency_key = wc_square()->get_idempotency_key( md5( serialize( $batch_list ) ) . time() . '_upsert_products' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 
 				if ( $new_products ) {
 					// Use the retry idempotency key if it exists.
@@ -1255,32 +1346,64 @@ class Manual_Synchronization extends Stepped_Job {
 					}
 				}
 
-				$response        = wc_square()->get_api()->batch_upsert_catalog_objects( $idempotency_key, $batches );
+				$response        = wc_square()->get_api()->batch_upsert_catalog_objects( $idempotency_key, $batch_list );
 				$upsert_response = $response->get_data();
 			} catch ( \Exception $e ) {
-				$retry         = $this->get_attr( 'retry', 0 );
-				$error_message = $e->getMessage();
+				$retry          = $this->get_attr( 'retry', 0 );
+				$error_message  = $e->getMessage();
+				$classification = $this->classify_sync_error( $e );
 
 				// Retry the request if it was rate limited, and we are uploading new products. Retry up to 3 times.
-				if ( false !== strpos( $error_message, 'RATE_LIMITED' ) && $new_products && $retry < 3 ) {
+				if ( 'rate_limited' === $classification && $new_products && $retry < 3 ) {
 					$this->set_attr( 'upsert_retry_idempotency_key', $idempotency_key );
 					$this->set_attr( 'upsert_retry_product_ids', $product_ids );
 				}
-				// Re-throw the exception to allow centralized error handling at the job level.
-				throw $e;
+
+				if ( 'isolatable' !== $classification ) {
+					// Rate limiting keeps the existing job level retry; auth errors fail the job.
+					throw $e;
+				}
+
+				// One bad product must not terminate the sync for every other product: retry the
+				// staged set one request per product, record and skip the failing ones, and let the
+				// step continue with whatever succeeded (SQUARE-143 / SQUARE-31). Products that
+				// already failed at the staging stage are excluded so they are not recorded twice,
+				// and only products the fallback actually attempted are consumed this cycle; the
+				// rest are staged again on the next cycle.
+				wc_square()->log( 'Batch upsert failed (' . $error_message . '); retrying the staged products individually.' );
+				$isolation          = $this->upsert_products_individually( $batches, array_values( array_diff( $staged_product_ids, $isolated_fail_ids ) ) );
+				$upsert_response    = $isolation['response'];
+				$staged_product_ids = array_values( array_unique( array_merge( $isolated_fail_ids, $isolation['done_ids'], $isolation['failed_ids'] ) ) );
+				$isolated_fail_ids  = array_values( array_unique( array_merge( $isolated_fail_ids, $isolation['failed_ids'] ) ) );
 			}
 
 			if ( ! $upsert_response instanceof BatchUpsertCatalogObjectsResponse ) {
 				throw new \Exception( 'API response data is missing' );
 			}
 
+			// A response can be a 200 with partial failures: keep the error detail for the
+			// skipped product records below (Square does not always name the failing object).
+			// Every error is kept, not just the first: a single request carries several batches
+			// and Square does not say which batch an error belongs to, so attributing one error
+			// to every unreturned product would present a guess as the reason.
+			if ( is_array( $upsert_response->getErrors() ) && ! empty( $upsert_response->getErrors() ) ) {
+				$error_details = array();
+				foreach ( $upsert_response->getErrors() as $response_error ) {
+					$error_details[] = trim( ( $response_error->getCode() ? '[' . $response_error->getCode() . '] ' : '' ) . ( $response_error->getDetail() ?? '' ) );
+				}
+				$partial_error_detail = implode( ' | ', array_filter( array_unique( $error_details ) ) );
+			}
+
 			$in_progress['staged_product_ids']          = $staged_product_ids;
 			$in_progress['unprocessed_upsert_response'] = wp_json_encode( $upsert_response, JSON_PRETTY_PRINT );
+			$in_progress['isolated_fail_ids']           = $isolated_fail_ids;
+			$in_progress['partial_error_detail']        = $partial_error_detail;
 			$this->set_attr( 'in_progress_upsert_catalog_objects', $in_progress );
 
 			$duration = number_format( microtime( true ) - $start, 2 );
 
-			wc_square()->log( 'Upserted ' . count( $upsert_response->getObjects() ) . ' objects in ' . $duration . 's' );
+			// getObjects() is null when every batch failed; that must not fatal the job.
+			wc_square()->log( 'Upserted ' . ( is_array( $upsert_response->getObjects() ) ? count( $upsert_response->getObjects() ) : 0 ) . ' objects in ' . $duration . 's' );
 		}
 
 		// update local square meta for newly upserted objects
@@ -1328,7 +1451,8 @@ class Manual_Synchronization extends Stepped_Job {
 		$start = microtime( true );
 
 		// loop through all returned objects and store their IDs to Woo products
-		foreach ( $upsert_response->getObjects() as $remote_catalog_item ) {
+		// (null when every batch failed; the skip records below still run)
+		foreach ( is_array( $upsert_response->getObjects() ) ? $upsert_response->getObjects() : array() as $remote_catalog_item ) {
 
 			$remote_item_id = $remote_catalog_item->getId();
 
@@ -1396,19 +1520,20 @@ class Manual_Synchronization extends Stepped_Job {
 
 		wc_square()->log( 'Stored Square data to ' . count( $staged_product_ids ) . ' products in ' . $duration . 's' );
 
-		// log any failed products
-		foreach ( array_diff( $staged_product_ids, $successful_product_ids ) as $product_id ) {
+		// log any failed products (isolation failures were already recorded with their reason)
+		foreach ( array_diff( $staged_product_ids, $successful_product_ids, $isolated_fail_ids ) as $product_id ) {
 
-			Records::set_record(
-				array(
-					'type'       => 'alert',
-					'product_id' => $product_id,
-					'message'    => sprintf(
-						/* translators: Placeholder: %s - product ID */
-						esc_html__( 'Product %s could not be updated in Square.', 'woocommerce-square' ),
-						'<a href="' . esc_url( get_edit_post_link( $product_id ) ) . '">' . $product_id . '</a>'
-					),
-				)
+			// Square names no product against these errors, so the reason is worded as the set of
+			// errors the request returned rather than as this product's own confirmed cause.
+			$this->record_skipped_product(
+				$product_id,
+				'' !== $partial_error_detail
+					? sprintf(
+						/* translators: Placeholder: %s - one or more error messages returned by Square */
+						__( 'Square did not return the product in the upsert response. Errors returned by the request: %s', 'woocommerce-square' ),
+						$partial_error_detail
+					)
+					: __( 'Square did not return the product in the upsert response', 'woocommerce-square' )
 			);
 		}
 
@@ -1608,6 +1733,116 @@ class Manual_Synchronization extends Stepped_Job {
 		// that skips many products would otherwise double that cost with a full job write per
 		// product. Both counters reach the option on the next persisting set_attr() in the cycle.
 		$this->set_attr( 'sync_error_count', (int) $this->get_attr( 'sync_error_count', 0 ) + 1, false );
+	}
+
+
+	/**
+	 * Upserts the staged products one request per product after a combined batch request failed.
+	 *
+	 * Square rejects a whole upsert when any object in it is invalid and does not always identify
+	 * the offender, so the reliable isolation is granularity: one request per product. Successful
+	 * responses are merged into a single synthesized response so the caller's post processing works
+	 * unchanged; failing products are recorded with their reason and skipped (SQUARE-143/31).
+	 *
+	 * The batches built by the staging loop are reused rather than rebuilt. Rebuilding would not be
+	 * free: Catalog_Item::get_batch() reaches Square to create item options for variable products,
+	 * so re-deriving a payload here would multiply the request count on the one path that only runs
+	 * because something already failed.
+	 *
+	 * @since x.x.x
+	 *
+	 * At most MAX_ISOLATED_UPSERTS_PER_CYCLE products are attempted per invocation so a huge
+	 * fallback cannot exhaust PHP's execution time inside one step cycle; unattempted products are
+	 * simply not consumed and are staged again on the next cycle. A rate limit mid loop stops the
+	 * slice: with partial progress the progress is kept, with none the exception bubbles so the
+	 * existing job level retry and backoff take over.
+	 *
+	 * @param \Square\Models\CatalogObjectBatch[] $batches product ID keyed batches already built by the staging loop
+	 * @param int[] $staged_product_ids the product IDs staged into the failed combined request
+	 * @return array { response: BatchUpsertCatalogObjectsResponse, done_ids: int[], failed_ids: int[] }
+	 */
+	protected function upsert_products_individually( array $batches, array $staged_product_ids ) {
+
+		$merged_objects  = array();
+		$merged_mappings = array();
+		$done_ids        = array();
+		$failed_ids      = array();
+		$attempted       = 0;
+
+		foreach ( $staged_product_ids as $product_id ) {
+
+			if ( self::MAX_ISOLATED_UPSERTS_PER_CYCLE <= $attempted ) {
+				break;
+			}
+
+			// Products that never made it into a batch were already recorded while staging.
+			if ( ! isset( $batches[ $product_id ] ) ) {
+				continue;
+			}
+
+			$batch = $batches[ $product_id ];
+
+			++$attempted;
+
+			try {
+				// Deterministic key (no timestamp): a retry with an unchanged body must reuse the
+				// same key or Square treats the temp ids as a brand new upsert and creates
+				// duplicate catalog items. The whole input is hashed so the key stays well inside
+				// Square's documented length limits regardless of job and product ID length.
+				$idempotency_key = wc_square()->get_idempotency_key( md5( $this->get_attr( 'id' ) . '_' . $product_id . '_' . serialize( $batch ) ) . '_isolated_upsert' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+
+				$response      = wc_square()->get_api()->batch_upsert_catalog_objects( $idempotency_key, array( $batch ) );
+				$response_data = $response->get_data();
+
+				if ( ! $response_data instanceof BatchUpsertCatalogObjectsResponse ) {
+					throw new \Exception( 'API response data is missing' );
+				}
+
+				if ( is_array( $response_data->getObjects() ) ) {
+					$merged_objects = array_merge( $merged_objects, $response_data->getObjects() );
+				}
+				if ( is_array( $response_data->getIdMappings() ) ) {
+					$merged_mappings = array_merge( $merged_mappings, $response_data->getIdMappings() );
+				}
+				$done_ids[] = $product_id;
+			} catch ( \Exception $product_exception ) {
+
+				$classification = $this->classify_sync_error( $product_exception );
+
+				// Not this product's data: either nothing will succeed (auth, permissions) or the
+				// write may already have been applied (server error, timeout). Recording a skip
+				// would be wrong in both cases, so fail the job. The job level retry re-sends this
+				// product under the same deterministic key, which Square deduplicates.
+				if ( 'fatal' === $classification ) {
+					throw $product_exception;
+				}
+
+				// Rate limited mid slice: stop here. Progress made so far is kept and the
+				// remaining products are staged again next cycle; with no progress at all the
+				// exception bubbles to the job level retry and backoff.
+				if ( 'rate_limited' === $classification ) {
+					if ( empty( $done_ids ) && empty( $failed_ids ) ) {
+						throw $product_exception;
+					}
+					wc_square()->log( 'Rate limited during isolated upserts; pausing the fallback with ' . count( $done_ids ) . ' done, the rest resume next cycle.' );
+					break;
+				}
+
+				$failed_ids[] = $product_id;
+				$this->record_skipped_product( $product_id, $product_exception->getMessage() );
+				wc_square()->log( 'Isolated upsert failed for product #' . $product_id . ': ' . $product_exception->getMessage() );
+			}
+		}
+
+		$synthesized = new BatchUpsertCatalogObjectsResponse();
+		$synthesized->setObjects( $merged_objects );
+		$synthesized->setIdMappings( $merged_mappings );
+
+		return array(
+			'response'   => $synthesized,
+			'done_ids'   => $done_ids,
+			'failed_ids' => $failed_ids,
+		);
 	}
 
 

--- a/tests/php/Unit/Sync/Error_Classification_Test.php
+++ b/tests/php/Unit/Sync/Error_Classification_Test.php
@@ -131,24 +131,4 @@ class Error_Classification_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'isolatable', $this->call( 'classify_sync_error', new \Exception( '[SOME_NEW_CODE] nope' ) ) );
 	}
-
-	/**
-	 * @dataProvider provide_code_presence
-	 */
-	public function test_has_square_error_code( $message, $expected ) {
-		$this->assertSame( $expected, $this->call( 'has_square_error_code', new \Exception( $message ) ) );
-	}
-
-	public function provide_code_presence() {
-		return array(
-			array( '[BAD_REQUEST] nope', true ),
-			array( '[RATE_LIMITED] a | [BAD_REQUEST] b', true ),
-			array( 'Invalid product', false ),
-			array( 'Type of $catalog_object must be an ITEM', false ),
-			array( '', false ),
-			// A bracketed word mid detail is not a code.
-			array( '[BAD_REQUEST] Product "[UNAUTHORIZED] Widget" is invalid', true ),
-			array( 'Product "[UNAUTHORIZED] Widget" is invalid', false ),
-		);
-	}
 }

--- a/tests/php/Unit/Sync/Error_Classification_Test.php
+++ b/tests/php/Unit/Sync/Error_Classification_Test.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for the sync error classification used to decide whether a single object is skipped
+ * or the whole job fails.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync;
+
+use WP_UnitTestCase;
+use WooCommerce\Square\Sync\Manual_Synchronization;
+
+/**
+ * classify_sync_error() decides whether one product is skipped or the entire sync job fails,
+ * so a wrong answer either strands a good product or hides a broken connection behind dozens
+ * of misleading per product alerts.
+ *
+ * Messages here use the exact format API::do_post_parse_response_validation() produces:
+ * "[CODE] detail", joined with " | " when a response carries several errors.
+ */
+class Error_Classification_Test extends WP_UnitTestCase {
+
+	/** @var Manual_Synchronization */
+	private $job;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->job = new Manual_Synchronization( new \stdClass() );
+	}
+
+	/**
+	 * Calls a protected method on the job under test.
+	 *
+	 * @param string $method method name
+	 * @param mixed  ...$args arguments
+	 * @return mixed
+	 */
+	private function call( $method, ...$args ) {
+		$reflection = new \ReflectionMethod( Manual_Synchronization::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( $this->job, $args );
+	}
+
+	public function tearDown(): void {
+		remove_all_filters( 'wc_square_isolatable_error_codes' );
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider provide_messages
+	 */
+	public function test_classify_sync_error( $message, $expected, $why ) {
+		$this->assertSame( $expected, $this->call( 'classify_sync_error', new \Exception( $message ) ), $why );
+	}
+
+	public function provide_messages() {
+		return array(
+			// Throttling keeps the existing job level retry and backoff.
+			array( '[RATE_LIMITED] Too many requests', 'rate_limited', 'rate limiting must keep the existing retry path' ),
+			array( '[RATE_LIMITED] a | [BAD_REQUEST] b', 'rate_limited', 'rate limiting wins over a data error in the same response' ),
+
+			// Object level data problems: the same request will always fail, so skip the object.
+			array( '[BAD_REQUEST] Item name is too long', 'isolatable', 'a data error is the object own fault' ),
+			array( '[VALUE_TOO_LONG] Value at `item_data.name`', 'isolatable', 'a data error is the object own fault' ),
+			// Isolatable at the classifier level, but do NOT read this row as "an item option
+			// collision is fixed by skipping the product". This exact message is the job restart
+			// case: API::create_options_and_values() sets woocommerce_square_refresh_sync_cycle
+			// and clears the cached options data before re-throwing, so run() replays the cycle
+			// with fresh options and the product syncs. The staging catch in
+			// upsert_catalog_objects() snapshots that option and rethrows when it changed, which
+			// takes effect before isolation ever applies. Believing isolation handles this is
+			// what produced the original regression: the product was recorded as skipped and
+			// stranded even though the replay would have synced it. Same two gate structure as
+			// NOT_FOUND below. The classifier cannot tell the two apart, and it does not need to.
+			array( '[INVALID_VALUE] An existing Item Option has name "Size"', 'isolatable', 'a data error is the object own fault at the classifier level' ),
+			// NOT_FOUND is deliberately isolatable even though Square also returns it when the
+			// configured location does not belong to the account, which no amount of skipping
+			// fixes. push_inventory_changes_isolated() gates that second case separately, by
+			// refusing to drop anything unless Square named an object present in the chunk. Do
+			// not remove NOT_FOUND from the allow list to solve the location case; that would
+			// stop stale catalog mappings from being isolated at all.
+			array( '[NOT_FOUND] Object ABC not found', 'isolatable', 'a stale mapping is the object own fault' ),
+			array( '[CONFLICT] version mismatch', 'isolatable', 'a version conflict is the object own fault' ),
+			array( '[BAD_REQUEST] a | [VALUE_TOO_LONG] b', 'isolatable', 'every code is a data error, so the object can be skipped' ),
+
+			// Connection level problems. Skipping cannot fix these and would bury the real cause
+			// under one misleading alert per product.
+			array( '[UNAUTHORIZED] This request could not be authorized.', 'fatal', 'auth failure must fail the job' ),
+			array( '[ACCESS_TOKEN_EXPIRED] The access token has expired.', 'fatal', 'auth failure must fail the job' ),
+			array( '[ACCESS_TOKEN_REVOKED] Token revoked', 'fatal', 'auth failure must fail the job' ),
+			array( '[FORBIDDEN] Not authorized to perform this action.', 'fatal', 'a permission problem is not product data' ),
+			array( '[INSUFFICIENT_SCOPES] Missing ITEMS_WRITE', 'fatal', 'a missing scope is not product data' ),
+
+			// Transient problems. The write may already have been applied, so re-sending the
+			// objects individually under fresh temporary IDs would duplicate them in Square.
+			array( '[INTERNAL_SERVER_ERROR] Something went wrong', 'fatal', 'a server error may already have been applied' ),
+			array( '[SERVICE_UNAVAILABLE] Try again', 'fatal', 'a server error may already have been applied' ),
+			array( 'cURL error 28: Operation timed out after 30001 milliseconds', 'fatal', 'a timeout may already have been applied' ),
+
+			// Anything unrecognised must fail closed, never be assumed to be bad product data.
+			array( '', 'fatal', 'an empty message must not be assumed to be a data error' ),
+			array( 'Response data is invalid', 'fatal', 'a plugin level error must not be assumed to be a data error' ),
+			array( '[INVALID_REQUEST_ERROR] Bad body', 'fatal', 'a code that is not on the allow list must fail closed' ),
+			array( '[BAD_REQUEST] a | [INTERNAL_SERVER_ERROR] b', 'fatal', 'a mixed response may still have been partly applied' ),
+		);
+	}
+
+	/**
+	 * Merchant supplied names are echoed verbatim inside error details, so a product literally
+	 * named "[UNAUTHORIZED] Widget" must not turn a data error into a job failure. Codes are
+	 * only read from the start of each " | " separated segment.
+	 */
+	public function test_bracketed_text_inside_a_detail_is_not_read_as_a_code() {
+		$this->assertSame(
+			'isolatable',
+			$this->call( 'classify_sync_error', new \Exception( '[BAD_REQUEST] Product "[UNAUTHORIZED] Widget" is invalid' ) )
+		);
+	}
+
+	public function test_isolatable_codes_are_filterable() {
+		$this->assertSame( 'fatal', $this->call( 'classify_sync_error', new \Exception( '[SOME_NEW_CODE] nope' ) ) );
+
+		add_filter(
+			'wc_square_isolatable_error_codes',
+			static function ( $codes ) {
+				$codes[] = 'SOME_NEW_CODE';
+				return $codes;
+			}
+		);
+
+		$this->assertSame( 'isolatable', $this->call( 'classify_sync_error', new \Exception( '[SOME_NEW_CODE] nope' ) ) );
+	}
+
+	/**
+	 * @dataProvider provide_code_presence
+	 */
+	public function test_has_square_error_code( $message, $expected ) {
+		$this->assertSame( $expected, $this->call( 'has_square_error_code', new \Exception( $message ) ) );
+	}
+
+	public function provide_code_presence() {
+		return array(
+			array( '[BAD_REQUEST] nope', true ),
+			array( '[RATE_LIMITED] a | [BAD_REQUEST] b', true ),
+			array( 'Invalid product', false ),
+			array( 'Type of $catalog_object must be an ITEM', false ),
+			array( '', false ),
+			// A bracketed word mid detail is not a code.
+			array( '[BAD_REQUEST] Product "[UNAUTHORIZED] Widget" is invalid', true ),
+			array( 'Product "[UNAUTHORIZED] Widget" is invalid', false ),
+		);
+	}
+}

--- a/tests/php/Unit/Sync/Inventory_Isolation_Test.php
+++ b/tests/php/Unit/Sync/Inventory_Isolation_Test.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the attribution gate that decides whether a failed inventory batch drops one change
+ * or fails the whole job.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\Sync;
+
+use WP_UnitTestCase;
+use WooCommerce\Square\Sync\Manual_Synchronization;
+
+/**
+ * Square answers with the same error code for a catalog object that no longer exists and for a
+ * location the account does not own. Only this gate separates them: an object the error names is
+ * dropped and the rest of the batch is retried, while an error naming nothing in the batch is
+ * unattributable and must fail loudly rather than silently discarding real stock updates.
+ */
+class Inventory_Isolation_Test extends WP_UnitTestCase {
+
+	/** @var Manual_Synchronization */
+	private $job;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->job = new Manual_Synchronization( new \stdClass() );
+	}
+
+	/**
+	 * Calls a protected method on the job under test.
+	 *
+	 * @param string $method method name.
+	 * @param mixed  ...$args arguments.
+	 * @return mixed
+	 */
+	private function call( $method, ...$args ) {
+		$reflection = new \ReflectionMethod( Manual_Synchronization::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( $this->job, $args );
+	}
+
+	/**
+	 * Builds a physical count change for a catalog object, as the push path does.
+	 *
+	 * @param string $catalog_object_id Square catalog object ID.
+	 * @return \Square\Models\InventoryChange
+	 */
+	private function change( $catalog_object_id ) {
+		$count = new \Square\Models\InventoryPhysicalCount();
+		$count->setCatalogObjectId( $catalog_object_id );
+		$count->setQuantity( '5' );
+		$count->setState( 'IN_STOCK' );
+
+		$change = new \Square\Models\InventoryChange();
+		$change->setType( 'PHYSICAL_COUNT' );
+		$change->setPhysicalCount( $count );
+
+		return $change;
+	}
+
+	/**
+	 * Reduces a partition result to plain values for comparison.
+	 *
+	 * @param array $partition result of partition_inventory_changes_by_error().
+	 * @return array
+	 */
+	private function summarize( array $partition ) {
+		$remaining = array();
+
+		foreach ( $partition['remaining'] as $change ) {
+			$remaining[] = $change->getPhysicalCount()->getCatalogObjectId();
+		}
+
+		return array( $partition['named'], $remaining );
+	}
+
+	public function test_a_named_object_is_dropped_and_the_rest_retried() {
+		$chunk = array( $this->change( 'AAAAAAAAAAAAAAAAAAAAAAAA' ), $this->change( 'BBBBBBBBBBBBBBBBBBBBBBBB' ) );
+
+		list( $named, $remaining ) = $this->summarize(
+			$this->call(
+				'partition_inventory_changes_by_error',
+				$chunk,
+				'[NOT_FOUND] Object `AAAAAAAAAAAAAAAAAAAAAAAA` not found.'
+			)
+		);
+
+		$this->assertSame( array( 'AAAAAAAAAAAAAAAAAAAAAAAA' ), $named );
+		$this->assertSame( array( 'BBBBBBBBBBBBBBBBBBBBBBBB' ), $remaining, 'the change Square did not name must survive' );
+	}
+
+	public function test_every_named_object_is_dropped_in_a_single_round() {
+		$chunk = array(
+			$this->change( 'AAAAAAAAAAAAAAAAAAAAAAAA' ),
+			$this->change( 'BBBBBBBBBBBBBBBBBBBBBBBB' ),
+			$this->change( 'CCCCCCCCCCCCCCCCCCCCCCCC' ),
+		);
+
+		list( $named, $remaining ) = $this->summarize(
+			$this->call(
+				'partition_inventory_changes_by_error',
+				$chunk,
+				'[NOT_FOUND] Object `AAAAAAAAAAAAAAAAAAAAAAAA` not found. | [NOT_FOUND] Object `CCCCCCCCCCCCCCCCCCCCCCCC` not found.'
+			)
+		);
+
+		$this->assertSame( array( 'AAAAAAAAAAAAAAAAAAAAAAAA', 'CCCCCCCCCCCCCCCCCCCCCCCC' ), $named );
+		$this->assertSame( array( 'BBBBBBBBBBBBBBBBBBBBBBBB' ), $remaining );
+	}
+
+	/**
+	 * The account level case. Square reports a location it does not own with the same NOT_FOUND
+	 * code as a dead object, and names no object from the batch. Nothing may be dropped, which is
+	 * what makes the caller fail loudly instead of discarding the batch.
+	 */
+	public function test_an_error_naming_no_object_in_the_batch_drops_nothing() {
+		$chunk = array( $this->change( 'AAAAAAAAAAAAAAAAAAAAAAAA' ), $this->change( 'BBBBBBBBBBBBBBBBBBBBBBBB' ) );
+
+		list( $named, $remaining ) = $this->summarize(
+			$this->call(
+				'partition_inventory_changes_by_error',
+				$chunk,
+				'[NOT_FOUND] This merchant does not have a location with the ID `L0000000FOREIGN`.'
+			)
+		);
+
+		$this->assertSame( array(), $named, 'an unattributable failure must drop nothing' );
+		$this->assertCount( 2, $remaining, 'the whole batch must survive for the caller to rethrow' );
+	}
+
+	/**
+	 * Square quotes the JSON field path rather than the value often enough that parsing an ID out
+	 * of the message is unsafe. Matching the batch's own IDs against the text handles both shapes.
+	 */
+	public function test_the_object_is_found_however_square_formats_the_message() {
+		$chunk = array( $this->change( 'AAAAAAAAAAAAAAAAAAAAAAAA' ) );
+
+		foreach (
+			array(
+				'[NOT_FOUND] Object `AAAAAAAAAAAAAAAAAAAAAAAA` not found.',
+				"[NOT_FOUND] Catalog object 'AAAAAAAAAAAAAAAAAAAAAAAA' was not found",
+				'[NOT_FOUND] Catalog object AAAAAAAAAAAAAAAAAAAAAAAA was not found',
+				'[INVALID_VALUE] Value at `catalog_object_id` is invalid: `AAAAAAAAAAAAAAAAAAAAAAAA`',
+				'[BAD_REQUEST] `changes[0].physical_count.catalog_object_id` bad: AAAAAAAAAAAAAAAAAAAAAAAA',
+			) as $message
+		) {
+			list( $named ) = $this->summarize( $this->call( 'partition_inventory_changes_by_error', $chunk, $message ) );
+			$this->assertSame( array( 'AAAAAAAAAAAAAAAAAAAAAAAA' ), $named, 'failed for: ' . $message );
+		}
+	}
+
+	/**
+	 * A location NOT_FOUND classifies as isolatable, exactly like a dead mapping. This pins the
+	 * pairing so nobody removes NOT_FOUND from the allow list to fix the location case, which
+	 * would stop stale catalog mappings from being isolated at all.
+	 */
+	public function test_not_found_stays_isolatable_so_the_gate_remains_the_discriminator() {
+		$this->assertSame(
+			'isolatable',
+			$this->call( 'classify_sync_error', new \Exception( '[NOT_FOUND] This merchant does not have a location with the ID `L0000000FOREIGN`.' ) )
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Square rejects a whole `batch-upsert` request when any single object in it is invalid, and the sync treated that rejection as a job level failure. One unsyncable product therefore stopped the entire sync, and because the same product failed the same way on every retry, the sync stayed stuck until the merchant found and fixed it themselves. The same shape applied to a failing category chunk and to an inventory batch that referenced a Square object which no longer exists, where every other change in the batch was lost with it.

Reporting was the other half of the problem. The merchant was told only that a product ID "could not be updated in Square", even though Square had returned a precise reason that the plugin discarded.

This PR makes a failure that belongs to one object skip that object and let the rest of the sync finish, and it reports what happened. A failure is only ever isolated when Square's own error code says the object's data is invalid. Anything else, including server errors, timeouts and permission problems, still fails the job loudly, because in those cases the write may already have been applied and retrying the objects one at a time would create duplicate catalog items in Square. Skipping is opted into, never assumed.

Where an error code alone cannot prove whose fault it is, a second check decides. Inventory failures are attributed by testing the batch's own catalog object IDs against the error text, so a stale mapping is dropped while a misconfigured location, which Square reports with the same code, fails loudly instead of silently discarding up to a hundred inventory updates. Similarly, an item option collision raised while building a payload asks the job to restart with refreshed option data, so it is re-thrown rather than blamed on a product that was never broken.

Skipped products are now reported with the product name, SKU, a link to the product, and Square's own reason, and every skip is also logged. The job finishes with a "completed with errors" outcome and a summary of how many products were skipped.

Deviation from an acceptance criterion, called out deliberately: SQUARE-31 asks that when a batch fails and the problem item cannot be identified, the sync log the error and continue to the next batch. That holds for the catalog paths. For inventory it does not, and intentionally so. Continuing there means discarding real stock updates for products that were never at fault, and the case that triggers it in practice is an account level location misconfiguration that would then stay hidden. That path fails loudly instead. Happy to change it if the tradeoff should go the other way.

Closes https://linear.app/a8c/issue/SQUARE-143/feature-request-square-if-product-has-an-issue-skip-the-product
Closes https://linear.app/a8c/issue/SQUARE-31/improve-error-handling-in-the-sync-process

### Notes for reviewers

1. **No workflow runs the unit suite, so nothing here is gated by CI.** Correcting an earlier version of this description which implied otherwise: `.github/workflows/` runs phpcs, php-compat, eslint, e2e, plugin-check and qit, and none of them run `composer test-unit`. The tests this PR adds are tracked, reviewable and runnable by hand, but they will not fail a check. Please run them locally if you want that signal (see note 4 for the one line needed to make the suite boot).
2. What the tests do and do not cover, stated plainly. Covered by the added PHPUnit tests: the error classifier, which alone decides whether one product is skipped or the whole job fails, and the inventory attribution check that separates a stale catalog mapping from an account level location error. Not covered by them, and only exercised by a standalone harness kept outside the repo: the job restart check in the staging path, and the wiring that makes the staging path consult the classifier at all. Removing either of those last two leaves the unit suite green, so anyone changing those blocks should verify by hand.
3. The isolation, inventory and end to end paths were verified against a live Square sandbox, driven through the real background job rather than by calling step methods with injected state. What was exercised: a mixed inventory batch where a stale mapping was dropped and the good updates confirmed by reading the counts back out of Square, a product Square rejects on its own data end to end, a location the token does not own, a variable product with two attributes and four variations, and a resumed cycle. A trunk versus branch comparison on the same product set was also run, which is where the intended behaviour change is visible.
4. `NOT_FOUND` is deliberately treated as an isolatable code even though Square also returns it for a location that does not belong to the account. The attribution check handles that second case separately. Removing `NOT_FOUND` from the list to fix a location error would stop stale catalog mappings from being isolated at all.
5. This PR does not touch the plugin bootstrap, so on a plain trunk checkout `composer test-unit` cannot start and the new tests will not run. `require_once` on the Composer autoloader returns `true` rather than the `ClassLoader` once something else has loaded it, which is always the case under PHPUnit, so the `addPsr4()` call after it fatals. That is pre-existing and reproduces on clean trunk, and it is already fixed on the branch for #529, so this PR relies on that fix rather than repeating it. Until #529 is in trunk, the unit job will fail to boot. To run the tests before then, apply the small local patch in this gist: https://gist.github.com/faisal-alvi/208838dce6238a14d481c6822cba8280
6. `composer test-unit` reports 1 skipped test. That is a pre-existing conditional in the abilities registrar test which only applies when the abilities loader is absent, and is unrelated to this work.
7. A skipped product still counts toward the sync progress figure, so a sync that skipped products can report 100 per cent complete. That is deliberate for now: the progress figure counts products the cycle consumed, and consuming a product is what stops the sync retrying it forever. The outcome is reported separately as a completed with errors notice naming each skipped product. Splitting progress from success touches the shared status calculation used by the Square to WooCommerce import as well, so it is left out of this change.
8. This branch shares a method with #529. The two compose, and a test merge of the sync file is clean, but #529 should merge first and this branch will be rebased onto it before review.

### Steps to test the changes in this Pull Request:

1. Connect the plugin to a Square sandbox and set the sync setting so WooCommerce is the system of record.
2. Create three simple products with SKUs and stock quantities, and let a sync complete so they exist in Square.
3. Give one of those products a name longer than 512 characters, which Square rejects, and leave the other two valid.
4. Run "Sync now" and let the job finish.
5. Confirm the job completes rather than failing, and that the sync records show one alert naming the offending product and SKU with Square's reason, plus a summary line stating that one product was skipped.
6. Confirm in Square that the other two products synced, and that no duplicate items were created for any of them.
7. For the inventory path, set a valid product's stored Square variation ID meta to a well formed but nonexistent ID, set fresh stock quantities on it and on a valid product, and run "Sync now" again.
8. Confirm the products with real mappings have their new quantities in Square, and that the product with the dead mapping is reported as skipped rather than the whole inventory batch being lost.
9. To check the loud failure path, temporarily set the configured location ID to one the token does not own and run a sync. Confirm the job fails and that no product is reported as skipped, since nothing here is the product's fault. Restore the location afterwards.

### Changelog entry

> Fix - Skip products that Square rejects during a sync instead of failing the whole sync, and report the name, SKU and reason for each skipped product.

