### PR TITLE
Reuse existing Square item options instead of failing on case or pagination

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -818,8 +818,25 @@ class API extends Base {
 
 			$id_mappings = $new_option->get_data()->getIdMappings();
 
-			if ( isset( $id_mappings[0] ) ) {
-				$option_id = $id_mappings[0]->getObjectId();
+			// Resolved on the create path only, and never positionally. The upsert reports a mapping
+			// for every object it created, so when an option that already existed merely gained a
+			// value, the first row is that new ITEM_OPTION_VAL and the option has no row at all.
+			// Index 0 therefore hands back a value ID, which travels on into the item's item_options
+			// and kills the following sync with "An existing Item Option has name X". On the reuse
+			// path $option_id is already the real ID Square gave us, so the mappings add nothing and
+			// must not be allowed to overwrite it.
+			if ( ! $option_id ) {
+				// The option went up under the temp ID set above, and that is the client ID Square
+				// echoes back alongside the real one. It is empty only when no attribute name was
+				// supplied, and there is nothing to correlate on then: guessing a row is the bug.
+				$client_option_id = $option->getId();
+
+				foreach ( (array) $id_mappings as $id_mapping ) {
+					if ( $client_option_id && $client_option_id === $id_mapping->getClientObjectId() ) {
+						$option_id = $id_mapping->getObjectId();
+						break;
+					}
+				}
 			}
 
 			$response = $this->retrieve_catalog_object( $option_id );

--- a/includes/API.php
+++ b/includes/API.php
@@ -692,6 +692,47 @@ class API extends Base {
 	}
 
 	/**
+	 * Records one item option in whichever options cache is authoritative right now.
+	 *
+	 * Callers here hold a single option they just read or created, not a walked catalogue. The
+	 * cache they must not touch is the finished one: building it from an unlooped read would pass
+	 * off the first page of a paginated catalogue as the whole of it, for a day. So a read still
+	 * in flight owns the data and the option joins its partial cache; otherwise the option is
+	 * folded into a finished cache that already exists. With neither, there is nothing to extend
+	 * and the next full read is left to build it.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $option_id   Square item option ID.
+	 * @param array  $option_data Cache entry for the option.
+	 * @return void
+	 */
+	public function cache_option_data( $option_id, array $option_data ) {
+
+		if ( ! $option_id ) {
+			return;
+		}
+
+		$partial = get_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT );
+
+		if ( is_array( $partial ) ) {
+			$partial[ $option_id ] = $option_data;
+			set_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT, $partial, DAY_IN_SECONDS );
+
+			return;
+		}
+
+		$options_data = get_transient( 'wc_square_options_data' );
+
+		if ( ! is_array( $options_data ) ) {
+			return;
+		}
+
+		$options_data[ $option_id ] = $option_data;
+		set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
+	}
+
+	/**
 	 * Create options and values in Square.
 	 *
 	 * @since 4.9.0
@@ -777,15 +818,14 @@ class API extends Base {
 				$option_values[]    = $option_value->getItemOptionValueData()->getName();
 			}
 
-			$result       = $this->retrieve_options_data();
-			$options_data = isset( $result[1] ) ? $result[1] : array();
-
-			$options_data[ $option_id ] = array(
-				'name'      => $attribute_name,
-				'values'    => $option_values,
-				'value_ids' => array_combine( $option_value_ids, $option_values ),
+			$this->cache_option_data(
+				$option_id,
+				array(
+					'name'      => $attribute_name,
+					'values'    => $option_values,
+					'value_ids' => array_combine( $option_value_ids, $option_values ),
+				)
 			);
-			set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
 
 		} catch ( \Exception $e ) {
 			/**

--- a/includes/API.php
+++ b/includes/API.php
@@ -42,6 +42,17 @@ defined( 'ABSPATH' ) || exit;
 class API extends Base {
 
 
+	/**
+	 * Holds item option pages while the catalogue is still being walked.
+	 *
+	 * Kept apart from `wc_square_options_data`, which means "every option, fully read". Writing
+	 * partial pages under that name would make the next call return early with an incomplete cache.
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	const OPTIONS_DATA_PARTIAL_TRANSIENT = 'wc_square_options_data_partial';
+
 	/** catalog request type */
 	const REQUEST_TYPE_CATALOG = 'catalog';
 
@@ -629,6 +640,18 @@ class API extends Base {
 			$options_data = array();
 		}
 
+		// Carry earlier pages forward. The finished cache is only written once the cursor is
+		// exhausted, because the early return above would otherwise hand back a half built cache and
+		// re-emit the same cursor forever. So pages accumulate under their own key, and without this
+		// every page starts from nothing and only the last one survives.
+		if ( $cursor ) {
+			$partial = get_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT );
+
+			if ( is_array( $partial ) ) {
+				$options_data = $partial + $options_data;
+			}
+		}
+
 		$response = $this->list_catalog( $cursor, array( 'ITEM_OPTION' ) );
 
 		if ( ! $response->get_data() instanceof ListCatalogResponse ) {
@@ -654,8 +677,13 @@ class API extends Base {
 		}
 
 		$cursor = $response->get_data()->getCursor();
-		if ( ! $cursor ) {
+		if ( $cursor ) {
+			// More pages to come, so keep what has been read so far somewhere the early return
+			// cannot mistake for a finished cache.
+			set_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT, $options_data, HOUR_IN_SECONDS );
+		} else {
 			set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
+			delete_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT );
 		}
 
 		return array( $response, $options_data, $cursor );

--- a/includes/API.php
+++ b/includes/API.php
@@ -679,8 +679,10 @@ class API extends Base {
 		$cursor = $response->get_data()->getCursor();
 		if ( $cursor ) {
 			// More pages to come, so keep what has been read so far somewhere the early return
-			// cannot mistake for a finished cache.
-			set_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT, $options_data, HOUR_IN_SECONDS );
+			// cannot mistake for a finished cache. Given the same lifetime as the finished cache so
+			// a walk left sitting in the queue cannot come back to a vanished partial and resume
+			// from nothing, which would truncate it in silence.
+			set_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT, $options_data, DAY_IN_SECONDS );
 		} else {
 			set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
 			delete_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT );

--- a/includes/API.php
+++ b/includes/API.php
@@ -48,6 +48,14 @@ class API extends Base {
 	 * Kept apart from `wc_square_options_data`, which means "every option, fully read". Writing
 	 * partial pages under that name would make the next call return early with an incomplete cache.
 	 *
+	 * One key is shared by every walk, which is only safe because the background job runner takes
+	 * the oldest queued or processing job on every tick and runs a single step of it
+	 * (`WP_Background_Job_Handler::get_job()`, `ORDER BY option_id ASC LIMIT 1`). A job therefore
+	 * holds the runner for the whole of its walk, and no second job can interleave a step that
+	 * starts a competing read. If job selection ever gains priority ordering or parallel runners,
+	 * two walks could overwrite each other's pages here and promote a silently truncated cache,
+	 * which is the very failure this class of bug is about. Make the key per job before that lands.
+	 *
 	 * @since x.x.x
 	 * @var string
 	 */
@@ -736,8 +744,27 @@ class API extends Base {
 		$options_value_data = array();
 
 		if ( $option_id ) {
-			$response = $this->retrieve_catalog_object( $option_id );
-			$option   = $response->get_data() ? $response->get_data()->getObject() : null;
+			$option = null;
+
+			try {
+				$response = $this->retrieve_catalog_object( $option_id );
+				$option   = $response->get_data() ? $response->get_data()->getObject() : null;
+			} catch ( \Exception $e ) {
+				// Square answers a deleted or unknown ID with NOT_FOUND, and the response validator
+				// turns that into an exception before any data comes back, so the null check below
+				// never gets the chance to see it. Without this the whole method gives up on a
+				// stale cached ID, no refresh flag is set, and every sync fails the same way until
+				// the cache expires a day later.
+				//
+				// Narrowed to that one code deliberately, and matched in the bracketed form
+				// do_post_parse_response_validation() emits so it cannot be tripped by another
+				// error quoting those words in its detail text. Reading a RATE_LIMITED or an auth
+				// failure as "no such option" would create a duplicate of an option Square still
+				// holds, and would swallow the rate limit the job runner needs in order to back off.
+				if ( false === strpos( $e->getMessage(), '[NOT_FOUND]' ) ) {
+					throw $e;
+				}
+			}
 
 			// A cached option ID can name an object Square no longer has, or one that is not an
 			// item option at all. Treat that as no match and fall through to the create path,

--- a/includes/API.php
+++ b/includes/API.php
@@ -677,8 +677,17 @@ class API extends Base {
 
 		if ( $option_id ) {
 			$response = $this->retrieve_catalog_object( $option_id );
-			$option   = $response->get_data()->getObject();
+			$option   = $response->get_data() ? $response->get_data()->getObject() : null;
 
+			// A cached option ID can name an object Square no longer has, or one that is not an
+			// item option at all. Treat that as no match and fall through to the create path,
+			// rather than calling setValues() on a null item option and taking the sync down.
+			if ( ! $option || 'ITEM_OPTION' !== $option->getType() || ! $option->getItemOptionData() ) {
+				$option_id = false;
+			}
+		}
+
+		if ( $option_id ) {
 			// Filter out the existing option values from the attribute values.
 			$square_existing_option_objects = $option->getItemOptionData() ? $option->getItemOptionData()->getValues() : array();
 			$options_value_data             = $square_existing_option_objects;

--- a/includes/API.php
+++ b/includes/API.php
@@ -687,7 +687,10 @@ class API extends Base {
 			foreach ( $square_existing_option_objects as $option_object ) {
 				$square_existing_option_values[] = $option_object->getItemOptionValueData()->getName();
 			}
-			$attribute_option_values = array_diff( $attribute_option_values, $square_existing_option_values );
+			// Compared without case for the same reason the option name is: Square rejects a value
+			// whose name differs from an existing one only by case, so a case sensitive diff would
+			// ask for a value that can never be created.
+			$attribute_option_values = array_udiff( $attribute_option_values, $square_existing_option_values, 'strcasecmp' );
 		} else {
 			// Initialize the option object with a temp ID prefixed with #.
 			$option = new \Square\Models\CatalogObject( 'ITEM_OPTION', '' );

--- a/includes/API.php
+++ b/includes/API.php
@@ -692,14 +692,12 @@ class API extends Base {
 	}
 
 	/**
-	 * Records one item option in whichever options cache is authoritative right now.
+	 * Folds one item option into the finished options cache.
 	 *
-	 * Callers here hold a single option they just read or created, not a walked catalogue. The
-	 * cache they must not touch is the finished one: building it from an unlooped read would pass
-	 * off the first page of a paginated catalogue as the whole of it, for a day. So a read still
-	 * in flight owns the data and the option joins its partial cache; otherwise the option is
-	 * folded into a finished cache that already exists. With neither, there is nothing to extend
-	 * and the next full read is left to build it.
+	 * Callers here hold a single option they just read or created, not a walked catalogue, so the
+	 * cache is only ever extended, never built: writing one from an unlooped read would pass off
+	 * the first page of a paginated catalogue as the whole of it, for a day. With no cache to
+	 * extend there is nothing to do and the next full read is left to build it.
 	 *
 	 * @since x.x.x
 	 *
@@ -710,15 +708,6 @@ class API extends Base {
 	public function cache_option_data( $option_id, array $option_data ) {
 
 		if ( ! $option_id ) {
-			return;
-		}
-
-		$partial = get_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT );
-
-		if ( is_array( $partial ) ) {
-			$partial[ $option_id ] = $option_data;
-			set_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT, $partial, DAY_IN_SECONDS );
-
 			return;
 		}
 

--- a/includes/API.php
+++ b/includes/API.php
@@ -836,6 +836,10 @@ class API extends Base {
 			 */
 			update_option( 'woocommerce_square_refresh_sync_cycle', true );
 			delete_transient( 'wc_square_options_data' );
+			// Cleared alongside the finished cache. A walk abandoned by this reset has no reader
+			// left, and leaving its pages behind would only give the writes below somewhere stale
+			// to land until the next walk overwrites it.
+			delete_transient( self::OPTIONS_DATA_PARTIAL_TRANSIENT );
 
 			// Log the error and throw it.
 			wc_square()->log( sprintf( 'Resetting the Sync Job. Failed to create option in Square: %s. The system will refetch latest Options from Square.', $e->getMessage() ) );

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -130,7 +130,10 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 					// if yes, use the relative Square ID.
 					$option_id = false;
 					foreach ( $options_data as $transient_option_id => $option_data_transient ) {
-						if ( $option_data_transient['name'] === $attribute_name ) {
+						// Square treats Item Option names as case insensitive and rejects a create whose
+						// name differs from an existing one only by case, so match the same way and
+						// reuse what Square already has.
+						if ( 0 === strcasecmp( (string) $option_data_transient['name'], (string) $attribute_name ) ) {
 							$option_id = $transient_option_id;
 							break;
 						}
@@ -349,7 +352,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						$option_id = $options_ids[ $variation_index ];
 
 						foreach ( $options_data[ $options_ids[ $variation_index ] ]['value_ids'] as $value_id => $value_name ) {
-							if ( $value_name === $attribute_value ) {
+							if ( 0 === strcasecmp( (string) $value_name, (string) $attribute_value ) ) {
 								$option_value_id = $value_id;
 								break;
 							}
@@ -385,7 +388,7 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						// Get the Square ID of the attribute value.
 						$updated_option_values = $option->getItemOptionData() ? $option->getItemOptionData()->getValues() : array();
 						foreach ( $updated_option_values as $option_value ) {
-							if ( $option_value->getItemOptionValueData()->getName() === $attribute_value ) {
+							if ( 0 === strcasecmp( (string) $option_value->getItemOptionValueData()->getName(), (string) $attribute_value ) ) {
 								$option_value_id = $option_value->getId();
 								break;
 							}

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -346,6 +346,14 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						$variation_name[] = $attribute_value;
 					}
 
+					// Remembered so a case insensitive match below can correct this entry in place.
+					// Square builds a variation's name out of its own option value names and then
+					// refuses to let that name be edited for as long as the variation uses item
+					// options. A name carrying Woo's casing against values bound to Square's is
+					// therefore accepted on the create and rejected on every update after it, with
+					// no refresh flag and no self heal, so the product stays unsyncable for good.
+					$variation_name_index = count( $variation_name ) - 1;
+
 					// Taken from the option the parent product just created or reused, not from the
 					// cache, because the cache can legitimately not know about it yet: an unlooped
 					// read on a paginated catalogue leaves the new option in the partial cache only.
@@ -357,6 +365,11 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						foreach ( $options_data[ $option_id ]['value_ids'] as $value_id => $value_name ) {
 							if ( 0 === strcasecmp( (string) $value_name, (string) $attribute_value ) ) {
 								$option_value_id = $value_id;
+								// Square's spelling of the value wins, because that is the value
+								// the ID above points at and the one Square will name the variation
+								// from. Byte identical whenever the casing already agrees, so
+								// nothing that was already in sync gets renamed.
+								$variation_name[ $variation_name_index ] = $value_name;
 								break;
 							}
 						}
@@ -393,6 +406,9 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						foreach ( $updated_option_values as $option_value ) {
 							if ( 0 === strcasecmp( (string) $option_value->getItemOptionValueData()->getName(), (string) $attribute_value ) ) {
 								$option_value_id = $option_value->getId();
+								// Same rule as the cache path above: follow the bound value's own
+								// name, not the Woo attribute's.
+								$variation_name[ $variation_name_index ] = $option_value->getItemOptionValueData()->getName();
 								break;
 							}
 						}

--- a/includes/Handlers/Product/Woo_SOR.php
+++ b/includes/Handlers/Product/Woo_SOR.php
@@ -346,12 +346,15 @@ class Woo_SOR extends \WooCommerce\Square\Handlers\Product {
 						$variation_name[] = $attribute_value;
 					}
 
-					$option_id       = '';
+					// Taken from the option the parent product just created or reused, not from the
+					// cache, because the cache can legitimately not know about it yet: an unlooped
+					// read on a paginated catalogue leaves the new option in the partial cache only.
+					// Carrying the ID regardless means the create below takes the retrieve path and
+					// reuses that option, instead of asking Square for one it already has.
+					$option_id       = isset( $options_ids[ $variation_index ] ) ? $options_ids[ $variation_index ] : '';
 					$option_value_id = '';
-					if ( isset( $options_data[ $options_ids[ $variation_index ] ] ) ) {
-						$option_id = $options_ids[ $variation_index ];
-
-						foreach ( $options_data[ $options_ids[ $variation_index ] ]['value_ids'] as $value_id => $value_name ) {
+					if ( isset( $options_data[ $option_id ] ) ) {
+						foreach ( $options_data[ $option_id ]['value_ids'] as $value_id => $value_name ) {
 							if ( 0 === strcasecmp( (string) $value_name, (string) $attribute_value ) ) {
 								$option_value_id = $value_id;
 								break;

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2182,6 +2182,13 @@ class Manual_Synchronization extends Stepped_Job {
 		$result     = wc_square()->get_api()->retrieve_options_data( $cursor );
 		$new_cursor = isset( $result[2] ) ? $result[2] : null;
 
+		// Keep the options this page returned. The API layer accumulates them across pages now, and
+		// recording the running count here is what makes a truncated read visible in the log instead
+		// of surfacing later as Square rejecting an option it already has.
+		if ( isset( $result[1] ) && is_array( $result[1] ) ) {
+			$this->set_attr( 'fetch_options_data_count', count( $result[1] ) );
+		}
+
 		$this->set_attr( 'fetch_options_data_cursor', $new_cursor );
 
 		if ( empty( $new_cursor ) ) {

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2188,8 +2188,6 @@ class Manual_Synchronization extends Stepped_Job {
 		if ( isset( $result[1] ) && is_array( $result[1] ) ) {
 			$option_count = count( $result[1] );
 
-			$this->set_attr( 'fetch_options_data_count', $option_count );
-
 			wc_square()->log(
 				sprintf(
 					'Fetched item options from Square: %1$d accumulated, %2$s.',

--- a/includes/Sync/Manual_Synchronization.php
+++ b/includes/Sync/Manual_Synchronization.php
@@ -2182,11 +2182,21 @@ class Manual_Synchronization extends Stepped_Job {
 		$result     = wc_square()->get_api()->retrieve_options_data( $cursor );
 		$new_cursor = isset( $result[2] ) ? $result[2] : null;
 
-		// Keep the options this page returned. The API layer accumulates them across pages now, and
-		// recording the running count here is what makes a truncated read visible in the log instead
-		// of surfacing later as Square rejecting an option it already has.
+		// Logged per page, not just at the end, so a read that stops short is visible here as a
+		// count that never reaches the number of options Square holds. Without it a truncated read
+		// only surfaces much later, as Square rejecting an option it already has.
 		if ( isset( $result[1] ) && is_array( $result[1] ) ) {
-			$this->set_attr( 'fetch_options_data_count', count( $result[1] ) );
+			$option_count = count( $result[1] );
+
+			$this->set_attr( 'fetch_options_data_count', $option_count );
+
+			wc_square()->log(
+				sprintf(
+					'Fetched item options from Square: %1$d accumulated, %2$s.',
+					$option_count,
+					empty( $new_cursor ) ? 'read complete' : 'more pages to follow'
+				)
+			);
 		}
 
 		$this->set_attr( 'fetch_options_data_cursor', $new_cursor );

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -93,6 +93,7 @@ class Product_Import extends Stepped_Job {
 		$result     = wc_square()->get_api()->retrieve_options_data( $cursor );
 		$new_cursor = isset( $result[2] ) ? $result[2] : null;
 
+
 		if ( ! empty( $new_cursor ) ) {
 			$this->set_attr( 'fetch_options_data_cursor', $new_cursor );
 		} else {
@@ -771,7 +772,10 @@ class Product_Import extends Stepped_Job {
 					'value_ids' => $option_value_ids,
 				);
 
-				set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
+				// Handed to the API layer rather than written straight to the finished cache: the
+				// read above never walks the cursor, so its set can be the first page of a
+				// paginated catalogue and must not be published as the whole of it.
+				wc_square()->get_api()->cache_option_data( $option_id, $options_data[ $option_id ] );
 			}
 
 			$attributes[] = array(
@@ -868,7 +872,9 @@ class Product_Import extends Stepped_Job {
 					'values'    => $option_values,
 					'value_ids' => array_combine( $option_value_ids, $option_values ),
 				);
-				set_transient( 'wc_square_options_data', $options_data, DAY_IN_SECONDS );
+
+				// Same reason as above: an unlooped read must not publish under the finished cache.
+				wc_square()->get_api()->cache_option_data( $option_id, $options_data[ $option_id ] );
 			}
 
 			// Filter option values to only include those actually used by variations.

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -93,6 +93,22 @@ class Product_Import extends Stepped_Job {
 		$result     = wc_square()->get_api()->retrieve_options_data( $cursor );
 		$new_cursor = isset( $result[2] ) ? $result[2] : null;
 
+		// Logged per page, not just at the end, so a read that stops short is visible here as a
+		// count that never reaches the number of options Square holds. Without it a truncated read
+		// only surfaces much later, as Square rejecting an option it already has.
+		if ( isset( $result[1] ) && is_array( $result[1] ) ) {
+			$option_count = count( $result[1] );
+
+			$this->set_attr( 'fetch_options_data_count', $option_count );
+
+			wc_square()->log(
+				sprintf(
+					'Fetched item options from Square: %1$d accumulated, %2$s.',
+					$option_count,
+					empty( $new_cursor ) ? 'read complete' : 'more pages to follow'
+				)
+			);
+		}
 
 		if ( ! empty( $new_cursor ) ) {
 			$this->set_attr( 'fetch_options_data_cursor', $new_cursor );

--- a/includes/Sync/Product_Import.php
+++ b/includes/Sync/Product_Import.php
@@ -99,8 +99,6 @@ class Product_Import extends Stepped_Job {
 		if ( isset( $result[1] ) && is_array( $result[1] ) ) {
 			$option_count = count( $result[1] );
 
-			$this->set_attr( 'fetch_options_data_count', $option_count );
-
 			wc_square()->log(
 				sprintf(
 					'Fetched item options from Square: %1$d accumulated, %2$s.',

--- a/tests/php/Unit/API/Create_Options_And_Values_Test.php
+++ b/tests/php/Unit/API/Create_Options_And_Values_Test.php
@@ -113,6 +113,9 @@ class Create_Options_And_Values_Test extends WP_UnitTestCase {
 	/**
 	 * A cached ID naming an object Square no longer holds used to call setValues() on a null
 	 * item option and take the whole sync down with a fatal.
+	 *
+	 * The retrieve throws NOT_FOUND here rather than answering emptily, which is what Square
+	 * really does, so this now exercises the catch rather than the null check.
 	 */
 	public function test_unresolvable_option_id_falls_through_to_the_create_path() {
 		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_NEW' => 'Green' ) );
@@ -126,6 +129,31 @@ class Create_Options_And_Values_Test extends WP_UnitTestCase {
 		$this->assertSame( array( 'Green' ), $this->upserted_value_names( $this->api->upserted_objects[0] ) );
 		$this->assertSame( 'NEW_OPT', $option->getId() );
 		$this->assertSame( array( 'DELETED_OPT', 'NEW_OPT' ), $this->api->retrieved_object_ids );
+	}
+
+	/**
+	 * The other half of the missing object handling: only NOT_FOUND means "no such option".
+	 *
+	 * A rate limit or an auth failure is a temporary condition on an option that probably still
+	 * exists. Swallowing it would create a second option under a name Square already has, which is
+	 * the exact error this whole change exists to stop, and would hide the RATE_LIMITED string the
+	 * job runner matches on to back off and retry.
+	 */
+	public function test_a_non_missing_failure_is_not_treated_as_a_missing_option() {
+		$this->api->set_retrieve_exception( new \Exception( '[RATE_LIMITED] Too many requests' ) );
+
+		$threw = false;
+
+		try {
+			$this->api->create_options_and_values( 'OPT_COLOUR', 'Colour', array( 'Red' ) );
+		} catch ( \Exception $e ) {
+			$threw = true;
+			$this->assertStringContainsString( 'RATE_LIMITED', $e->getMessage(), 'The rate limit must reach the caller intact.' );
+		}
+
+		$this->assertTrue( $threw, 'A rate limited retrieve must not be reported as success.' );
+		$this->assertSame( array(), $this->api->upserted_objects, 'A transient failure must never create a duplicate option.' );
+		$this->assertFalse( get_option( 'woocommerce_square_refresh_sync_cycle' ), 'The retrieve sits outside the reset handler, so no sync reset is expected.' );
 	}
 
 	/**
@@ -161,6 +189,64 @@ class Create_Options_And_Values_Test extends WP_UnitTestCase {
 		$this->api->create_options_and_values( 'HOLLOW_OPT', 'Colour', array( 'Green' ) );
 
 		$this->assertSame( '#Colour', $this->api->upserted_objects[0]->getId() );
+	}
+
+	/**
+	 * Adding a value to an option Square already holds must still return the OPTION's ID.
+	 *
+	 * The upsert reports a mapping for the value it just created and none for the option, which
+	 * already existed, so reading the mappings positionally returned that value ID. It then went
+	 * into the item's item_options, the variation loop found no value beneath it, and the next sync
+	 * died with "An existing Item Option has name". Case insensitive matching sends far more stores
+	 * down this reuse path, which is what turned a latent bug into a common one.
+	 */
+	public function test_adding_a_value_to_an_existing_option_returns_the_option_id() {
+		$existing = Scripted_API::make_option( 'OPT_COLOUR', 'color', array( 'VAL_RED' => 'red' ) );
+
+		$this->api->register_catalog_object( 'OPT_COLOUR', $existing )
+			->set_upsert_id_mappings(
+				array(
+					array(
+						'client_object_id' => '#color_Blue',
+						'object_id'        => 'VAL_BLUE',
+					),
+				)
+			)
+			->set_upsert_object_id( null );
+
+		$option = $this->api->create_options_and_values( 'OPT_COLOUR', 'color', array( 'red', 'Blue' ) );
+
+		$this->assertSame( 'OPT_COLOUR', $option->getId(), 'The option ID must survive an upsert that only created a value.' );
+		$this->assertSame( array( 'OPT_COLOUR', 'OPT_COLOUR' ), $this->api->retrieved_object_ids, 'A value ID must never be retrieved in place of the option.' );
+
+		$cached = get_transient( 'wc_square_options_data' );
+
+		$this->assertArrayHasKey( 'OPT_COLOUR', $cached );
+		$this->assertArrayNotHasKey( 'VAL_BLUE', $cached, 'A value ID must never be cached as though it were an option.' );
+	}
+
+	/**
+	 * On the create path the option does have a mapping, but Square need not report it first.
+	 */
+	public function test_create_path_takes_the_option_mapping_not_the_first_one() {
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_GREEN' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'NEW_OPT', $created )
+			->set_upsert_id_mappings(
+				array(
+					array(
+						'client_object_id' => '#Colour_Green',
+						'object_id'        => 'VAL_GREEN',
+					),
+				)
+			)
+			->set_upsert_object_id( 'NEW_OPT' );
+
+		$option = $this->api->create_options_and_values( false, 'Colour', array( 'Green' ) );
+
+		$this->assertSame( 'NEW_OPT', $option->getId(), 'The option must be resolved by the temp ID it was sent under.' );
+		$this->assertSame( array( 'NEW_OPT' ), $this->api->retrieved_object_ids );
+		$this->assertArrayHasKey( 'NEW_OPT', get_transient( 'wc_square_options_data' ) );
 	}
 
 	/**

--- a/tests/php/Unit/API/Create_Options_And_Values_Test.php
+++ b/tests/php/Unit/API/Create_Options_And_Values_Test.php
@@ -210,10 +210,11 @@ class Create_Options_And_Values_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * While a paginated read is in flight the partial cache is the authoritative one, so the
-	 * new option belongs there and the finished cache must be left untouched.
+	 * A partial left behind by an unlooped read has no reader: every caller of the write back runs
+	 * after the options step has emptied the cursor, so a walk can never be in flight here. The
+	 * write belongs to the finished cache and the leftover is not to be touched.
 	 */
-	public function test_created_option_joins_an_in_flight_partial_read() {
+	public function test_created_option_ignores_a_leftover_partial_read() {
 		set_transient(
 			API::OPTIONS_DATA_PARTIAL_TRANSIENT,
 			array(
@@ -232,14 +233,14 @@ class Create_Options_And_Values_Test extends WP_UnitTestCase {
 
 		$this->api->create_options_and_values( false, 'Colour', array( 'Green' ) );
 
-		$partial = get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+		$finished = get_transient( 'wc_square_options_data' );
 
-		$this->assertSame( array( 'OPT_PAGE_ONE', 'NEW_OPT' ), array_keys( $partial ) );
-		$this->assertSame( 'Colour', $partial['NEW_OPT']['name'] );
+		$this->assertSame( array( 'OPT_UNRELATED', 'NEW_OPT' ), array_keys( $finished ) );
+		$this->assertSame( 'Colour', $finished['NEW_OPT']['name'] );
 		$this->assertSame(
-			array( 'OPT_UNRELATED' ),
-			array_keys( get_transient( 'wc_square_options_data' ) ),
-			'A read in flight owns the data, so the finished cache must not be touched.'
+			array( 'OPT_PAGE_ONE' ),
+			array_keys( get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT ) ),
+			'A leftover partial belongs to an abandoned walk, so it must be left alone.'
 		);
 	}
 

--- a/tests/php/Unit/API/Create_Options_And_Values_Test.php
+++ b/tests/php/Unit/API/Create_Options_And_Values_Test.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Tests for WooCommerce\Square\API::create_options_and_values().
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\API;
+
+use Square\Models\CatalogItem;
+use Square\Models\CatalogObject;
+use WooCommerce\Square\API;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/Scripted_API.php';
+
+class Create_Options_And_Values_Test extends WP_UnitTestCase {
+
+	/**
+	 * Scripted API under test.
+	 *
+	 * @var Scripted_API
+	 */
+	private $api;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_transient( 'wc_square_options_data' );
+		delete_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+		delete_option( 'woocommerce_square_refresh_sync_cycle' );
+
+		$this->api = new Scripted_API();
+
+		// A complete cache keeps the tail of create_options_and_values() off the wire, so each
+		// test only exercises the option matching it is about.
+		set_transient(
+			'wc_square_options_data',
+			array(
+				'OPT_UNRELATED' => array(
+					'name'      => 'Unrelated',
+					'values'    => array(),
+					'value_ids' => array(),
+				),
+			),
+			DAY_IN_SECONDS
+		);
+	}
+
+	public function tearDown(): void {
+		delete_transient( 'wc_square_options_data' );
+		delete_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+		delete_option( 'woocommerce_square_refresh_sync_cycle' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Returns the value names on the object handed to the upsert call.
+	 *
+	 * @param CatalogObject $catalog_object Upserted option object.
+	 * @return array
+	 */
+	private function upserted_value_names( CatalogObject $catalog_object ) {
+		$names = array();
+
+		foreach ( $catalog_object->getItemOptionData()->getValues() as $value ) {
+			$names[] = $value->getItemOptionValueData()->getName();
+		}
+
+		return $names;
+	}
+
+	/**
+	 * Square rejects a value whose name differs from an existing one only by case, so a
+	 * case sensitive diff would keep asking for a value that can never be created.
+	 */
+	public function test_existing_values_are_matched_without_regard_to_case() {
+		$existing = Scripted_API::make_option(
+			'OPT_COLOUR',
+			'Colour',
+			array(
+				'VAL_RED'  => 'Red',
+				'VAL_BLUE' => 'Blue',
+			)
+		);
+
+		$this->api->register_catalog_object( 'OPT_COLOUR', $existing )->set_upsert_object_id( null );
+
+		$this->api->create_options_and_values( 'OPT_COLOUR', 'Colour', array( 'red', 'BLUE', 'Green' ) );
+
+		$this->assertCount( 1, $this->api->upserted_objects );
+
+		$upserted = $this->api->upserted_objects[0];
+
+		$this->assertSame( 'OPT_COLOUR', $upserted->getId(), 'The existing option must be updated, not recreated.' );
+		$this->assertSame( array( 'Red', 'Blue', 'Green' ), $this->upserted_value_names( $upserted ) );
+	}
+
+	/**
+	 * Nothing new to add: the upsert must carry only what Square already has.
+	 */
+	public function test_values_differing_only_by_case_add_nothing() {
+		$existing = Scripted_API::make_option( 'OPT_SIZE', 'Size', array( 'VAL_SMALL' => 'Small' ) );
+
+		$this->api->register_catalog_object( 'OPT_SIZE', $existing )->set_upsert_object_id( null );
+
+		$this->api->create_options_and_values( 'OPT_SIZE', 'Size', array( 'SMALL', 'small' ) );
+
+		$this->assertSame( array( 'Small' ), $this->upserted_value_names( $this->api->upserted_objects[0] ) );
+	}
+
+	/**
+	 * A cached ID naming an object Square no longer holds used to call setValues() on a null
+	 * item option and take the whole sync down with a fatal.
+	 */
+	public function test_unresolvable_option_id_falls_through_to_the_create_path() {
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_NEW' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'NEW_OPT', $created )->set_upsert_object_id( 'NEW_OPT' );
+
+		$option = $this->api->create_options_and_values( 'DELETED_OPT', 'Colour', array( 'Green' ) );
+
+		$this->assertCount( 1, $this->api->upserted_objects );
+		$this->assertSame( '#Colour', $this->api->upserted_objects[0]->getId(), 'A missing option must be created under a temp ID.' );
+		$this->assertSame( array( 'Green' ), $this->upserted_value_names( $this->api->upserted_objects[0] ) );
+		$this->assertSame( 'NEW_OPT', $option->getId() );
+		$this->assertSame( array( 'DELETED_OPT', 'NEW_OPT' ), $this->api->retrieved_object_ids );
+	}
+
+	/**
+	 * Same protection, for an ID that resolves to something that is not an item option.
+	 */
+	public function test_option_id_resolving_to_another_object_type_falls_through_to_the_create_path() {
+		$not_an_option = new CatalogObject( 'ITEM', 'SOME_ITEM' );
+		$not_an_option->setItemData( new CatalogItem() );
+
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_NEW' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'SOME_ITEM', $not_an_option )
+			->register_catalog_object( 'NEW_OPT', $created )
+			->set_upsert_object_id( 'NEW_OPT' );
+
+		$this->api->create_options_and_values( 'SOME_ITEM', 'Colour', array( 'Green' ) );
+
+		$this->assertSame( '#Colour', $this->api->upserted_objects[0]->getId() );
+		$this->assertSame( array( 'Green' ), $this->upserted_value_names( $this->api->upserted_objects[0] ) );
+	}
+
+	/**
+	 * An ITEM_OPTION carrying no item option data is just as unusable as a missing one.
+	 */
+	public function test_option_without_item_option_data_falls_through_to_the_create_path() {
+		$hollow  = new CatalogObject( 'ITEM_OPTION', 'HOLLOW_OPT' );
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_NEW' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'HOLLOW_OPT', $hollow )
+			->register_catalog_object( 'NEW_OPT', $created )
+			->set_upsert_object_id( 'NEW_OPT' );
+
+		$this->api->create_options_and_values( 'HOLLOW_OPT', 'Colour', array( 'Green' ) );
+
+		$this->assertSame( '#Colour', $this->api->upserted_objects[0]->getId() );
+	}
+
+	/**
+	 * The freshly created option is written back into the options cache under its real ID.
+	 */
+	public function test_created_option_is_written_back_to_the_options_cache() {
+		$created = Scripted_API::make_option(
+			'NEW_OPT',
+			'Colour',
+			array(
+				'VAL_GREEN' => 'Green',
+				'VAL_TEAL'  => 'Teal',
+			)
+		);
+
+		$this->api->register_catalog_object( 'NEW_OPT', $created )->set_upsert_object_id( 'NEW_OPT' );
+
+		$this->api->create_options_and_values( false, 'Colour', array( 'Green', 'Teal' ) );
+
+		$cached = get_transient( 'wc_square_options_data' );
+
+		$this->assertArrayHasKey( 'NEW_OPT', $cached );
+		$this->assertSame( 'Colour', $cached['NEW_OPT']['name'] );
+		$this->assertSame( array( 'Green', 'Teal' ), $cached['NEW_OPT']['values'] );
+		$this->assertSame(
+			array(
+				'VAL_GREEN' => 'Green',
+				'VAL_TEAL'  => 'Teal',
+			),
+			$cached['NEW_OPT']['value_ids']
+		);
+		$this->assertArrayHasKey( 'OPT_UNRELATED', $cached, 'Writing one option back must not drop the rest of the cache.' );
+	}
+}

--- a/tests/php/Unit/API/Create_Options_And_Values_Test.php
+++ b/tests/php/Unit/API/Create_Options_And_Values_Test.php
@@ -194,4 +194,69 @@ class Create_Options_And_Values_Test extends WP_UnitTestCase {
 		);
 		$this->assertArrayHasKey( 'OPT_UNRELATED', $cached, 'Writing one option back must not drop the rest of the cache.' );
 	}
+
+	/**
+	 * The write back must not reach for the catalogue itself. The old shape called
+	 * retrieve_options_data() here, which on a large account meant an unlooped read.
+	 */
+	public function test_write_back_does_not_read_the_catalogue() {
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_GREEN' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'NEW_OPT', $created )->set_upsert_object_id( 'NEW_OPT' );
+
+		$this->api->create_options_and_values( false, 'Colour', array( 'Green' ) );
+
+		$this->assertSame( array(), $this->api->list_catalog_cursors );
+	}
+
+	/**
+	 * While a paginated read is in flight the partial cache is the authoritative one, so the
+	 * new option belongs there and the finished cache must be left untouched.
+	 */
+	public function test_created_option_joins_an_in_flight_partial_read() {
+		set_transient(
+			API::OPTIONS_DATA_PARTIAL_TRANSIENT,
+			array(
+				'OPT_PAGE_ONE' => array(
+					'name'      => 'Page one',
+					'values'    => array(),
+					'value_ids' => array(),
+				),
+			),
+			DAY_IN_SECONDS
+		);
+
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_GREEN' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'NEW_OPT', $created )->set_upsert_object_id( 'NEW_OPT' );
+
+		$this->api->create_options_and_values( false, 'Colour', array( 'Green' ) );
+
+		$partial = get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+
+		$this->assertSame( array( 'OPT_PAGE_ONE', 'NEW_OPT' ), array_keys( $partial ) );
+		$this->assertSame( 'Colour', $partial['NEW_OPT']['name'] );
+		$this->assertSame(
+			array( 'OPT_UNRELATED' ),
+			array_keys( get_transient( 'wc_square_options_data' ) ),
+			'A read in flight owns the data, so the finished cache must not be touched.'
+		);
+	}
+
+	/**
+	 * With no cache to extend there is nothing to merge into, and a set built from one option
+	 * must not be published as a finished catalogue.
+	 */
+	public function test_created_option_is_not_published_when_no_cache_exists() {
+		delete_transient( 'wc_square_options_data' );
+
+		$created = Scripted_API::make_option( 'NEW_OPT', 'Colour', array( 'VAL_GREEN' => 'Green' ) );
+
+		$this->api->register_catalog_object( 'NEW_OPT', $created )->set_upsert_object_id( 'NEW_OPT' );
+
+		$this->api->create_options_and_values( false, 'Colour', array( 'Green' ) );
+
+		$this->assertFalse( get_transient( 'wc_square_options_data' ) );
+		$this->assertFalse( get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT ) );
+	}
 }

--- a/tests/php/Unit/API/Retrieve_Options_Data_Test.php
+++ b/tests/php/Unit/API/Retrieve_Options_Data_Test.php
@@ -243,4 +243,29 @@ class Retrieve_Options_Data_Test extends WP_UnitTestCase {
 		$this->assertSame( array( 'OPT_A', 'OPT_B' ), array_keys( $finished ) );
 		$this->assertArrayNotHasKey( 'OPT_OLD', $finished );
 	}
+
+	/**
+	 * The partial cache has to outlive the walk it protects, or a job left sitting in the queue
+	 * resumes from nothing and truncates in silence.
+	 */
+	public function test_partial_cache_lives_as_long_as_the_finished_cache() {
+		if ( wp_using_ext_object_cache() ) {
+			$this->markTestSkipped( 'Transient expiries are not readable through an external object cache.' );
+		}
+
+		$this->api->queue_catalog_pages(
+			array(
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_A', 'Colour' ) ),
+					'cursor'  => 'CURSOR_2',
+				),
+			)
+		);
+
+		$this->api->retrieve_options_data();
+
+		$timeout = (int) get_option( '_transient_timeout_' . API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+
+		$this->assertGreaterThan( time() + HOUR_IN_SECONDS, $timeout );
+	}
 }

--- a/tests/php/Unit/API/Retrieve_Options_Data_Test.php
+++ b/tests/php/Unit/API/Retrieve_Options_Data_Test.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Tests for WooCommerce\Square\API::retrieve_options_data().
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\API;
+
+use WooCommerce\Square\API;
+use WP_UnitTestCase;
+
+require_once __DIR__ . '/Scripted_API.php';
+
+class Retrieve_Options_Data_Test extends WP_UnitTestCase {
+
+	/**
+	 * Scripted API under test.
+	 *
+	 * @var Scripted_API
+	 */
+	private $api;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_transient( 'wc_square_options_data' );
+		delete_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+
+		$this->api = new Scripted_API();
+	}
+
+	public function tearDown(): void {
+		delete_transient( 'wc_square_options_data' );
+		delete_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The regression this covers: every page but the last used to be thrown away, because
+	 * each call started from an empty array and only the final page reached the cache.
+	 */
+	public function test_paginated_read_keeps_every_page_in_the_finished_transient() {
+		$this->api->queue_catalog_pages(
+			array(
+				array(
+					'objects' => array(
+						Scripted_API::make_option( 'OPT_A', 'Colour', array( 'VAL_A1' => 'Red' ) ),
+						Scripted_API::make_option( 'OPT_B', 'Size', array( 'VAL_B1' => 'Small' ) ),
+					),
+					'cursor'  => 'CURSOR_PAGE_TWO',
+				),
+				array(
+					'objects' => array(
+						Scripted_API::make_option( 'OPT_C', 'Material', array( 'VAL_C1' => 'Cotton' ) ),
+					),
+					'cursor'  => null,
+				),
+			)
+		);
+
+		// First page: nothing is promoted to the finished cache yet.
+		list( , $first_page_data, $first_cursor ) = $this->api->retrieve_options_data();
+
+		$this->assertSame( 'CURSOR_PAGE_TWO', $first_cursor );
+		$this->assertSame( array( 'OPT_A', 'OPT_B' ), array_keys( $first_page_data ) );
+		$this->assertFalse( get_transient( 'wc_square_options_data' ), 'A half read catalogue must not land in the finished cache.' );
+		$this->assertSame( array( 'OPT_A', 'OPT_B' ), array_keys( get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT ) ) );
+
+		// Second page: the cursor is exhausted, so the accumulated set is promoted.
+		list( , $final_data, $final_cursor ) = $this->api->retrieve_options_data( $first_cursor );
+
+		$this->assertNull( $final_cursor );
+		$this->assertSame( array( 'OPT_A', 'OPT_B', 'OPT_C' ), array_keys( $final_data ) );
+
+		$finished = get_transient( 'wc_square_options_data' );
+
+		$this->assertSame( array( 'OPT_A', 'OPT_B', 'OPT_C' ), array_keys( $finished ) );
+		$this->assertSame( 'Colour', $finished['OPT_A']['name'] );
+		$this->assertSame( 'Material', $finished['OPT_C']['name'] );
+		$this->assertSame( array( 'VAL_A1' => 'Red' ), $finished['OPT_A']['value_ids'] );
+		$this->assertSame( array( 'Small' ), $finished['OPT_B']['values'] );
+
+		$this->assertFalse( get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT ), 'The partial cache must be cleared once the read completes.' );
+		$this->assertSame( array( '', 'CURSOR_PAGE_TWO' ), $this->api->list_catalog_cursors );
+	}
+
+	/**
+	 * Three pages, to prove the middle one is not the special case that survives.
+	 */
+	public function test_three_page_read_accumulates_all_pages() {
+		$this->api->queue_catalog_pages(
+			array(
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_A', 'Colour' ) ),
+					'cursor'  => 'CURSOR_2',
+				),
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_B', 'Size' ) ),
+					'cursor'  => 'CURSOR_3',
+				),
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_C', 'Material' ) ),
+					'cursor'  => null,
+				),
+			)
+		);
+
+		$cursor = '';
+
+		do {
+			list( , $options_data, $cursor ) = $this->api->retrieve_options_data( $cursor );
+		} while ( $cursor );
+
+		$this->assertSame( array( 'OPT_A', 'OPT_B', 'OPT_C' ), array_keys( $options_data ) );
+		$this->assertSame( array( 'OPT_A', 'OPT_B', 'OPT_C' ), array_keys( get_transient( 'wc_square_options_data' ) ) );
+	}
+
+	/**
+	 * A later page holding a newer copy of an option must win over the earlier page.
+	 */
+	public function test_later_page_wins_for_a_repeated_option_id() {
+		$this->api->queue_catalog_pages(
+			array(
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_A', 'Colour', array( 'VAL_A1' => 'Red' ) ) ),
+					'cursor'  => 'CURSOR_2',
+				),
+				array(
+					'objects' => array(
+						Scripted_API::make_option(
+							'OPT_A',
+							'Colour',
+							array(
+								'VAL_A1' => 'Red',
+								'VAL_A2' => 'Blue',
+							)
+						),
+					),
+					'cursor'  => null,
+				),
+			)
+		);
+
+		list( , , $cursor ) = $this->api->retrieve_options_data();
+		$this->api->retrieve_options_data( $cursor );
+
+		$finished = get_transient( 'wc_square_options_data' );
+
+		$this->assertSame( array( 'Red', 'Blue' ), $finished['OPT_A']['values'] );
+	}
+
+	/**
+	 * A read abandoned part way through leaves a partial cache behind for up to an hour.
+	 * A fresh read starts at an empty cursor and must not inherit it.
+	 */
+	public function test_fresh_read_ignores_a_partial_left_by_an_abandoned_read() {
+		set_transient(
+			API::OPTIONS_DATA_PARTIAL_TRANSIENT,
+			array(
+				'OPT_STALE' => array(
+					'name'      => 'Abandoned',
+					'values'    => array(),
+					'value_ids' => array(),
+				),
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$this->api->queue_catalog_pages(
+			array(
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_A', 'Colour' ) ),
+					'cursor'  => null,
+				),
+			)
+		);
+
+		list( , $options_data ) = $this->api->retrieve_options_data();
+
+		$this->assertSame( array( 'OPT_A' ), array_keys( $options_data ) );
+		$this->assertSame( array( 'OPT_A' ), array_keys( get_transient( 'wc_square_options_data' ) ) );
+		$this->assertFalse( get_transient( API::OPTIONS_DATA_PARTIAL_TRANSIENT ) );
+	}
+
+	/**
+	 * A complete cache still short circuits the whole walk.
+	 */
+	public function test_finished_cache_short_circuits_without_touching_the_api() {
+		$cached = array(
+			'OPT_A' => array(
+				'name'      => 'Colour',
+				'values'    => array( 'Red' ),
+				'value_ids' => array( 'VAL_A1' => 'Red' ),
+			),
+		);
+
+		set_transient( 'wc_square_options_data', $cached, DAY_IN_SECONDS );
+
+		list( $response, $options_data ) = $this->api->retrieve_options_data();
+
+		$this->assertSame( '', $response );
+		$this->assertSame( $cached, $options_data );
+		$this->assertSame( array(), $this->api->list_catalog_cursors );
+	}
+
+	/**
+	 * A cache carrying a nameless option is refetched rather than trusted, and the
+	 * refetch is still allowed to paginate.
+	 */
+	public function test_nameless_cache_is_refetched_and_may_paginate() {
+		set_transient(
+			'wc_square_options_data',
+			array(
+				'OPT_OLD' => array(
+					'name'      => '',
+					'values'    => array(),
+					'value_ids' => array(),
+				),
+			),
+			DAY_IN_SECONDS
+		);
+
+		$this->api->queue_catalog_pages(
+			array(
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_A', 'Colour' ) ),
+					'cursor'  => 'CURSOR_2',
+				),
+				array(
+					'objects' => array( Scripted_API::make_option( 'OPT_B', 'Size' ) ),
+					'cursor'  => null,
+				),
+			)
+		);
+
+		list( , , $cursor ) = $this->api->retrieve_options_data();
+		$this->api->retrieve_options_data( $cursor );
+
+		$finished = get_transient( 'wc_square_options_data' );
+
+		$this->assertSame( array( 'OPT_A', 'OPT_B' ), array_keys( $finished ) );
+		$this->assertArrayNotHasKey( 'OPT_OLD', $finished );
+	}
+}

--- a/tests/php/Unit/API/Scripted_API.php
+++ b/tests/php/Unit/API/Scripted_API.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Test double that scripts the Square catalog endpoints used by the option helpers.
+ *
+ * @package WooCommerce\Square
+ */
+
+namespace WooCommerce\Square\Tests\Unit\API;
+
+use Square\Models\BatchUpsertCatalogObjectsResponse;
+use Square\Models\CatalogIdMapping;
+use Square\Models\CatalogItemOption;
+use Square\Models\CatalogItemOptionValue;
+use Square\Models\CatalogObject;
+use Square\Models\ListCatalogResponse;
+use Square\Models\RetrieveCatalogObjectResponse;
+use WooCommerce\Square\API\Responses\Catalog;
+
+/**
+ * Replaces the three catalog calls the option helpers make with canned responses.
+ *
+ * The parent constructor is deliberately not called: building a SquareClient is
+ * pointless here and leaving it unbuilt guarantees no test can reach the network.
+ */
+class Scripted_API extends \WooCommerce\Square\API {
+
+	/**
+	 * Cursors passed to list_catalog(), in call order.
+	 *
+	 * @var array
+	 */
+	public $list_catalog_cursors = array();
+
+	/**
+	 * Object IDs passed to retrieve_catalog_object(), in call order.
+	 *
+	 * @var array
+	 */
+	public $retrieved_object_ids = array();
+
+	/**
+	 * Objects handed to upsert_catalog_object(), in call order.
+	 *
+	 * @var array
+	 */
+	public $upserted_objects = array();
+
+	/**
+	 * Queued ListCatalog pages, each an array of `objects` and `cursor`.
+	 *
+	 * @var array
+	 */
+	private $catalog_pages = array();
+
+	/**
+	 * Catalog objects retrievable by ID. Anything absent responds with no data.
+	 *
+	 * @var array
+	 */
+	private $catalog_objects = array();
+
+	/**
+	 * Object ID an upsert reports back through its ID mappings, or null for none.
+	 *
+	 * @var string|null
+	 */
+	private $upsert_object_id = null;
+
+	/**
+	 * Skips the parent constructor so no Square client is ever built.
+	 */
+	public function __construct() {} // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Deliberately replaces the parent constructor.
+
+	/**
+	 * Queues the pages ListCatalog should return, in order.
+	 *
+	 * @param array $pages List of arrays with `objects` and `cursor` keys.
+	 * @return self
+	 */
+	public function queue_catalog_pages( array $pages ) {
+		$this->catalog_pages = $pages;
+
+		return $this;
+	}
+
+	/**
+	 * Registers a catalog object retrievable by ID.
+	 *
+	 * @param string        $object_id      Square object ID.
+	 * @param CatalogObject $catalog_object Object to hand back.
+	 * @return self
+	 */
+	public function register_catalog_object( $object_id, CatalogObject $catalog_object ) {
+		$this->catalog_objects[ $object_id ] = $catalog_object;
+
+		return $this;
+	}
+
+	/**
+	 * Sets the object ID an upsert reports through its ID mappings.
+	 *
+	 * @param string|null $object_id Object ID, or null to return no mappings.
+	 * @return self
+	 */
+	public function set_upsert_object_id( $object_id ) {
+		$this->upsert_object_id = $object_id;
+
+		return $this;
+	}
+
+	/**
+	 * Builds an ITEM_OPTION catalog object.
+	 *
+	 * @param string $object_id Option ID.
+	 * @param string $name      Option name.
+	 * @param array  $values    Map of value ID => value name.
+	 * @return CatalogObject
+	 */
+	public static function make_option( $object_id, $name, array $values = array() ) {
+		$catalog_object = new CatalogObject( 'ITEM_OPTION', $object_id );
+		$option_data    = new CatalogItemOption();
+		$option_data->setName( $name );
+
+		$option_values = array();
+
+		foreach ( $values as $value_id => $value_name ) {
+			$value_object = new CatalogObject( 'ITEM_OPTION_VAL', $value_id );
+			$value_data   = new CatalogItemOptionValue();
+			$value_data->setName( $value_name );
+			$value_object->setItemOptionValueData( $value_data );
+
+			$option_values[] = $value_object;
+		}
+
+		$option_data->setValues( $option_values );
+		$catalog_object->setItemOptionData( $option_data );
+
+		return $catalog_object;
+	}
+
+	/**
+	 * Returns the next queued page, or an empty final page once they run out.
+	 *
+	 * @param string $cursor Pagination cursor.
+	 * @param array  $types  Requested object types.
+	 * @return Catalog
+	 */
+	public function list_catalog( $cursor = '', $types = array() ) {
+		$this->list_catalog_cursors[] = $cursor;
+
+		$page = array_shift( $this->catalog_pages );
+
+		if ( ! is_array( $page ) ) {
+			$page = array(
+				'objects' => array(),
+				'cursor'  => null,
+			);
+		}
+
+		$data = new ListCatalogResponse();
+		$data->setObjects( isset( $page['objects'] ) ? $page['objects'] : array() );
+		$data->setCursor( isset( $page['cursor'] ) ? $page['cursor'] : null );
+
+		return new Catalog( $data );
+	}
+
+	/**
+	 * Returns a registered object, or a response with no data at all.
+	 *
+	 * @param string   $object_id               Square object ID.
+	 * @param bool     $include_related_objects Unused.
+	 * @param int|null $object_version          Unused.
+	 * @return Catalog
+	 */
+	public function retrieve_catalog_object( $object_id, $include_related_objects = false, $object_version = null ) {
+		$this->retrieved_object_ids[] = $object_id;
+
+		if ( ! isset( $this->catalog_objects[ $object_id ] ) ) {
+			return new Catalog( null );
+		}
+
+		$data = new RetrieveCatalogObjectResponse();
+		$data->setObject( $this->catalog_objects[ $object_id ] );
+
+		return new Catalog( $data );
+	}
+
+	/**
+	 * Records the upserted object and reports the configured ID mapping.
+	 *
+	 * @param string        $idempotency_key Unused.
+	 * @param CatalogObject $catalog_object  Object being upserted.
+	 * @return Catalog
+	 */
+	public function upsert_catalog_object( $idempotency_key, $catalog_object ) {
+		$this->upserted_objects[] = $catalog_object;
+
+		$data = new BatchUpsertCatalogObjectsResponse();
+
+		if ( null !== $this->upsert_object_id ) {
+			$mapping = new CatalogIdMapping();
+			$mapping->setObjectId( $this->upsert_object_id );
+			$data->setIdMappings( array( $mapping ) );
+		}
+
+		return new Catalog( $data );
+	}
+}

--- a/tests/php/Unit/API/Scripted_API.php
+++ b/tests/php/Unit/API/Scripted_API.php
@@ -67,6 +67,20 @@ class Scripted_API extends \WooCommerce\Square\API {
 	private $upsert_object_id = null;
 
 	/**
+	 * Extra ID mappings the upsert reports ahead of the option's own, as Square does for values.
+	 *
+	 * @var array
+	 */
+	private $upsert_id_mappings = array();
+
+	/**
+	 * Exception every retrieve_catalog_object() call raises, or null to behave normally.
+	 *
+	 * @var \Exception|null
+	 */
+	private $retrieve_exception = null;
+
+	/**
 	 * Skips the parent constructor so no Square client is ever built.
 	 */
 	public function __construct() {} // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Deliberately replaces the parent constructor.
@@ -104,6 +118,34 @@ class Scripted_API extends \WooCommerce\Square\API {
 	 */
 	public function set_upsert_object_id( $object_id ) {
 		$this->upsert_object_id = $object_id;
+
+		return $this;
+	}
+
+	/**
+	 * Queues mappings reported BEFORE the option's own, standing in for created option values.
+	 *
+	 * Square returns a mapping per created object with no guaranteed ordering, and an option that
+	 * already existed gets no mapping at all. That is the shape that makes a positional read of the
+	 * mappings return a value ID where the caller expected an option ID.
+	 *
+	 * @param array $mappings List of arrays with `client_object_id` and `object_id` keys.
+	 * @return self
+	 */
+	public function set_upsert_id_mappings( array $mappings ) {
+		$this->upsert_id_mappings = $mappings;
+
+		return $this;
+	}
+
+	/**
+	 * Makes every retrieve fail, so a test can prove which failures are not treated as a miss.
+	 *
+	 * @param \Exception $exception Exception to raise.
+	 * @return self
+	 */
+	public function set_retrieve_exception( \Exception $exception ) {
+		$this->retrieve_exception = $exception;
 
 		return $this;
 	}
@@ -165,18 +207,29 @@ class Scripted_API extends \WooCommerce\Square\API {
 	}
 
 	/**
-	 * Returns a registered object, or a response with no data at all.
+	 * Returns a registered object, or throws the way Square does for an ID it does not hold.
+	 *
+	 * Handing back an empty response for an unknown ID is what this double used to do, and it is
+	 * why a fatal in production passed as a green test: the real call runs the response through the
+	 * error validator, which throws on NOT_FOUND before any data is returned. A double that is
+	 * gentler than the API it stands in for cannot pin the behaviour that matters.
 	 *
 	 * @param string   $object_id               Square object ID.
 	 * @param bool     $include_related_objects Unused.
 	 * @param int|null $object_version          Unused.
 	 * @return Catalog
+	 * @throws \Exception When the object is unknown, or when a failure has been scripted.
 	 */
 	public function retrieve_catalog_object( $object_id, $include_related_objects = false, $object_version = null ) {
 		$this->retrieved_object_ids[] = $object_id;
 
+		if ( $this->retrieve_exception ) {
+			throw $this->retrieve_exception;
+		}
+
 		if ( ! isset( $this->catalog_objects[ $object_id ] ) ) {
-			return new Catalog( null );
+			// Matches the shape API::do_post_parse_response_validation() builds: "[CODE] detail".
+			throw new \Exception( '[NOT_FOUND] Object not found.' );
 		}
 
 		$data = new RetrieveCatalogObjectResponse();
@@ -186,7 +239,11 @@ class Scripted_API extends \WooCommerce\Square\API {
 	}
 
 	/**
-	 * Records the upserted object and reports the configured ID mapping.
+	 * Records the upserted object and reports the configured ID mappings.
+	 *
+	 * Any mappings queued through set_upsert_id_mappings() come first, so a test can reproduce
+	 * Square putting a created value ahead of the option. The option's own mapping is keyed on the
+	 * client ID it was actually sent under, which is what the real API echoes back.
 	 *
 	 * @param string        $idempotency_key Unused.
 	 * @param CatalogObject $catalog_object  Object being upserted.
@@ -195,12 +252,27 @@ class Scripted_API extends \WooCommerce\Square\API {
 	public function upsert_catalog_object( $idempotency_key, $catalog_object ) {
 		$this->upserted_objects[] = $catalog_object;
 
-		$data = new BatchUpsertCatalogObjectsResponse();
+		$data     = new BatchUpsertCatalogObjectsResponse();
+		$mappings = array();
+
+		foreach ( $this->upsert_id_mappings as $queued_mapping ) {
+			$mapping = new CatalogIdMapping();
+			$mapping->setClientObjectId( isset( $queued_mapping['client_object_id'] ) ? $queued_mapping['client_object_id'] : null );
+			$mapping->setObjectId( isset( $queued_mapping['object_id'] ) ? $queued_mapping['object_id'] : null );
+
+			$mappings[] = $mapping;
+		}
 
 		if ( null !== $this->upsert_object_id ) {
 			$mapping = new CatalogIdMapping();
+			$mapping->setClientObjectId( $catalog_object->getId() );
 			$mapping->setObjectId( $this->upsert_object_id );
-			$data->setIdMappings( array( $mapping ) );
+
+			$mappings[] = $mapping;
+		}
+
+		if ( $mappings ) {
+			$data->setIdMappings( $mappings );
 		}
 
 		return new Catalog( $data );

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -140,8 +140,12 @@ class WooCommerce_Square_Loader {
 		// autoload plugin and vendor files
 		$loader = require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
-		// register plugin namespace with autoloader
-		$loader->addPsr4( 'WooCommerce\\Square\\', __DIR__ . '/includes' );
+		// register plugin namespace with autoloader.
+		// `require_once` hands back `true` rather than the ClassLoader when something booted the
+		// autoloader first, which is what a test runner does, so there is nothing to extend then.
+		if ( is_object( $loader ) && method_exists( $loader, 'addPsr4' ) ) {
+			$loader->addPsr4( 'WooCommerce\\Square\\', __DIR__ . '/includes' );
+		}
 
 		require_once plugin_dir_path( __FILE__ ) . 'includes/Functions.php';
 

--- a/woocommerce-square.php
+++ b/woocommerce-square.php
@@ -140,12 +140,8 @@ class WooCommerce_Square_Loader {
 		// autoload plugin and vendor files
 		$loader = require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
-		// register plugin namespace with autoloader.
-		// `require_once` hands back `true` rather than the ClassLoader when something booted the
-		// autoloader first, which is what a test runner does, so there is nothing to extend then.
-		if ( is_object( $loader ) && method_exists( $loader, 'addPsr4' ) ) {
-			$loader->addPsr4( 'WooCommerce\\Square\\', __DIR__ . '/includes' );
-		}
+		// register plugin namespace with autoloader
+		$loader->addPsr4( 'WooCommerce\\Square\\', __DIR__ . '/includes' );
 
 		require_once plugin_dir_path( __FILE__ ) . 'includes/Functions.php';
 


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WooCommerce Sniffs](https://github.com/woocommerce/woocommerce-sniffs/) variant of WordPress coding standards?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] Will this change require new documentation or changes to existing documentation?

---

### Changes proposed in this Pull Request:

Closes https://linear.app/a8c/issue/SQUARE-363/sync-fails-with-invalid-value-when-square-has-100-item-options.

`[INVALID_VALUE] An existing Item Option has name "X"` has two independent causes. The ticket describes the first one. Testing the customer catalogue against a production Square account surfaced the second, and either one on its own is enough to fail an entire sync.

**Cause 1, a paginated read kept only its last page.** `retrieve_options_data()` started its accumulator empty on every call and wrote the cache only once the cursor was exhausted, so on a store with more than 100 item options the pages before the last were discarded. Options that exist in Square then looked absent, the sync asked Square to create them, and Square refused. `fetch_options_data()` also dropped the page payload it was handed.

Pages now accumulate under their own transient key and the finished set is promoted to `wc_square_options_data` only when the cursor runs out, at which point the partial is deleted. The separate key is not incidental: the function returns the cached value early when it exists, so persisting partial pages under the finished key would hand back a half built cache and re-emit the same cursor indefinitely. The reset path that discards the finished cache after a failed create discards the partial with it, so an abandoned walk leaves nothing behind for a later write to land in.

**Cause 2, names were matched case sensitively.** Square treats item option names as case insensitive and rejects a create whose name differs from an existing one only by case, while the plugin compared with `===`. A store whose Square account holds `size` and whose products use a `Size` attribute could not sync at all, and no amount of merging pages would help, because the option was in the cache the whole time.

Option names, existing option values, and the values read back from a freshly upserted option are now compared with `strcasecmp`, and the value diff uses `array_udiff( ..., 'strcasecmp' )` so a reused option is not asked to create `large` alongside Square's own `Large`. Reuse is non destructive: `create_options_and_values()` with an ID takes the retrieve path and never calls `setName`, so nothing already in the merchant's account is renamed.

**A fatal on the same path.** Once names matched case insensitively, cached IDs pointing at options that no longer exist in Square began to resolve, and `create_options_and_values()` called `setValues()` on the resulting null item option, taking the sync down with `Uncaught Error: Call to a member function setValues() on null`. Being a fatal rather than an exception, no error isolation can catch it. An ID that Square cannot resolve to an `ITEM_OPTION` is now treated as no match and falls through to the create path. This looks like an incomplete fix for SQUARE-292, which guarded `getValues()` in three places but not this call.

**A second create on the variation path.** With option matching fixed, `update_catalog_variation()` was still able to ask Square for an option it had just been handed. Its option ID started empty and was only filled from the options cache, so when the cache did not yet know about the option the parent product had created, the call fell through to the create path carrying no ID, and Square rejected the duplicate name. The ID the parent product resolved is now carried into that call whatever the cache holds, so the create takes the retrieve path and reuses the option. This was reachable only while the finished cache was absent on a paginating account, and a reset cycle recovered from it, but it failed the same sync the rest of this branch is fixing.

### Steps to test the changes in this Pull Request:

**Case sensitivity, the cause seen on real merchant data. No special data volume needed.**

1. In the Square dashboard, create an item option named entirely in lower case, for example `size`, with a couple of values.
2. In WooCommerce, create a global or custom product attribute whose name differs only by case, for example `Size`, mark it used for variations, and give a variable product two variations using it.
3. Set System of Record to WooCommerce and run a manual sync of that product.
4. On trunk the sync fails with `[INVALID_VALUE] An existing Item Option has name "Size"`, and the failure repeats through three reset cycles before the job dies.
5. On this branch the sync completes, the product is created in Square, and the existing `size` option is reused. Confirm in the Square dashboard that no second option was created and that the original name is unchanged.

**Pagination, the cause in the ticket. Needs more than 100 item options in Square.**

1. On a Square account holding more than 100 `ITEM_OPTION` objects, so that `ListCatalog` returns a cursor, set System of Record to WooCommerce.
2. Create a variable product whose attribute name matches an item option Square returns on a page other than the last.
3. Run a manual sync of that product.
4. On trunk the sync fails with `[INVALID_VALUE] An existing Item Option has name "..."`. On this branch it completes and reuses the existing option.
5. With logging enabled, `fetch_options_data` reports a running option count that reaches the full number of options in the account rather than the size of the final page alone.

**Regression check, either scenario.**

1. Run a sync of a handful of variable products with mixed attribute casing and confirm no duplicate item options appear in Square.
2. Confirm existing option values are reused rather than duplicated in different cases.

### Verification already done

Measured against the On The Square customer catalogue on a 10up owned Square **production** account, System of Record WooCommerce:

- Before this branch, a 60 product scope (30 variable, 30 simple) failed at **0 processed** with the `Size` collision, and every product after the failure point never got its turn.
- On this branch the same scope **completes, 60 of 60 processed**, with 0 of 319 products changed in stock quantity, stock status or stock management, and 47 of 53 managed products carrying exact Square counts.
- The `setValues()` fatal reproduced during that work and no longer occurs.

That run predates the last two commits on this branch. Neither has been through a production sync: the partial cache clear is covered by the reasoning above, and the variation path change has no unit coverage at all, because `update_catalog_variation()` is static and needs WooCommerce loaded, which the unit harness does not provide. Both are lint and sniff clean, and the existing suite still passes with them applied.

### Unit tests

The pagination half cannot be exercised on our sandbox: the account holds six item options and Square's page size is fixed at 100, so no cursor is ever returned. It is covered by unit tests instead, against a scripted catalogue rather than the wire.

`tests/php/Unit/API/Scripted_API.php` replaces `list_catalog()`, `retrieve_catalog_object()` and `upsert_catalog_object()` with canned responses and skips the parent constructor, so no test can reach the network.

`tests/php/Unit/API/Retrieve_Options_Data_Test.php` covers the read:

- a two page and a three page walk keep every page, not just the last
- a later page wins for a repeated option ID
- a half read catalogue never lands in the finished cache
- a fresh read ignores a partial left behind by an abandoned one
- a complete cache still short circuits the walk, and a nameless cache is refetched and may still paginate
- the partial cache is given the lifetime of the finished one

`tests/php/Unit/API/Create_Options_And_Values_Test.php` covers the write back:

- existing values are matched without regard to case, and values differing only by case add nothing
- an unresolvable option ID, an ID resolving to another object type, and an ITEM_OPTION carrying no option data each fall through to the create path rather than reaching `setValues()` on null
- a created option is written back under its real ID, joins an in flight partial read when one exists, and is not published as a finished catalogue when neither cache exists
- the write back never reads the catalogue

There is no PHPUnit job in CI, so these run locally:

```
bash tests/php/bin/install-wp-tests.sh wordpress_test root '' localhost latest
composer test-unit
```

**Still not proven by execution:** a real Square account holding more than 100 item options. The behaviour is covered by the tests above and reasoned from the code, but no live cursor has been walked. The variation path change shares that gap, since the state it guards against only arises on a paginating account.

### Changelog entry

> Fix - Sync no longer fails when Square already holds an item option whose name differs only by case, or when a store has more than 100 item options.


