### PR TITLE
Pin nested GitHub Action dependencies to full SHAs

### DIFF
--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -12,13 +12,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           tools: cs2pr
           install-deps: no
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@da5279aa4d76745ef32970e49b5ef7903a3b457a # v2.2.2
+        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -12,13 +12,13 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare PHP
-        uses: woocommerce/grow/prepare-php@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-php@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           tools: cs2pr
           install-deps: no
 
       - name: Prepare node
-        uses: woocommerce/grow/prepare-node@a81d3fca0166a02a4c25953d250d80d3612db4b8 # actions-v3
+        uses: woocommerce/grow/prepare-node@b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa # actions-v3.0.5
         with:
           node-version-file: ".nvmrc"
           ignore-scripts: "no"

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -18,7 +18,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Run plugin check
-      uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
+      uses: wordpress/plugin-check-action@10857da14b6c2246d15402b3e69f777edcf8c12e # v1.1.9
       with:
         exclude-checks: |
           plugin_readme


### PR DESCRIPTION
### Changes proposed in this Pull Request

Tracking: SQUARE-390

- Updates the affected parent actions or reusable workflows to immutable commits whose own remote action dependencies are pinned to full-length SHAs.
- Keeps human-readable version comments beside the SHAs.

This is part of the WooCommerce organization audit for transitive GitHub Action pinning. Shared Grow actions are pinned to the published [actions-v3.0.5 release](https://github.com/woocommerce/grow/releases/tag/actions-v3.0.5) build commit `b9c1e59aae9fdbe668b068ebd59c1545a88ea9fa`. The action trees used here are identical to the reviewed test build from woocommerce/grow#265.

### Detailed test instructions

1. Inspect the changed `uses:` references and confirm every remote action ref is a 40-character commit SHA.
2. Confirm the adjacent comments identify the intended version or upstream pinning PR.
3. Let the affected workflows run through this PR's hosted checks.

Validation already completed:

- Parsed every GitHub workflow and composite action in this repository as YAML.
- Ran `git diff --check`.
- Verified the replacement parent commits resolve through their canonical GitHub repositories.
- Verified their nested remote action dependencies are pinned to full-length SHAs.

### Documentation

- [x] No documentation changes are required.

### Changelog entry

> Dev - Pin GitHub Actions and their nested dependencies to immutable commit SHAs.

**left by Biff (AI agent) on behalf of Darren*

Closes #547
