### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/backlog-automation-issues.yml
+++ b/.github/workflows/backlog-automation-issues.yml
@@ -10,6 +10,7 @@ jobs:
   add-to-project:
     name: Add issue to project
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
 
     steps:
       # Checkout the private action repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       # Checkout the private action repository

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,7 @@ jobs:
   e2e:
     if: "${{ ( github.event_name == 'pull_request' ) ||  github.event_name == 'push' }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   eslint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -7,6 +7,7 @@ on:
 jobs:
     generate-zip-file:
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/gh-issue-gen.yml
+++ b/.github/workflows/gh-issue-gen.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   create-gh-issue:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       LINEAR_TEAM: SQUARE

--- a/.github/workflows/php-compat.yml
+++ b/.github/workflows/php-compat.yml
@@ -6,6 +6,7 @@ jobs:
   php-compatibility:
     name: PHP compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -5,6 +5,7 @@ on: pull_request
 jobs:
   phpcs:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -13,6 +13,7 @@ on: # rebuild any PRs and main branch changes
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -37,6 +37,7 @@ jobs:
     needs: build
     name: run
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     env:
       NO_COLOR: 1


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30d) | Max (30d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `backlog-automation-issues.yml` / `add-to-project` | no runs | no runs | 5 |
| `deploy.yml` / `deploy` | 11.1 min | 11.6 min | 60 |
| `e2e.yml` / `e2e` (4 matrix legs) | 13.6 min | 26.8 min | 35 |
| `eslint.yml` / `eslint` | 0.3 min | 0.8 min | 5 |
| `generate-zip.yml` / `generate-zip-file` | 1.0 min | 1.0 min | 5 |
| `gh-issue-gen.yml` / `create-gh-issue` | 0.1 min | 0.2 min | 5 |
| `php-compat.yml` / `php-compatibility` | 1.5 min | 2.0 min | 5 |
| `phpcs.yml` / `phpcs` | 0.4 min | 0.6 min | 5 |
| `plugin-check.yml` / `test` | 2.3 min | 2.9 min | 5 |
| `qit.yml` / `test` | 21.7 min* | 23.3 min* | 45 |

\* No successful QIT run in the last 30 days; figures come from the last four successes, 2026-06-29 to 2026-07-03.

`qit.yml` / `build` calls `generate-zip.yml` with `uses:`, which does not accept `timeout-minutes`. The limit in `generate-zip.yml` covers it.

Part of TESTOPS-272

Closes #550